### PR TITLE
Overview with word cloud and external dependencies

### DIFF
--- a/.github/workflows/code-reports.yml
+++ b/.github/workflows/code-reports.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Archive results
       uses: actions/upload-artifact@v3
       with:
-        name: AxonFramework-v${{ env.AXON_FRAMEWORK_VERSION }}-java-${{ matrix.java }}-python-${{ matrix.python }}-mambaforge-${{ matrix.mambaforge }}
+        name: code-report-results-java-${{ matrix.java }}-python-${{ matrix.python }}-mambaforge-${{ matrix.mambaforge }}
         path: ./results
         if-no-files-found: error
         retention-days: 5

--- a/.github/workflows/code-reports.yml
+++ b/.github/workflows/code-reports.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         path: ~/conda_pkgs_dir
         key:
-          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-environments-${{hashFiles('**/environment.yml') }}
+          ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-environments-${{hashFiles('**/environment.yml', '.github/workflows/*.yml') }}
 
     # "Setup Python" can be skipped if jupyter notebook reports aren't needed
     - name: Setup Python ${{ matrix.python }} with Conda package manager Mambaforge

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,5 +1,55 @@
 # Code Graph Analysis Pipeline - Commands
 
+## Start an analysis
+
+Use the following commands in the root directory of this repository to start an analysis manually e.g. for [AxonFramework](./scripts/artifacts/downloadAxonFramework.sh).
+
+### Notes
+
+- Be sure to use Java 11 (June 2023 Neo4j 4.x requirement)
+- Use your own initial Neo4j password
+- It uses the script [analyze.sh](./scripts/analysis/analyze.sh)
+- The script file names (without the prefix "download" and without the file extension) in the directory [scripts/artifacts](./scripts/artifacts) provide the possible analysis names.
+
+
+```shell
+export NEO4J_INITIAL_PASSWORD=theinitialpasswordthatihavechosenforneo4j
+mkdir -p ./temp
+./../scripts/analysis/analyze.sh --name AxonFramework --version 4.7.5 --report All
+```
+
+Have a look at [code-reports.yml](./.github/workflows/code-reports.yml) for all details about setup steps and full automation.
+
+## Generate Markdown References
+
+### Update Cypher Reference
+
+Change into the [cypher](./cypher/) directory e.g. with `cd cypher` and then execute the script [generateCypherReference.sh](./scripts/generateCypherReference.sh) with the following command:
+
+```script
+./../scripts/generateCypherReference.sh
+```
+
+### Update Script Reference
+
+Change into the [scripts](./scripts/) directory e.g. with `cd scripts` and then execute the script [generateScriptReference.sh](./scripts/generateScriptReference.sh) with the following command:
+
+```script
+./../scripts/generateScriptReference.sh
+```
+
+### Update Markdown Reference
+
+Change into the [results](./results/) directory e.g. with `cd results` and then execute the script [generateMarkdownReference.sh](./scripts/generateMarkdownReference.sh) with the following command:
+
+👉**Note:** This script is automatically triggered at the end of [copyReportsIntoResults.sh](./scripts/copyReportsIntoResults.sh)
+which is included in the pipeline [code-reports.yml](.github/workflows/code-reports.yml) and doesn't need to be executed manually normally.
+
+
+```script
+./../scripts/generateScriptReference.sh
+```
+
 ## Manual Setup
 
 The manual setup is only documented for completeness. It isn't needed since the analysis also covers download, installation and configuration of all needed tools.

--- a/README.md
+++ b/README.md
@@ -18,23 +18,41 @@ Contained within this repository is a comprehensive and automated code graph ana
 
 ## 🛠 Prerequisites
 
-- Java 11 is required
+- Java 11 is required (June 2023 Neo4j 4.x requirement)
 - Python with a conda package manager is needed for Jupyter Notebook reports
 - Chromium will automatically be downloaded if needed for Jupyter Notebook reports in PDF format.
 
-## 🏗 Pipeline
+## Getting Started
+
+See [Start an analysis](./COMMANDS.md#start-an-analysis) in the [Commands Reference](./COMMANDS.md) on how to start
+an analysis on your local machine.
+
+## 🏗 Pipeline and Tools
 
 The [Code Reports Pipeline](./.github/workflows/code-reports.yml) utilizes [GitHub Actions](https://docs.github.com/de/actions) to automate the whole analysis process:
 
-- Use Linux Runner
-- Setup Java
-- Setup Python
-- Setup Conda package manager [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
+- Use [GitHub Actions](https://docs.github.com/de/actions) Linux Runner
+- [Checkout GIT Repository](https://github.com/actions/checkout)
+- [Setup Java](https://github.com/actions/setup-java)
+- [Setup Python with Conda](https://github.com/conda-incubator/setup-miniconda) package manager [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
 - Setup [Neo4j](https://neo4j.com) Graph Database ([analysis.sh](./scripts/analysis/analyze.sh))
 - Setup [jQAssistant](https://jqassistant.org/get-started) for Java Analysis ([analysis.sh](./scripts/analysis/analyze.sh))
 - Start [Neo4j](https://neo4j.com) Graph Database ([analysis.sh](./scripts/analysis/analyze.sh))
-- Trigger (Java) artifacts download that contain the code to be analyzed [scripts/artifacts](./scripts/artifacts/)
-- Generate Reports [scripts/reports](./scripts/reports/)
+- Trigger Artifacts download that contain the code to be analyzed [scripts/artifacts](./scripts/artifacts/)
+- Generate CSV Reports [scripts/reports](./scripts/reports) using the command line JSON parser [jq](https://jqlang.github.io/jq)
+- Generate [Jupyter Notebook](https://jupyter.org) reports using these libraries specified in the [environment.yml](./jupyter/environment.yml):
+  - [Python](https://www.python.org)
+  - [jupyter](https://jupyter.org)
+  - [matplotlib](https://matplotlib.org)
+  - [nbconvert](https://nbconvert.readthedocs.io)
+  - [numpy](https://numpy.org)
+  - [pandas](https://pandas.pydata.org)
+  - [pip](https://pip.pypa.io/en/stable)
+  - [monotonic](https://github.com/atdt/monotonic)
+  - [py2neo](https://py2neo.org)
+  - [wordcloud](https://github.com/amueller/word_cloud)
+
+**Big shout-out** 📣 to all the creators and contributors of these great libraries 👍. Projects like these wouldn't be possible without them. Feel free to [create an issue](https://github.com/JohT/code-graph-analysis-pipeline/issues/new/choose) if i've forgotten something in the list. 
 
 ## 📈 Report Reference
 
@@ -42,13 +60,32 @@ The [Code Reports Pipeline](./.github/workflows/code-reports.yml) utilizes [GitH
 
 ## ⚙️ Script Reference
 
-[SCRIPTS.md](./scripts/SCRIPTS.md) lists all shell scripts of this repository with a description (first comment line).
+[SCRIPTS.md](./scripts/SCRIPTS.md) lists all shell scripts of this repository with a description (first comment line). It can updated as described in [Update Markdown Reference](./COMMANDS.md#update-script-reference) of the [Commands Reference](./COMMANDS.md).
 
 ## 🔎 Cypher Query Reference
 
-[CYPHER.md](./cypher/CYPHER.md) lists all Cypher queries of this repository with their description (first comment lines).
+[CYPHER.md](./cypher/CYPHER.md) lists all Cypher queries of this repository with their description (first comment lines). It can updated as described in [Update Cypher Reference](./COMMANDS.md#update-cypher-reference) of the [Commands Reference](./COMMANDS.md).
 > [Cypher](https://neo4j.com/docs/getting-started/cypher-intro) is Neo4j’s graph query language that lets you retrieve data from the graph.
 
 ## 🛠 Command Reference
 
-[COMMANDS.md](./COMMANDS.md) contains further details on commands and how to do a manual setup. 
+[COMMANDS.md](./COMMANDS.md) contains further details on commands and how to do a manual setup.
+
+## 🤔 Questions & Answers
+
+- How can i add an CSV report to the pipeline?  
+👉 Put your new cypher query into the [cypher](./cypher) directory or a suitable (new) sub directory.  
+👉 Create a new CSV report script in the [scripts/reports](./scripts/reports/) directory. Take for example [OverviewCsv.sh](./scripts/reports/OverviewCsv.sh) as a reference.
+👉 The script will automatically be included because of the directory and its name ending with "Csv.sh".
+
+- How can i add an Jupyter Notebook report to the pipeline?  
+👉 Put your new notebook into the [jupyter](./jupyter) directory.  
+👉 Create a new Jupyter report script in the [scripts/reports](./scripts/reports/) directory. Take [OverviewJupyter.sh](./scripts/reports/OverviewJupyter.sh) as a reference for example.  
+👉 The script will automatically be included because of the directory and its name ending with "Jupyter.sh".
+
+- How can i add another code base to analyze?
+👉 Create an new artifacts download script in the [scripts/artifacts](./scripts/artifacts) directory. Take [downloadAxonFramework.](./scripts/artifacts/downloadAxonFramework.sh) as a reference for example.
+👉 The script will be triggered when the [analyze](./scripts/analysis/analyze.sh) command 
+
+- How can i trigger a full rescan of all artifacts?
+👉 Delete the file `artifactsChangeDetectionHash.txt` in the temporary `arctifacts` directory.

--- a/cypher/CYPHER.md
+++ b/cypher/CYPHER.md
@@ -5,7 +5,7 @@ It provides a table listing each Cypher file and its corresponding description f
 
 Script | Directory | Description
 -------|-----------|------------
-| [Adding_the_artifact_name_temporarily_to_a_new_virtual_node_using_APOC.cypher](./Adding_the_artifact_name_temporarily_to_a_new_virtual_node_using_APOC.cypher) |  | Adding the artifact name temporarily to a new virtual node using APOC. Doesn't take all relationships into account and therefore doesn't work yet |
+| [Adding_the_artifact_name_temporarily_to_a_new_virtual_node_using_APOC.cypher](./Adding_the_artifact_name_temporarily_to_a_new_virtual_node_using_APOC.cypher) |  | Adding the artifact name temporarily to a new virtual node using APOC. Doesn't take all relationships into account and therefore doesn't work yet. |
 | [Adding_the_artifact_name_temporarily_to_the_Package_node_using_map_projection.cypher](./Adding_the_artifact_name_temporarily_to_the_Package_node_using_map_projection.cypher) |  | Adding the artifact name temporarily to the Package node using map projection |
 | [Candidates_for_Interface_Segregation.cypher](./Candidates_for_Interface_Segregation.cypher) |  | Candidates for Interface Segregation |
 | [Centrality_0_Delete_Projection.cypher](./Centrality/Centrality_0_Delete_Projection.cypher) | Centrality | Centrality 0 Delete Projection |
@@ -71,10 +71,18 @@ Script | Directory | Description
 | [Cyclic_Dependencies_Concatenated.cypher](./Cyclic_Dependencies/Cyclic_Dependencies_Concatenated.cypher) | Cyclic_Dependencies | Cyclic Dependencies Concatenated |
 | [Cyclic_Dependencies_as_List.cypher](./Cyclic_Dependencies/Cyclic_Dependencies_as_List.cypher) | Cyclic_Dependencies | Cyclic Dependencies as List |
 | [Cyclic_Dependencies_as_unwinded_List.cypher](./Cyclic_Dependencies/Cyclic_Dependencies_as_unwinded_List.cypher) | Cyclic_Dependencies | Cyclic Dependencies as unwinded List |
+| [External_package_usage_overall.cypher](./External_Dependencies/External_package_usage_overall.cypher) | External_Dependencies | External package usage overall |
+| [External_package_usage_per_artifact.cypher](./External_Dependencies/External_package_usage_per_artifact.cypher) | External_Dependencies | External package usage per artifact |
+| [External_package_usage_per_artifact_and_package.cypher](./External_Dependencies/External_package_usage_per_artifact_and_package.cypher) | External_Dependencies | External package usage per artifact and package |
+| [External_package_usage_per_type.cypher](./External_Dependencies/External_package_usage_per_type.cypher) | External_Dependencies | External package usage per type |
+| [External_package_usage_per_type_distribution.cypher](./External_Dependencies/External_package_usage_per_type_distribution.cypher) | External_Dependencies | External package usage per type distribution |
+| [External_types_per_artifact_using_requires.cypher](./External_Dependencies/External_types_per_artifact_using_requires.cypher) | External_Dependencies | External types per artifact using requires |
+| [Maven_POMs_and_their_declared_dependencies.cypher](./External_Dependencies/Maven_POMs_and_their_declared_dependencies.cypher) | External_Dependencies | Maven POMs and their declared dependencies |
 | [Extract_Custom_Manifest_Entries.cypher](./Extract_Custom_Manifest_Entries.cypher) |  | Extract Custom Manifest Entries |
 | [Get_Awesome_Procedures_On_Cypher_APOC_Version.cypher](./Get_Awesome_Procedures_On_Cypher_APOC_Version.cypher) |  | Get Awesome Procedures On Cypher APOC Version |
 | [Get_Graph_Data_Science_Library_Version.cypher](./Get_Graph_Data_Science_Library_Version.cypher) |  | Get Graph Data Science Library Version |
 | [Get_Graph_Data_Science_System_Information.cypher](./Get_Graph_Data_Science_System_Information.cypher) |  | Get Graph Data Science System Information |
+| [Get_all_declared_and_inherited_methods_of_a_type.cypher](./Get_all_declared_and_inherited_methods_of_a_type.cypher) |  | Get all declared and inherited methods of a type |
 | [Path_Finding_1_Create_Projection.cypher](./Graph_Data_Science_Path_Finding/Path_Finding_1_Create_Projection.cypher) | Graph_Data_Science_Path_Finding | Path Finding 1 Create Projection |
 | [Path_Finding_2_Estimate_Memory.cypher](./Graph_Data_Science_Path_Finding/Path_Finding_2_Estimate_Memory.cypher) | Graph_Data_Science_Path_Finding | Path Finding 2 Estimate Memory |
 | [Path_Finding_3_Depth_First_Search_Path.cypher](./Graph_Data_Science_Path_Finding/Path_Finding_3_Depth_First_Search_Path.cypher) | Graph_Data_Science_Path_Finding | Path Finding 3 Depth First Search Path |
@@ -97,6 +105,13 @@ Script | Directory | Description
 | [Set_Incoming_Package_Method_Call_Dependencies.cypher](./Metrics/Set_Incoming_Package_Method_Call_Dependencies.cypher) | Metrics | Set Incoming Package Method Call Dependencies |
 | [Set_Outgoing_Package_Dependencies.cypher](./Metrics/Set_Outgoing_Package_Dependencies.cypher) | Metrics | Set Outgoing Package Dependencies |
 | [Set_Outgoing_Package_Method_Call_Dependencies.cypher](./Metrics/Set_Outgoing_Package_Method_Call_Dependencies.cypher) | Metrics | Set Outgoing Package Method Call Dependencies |
+| [Cyclomatic_Method_Complexity_Distribution.cypher](./Overview/Cyclomatic_Method_Complexity_Distribution.cypher) | Overview | Cyclomatic Complexity Method Complexity Distribution |
+| [Effective_Method_Line_Count_Distribution.cypher](./Overview/Effective_Method_Line_Count_Distribution.cypher) | Overview | Effective Method Line Count Distribution |
+| [Effective_lines_of_method_code_per_package.cypher](./Overview/Effective_lines_of_method_code_per_package.cypher) | Overview | Effective lines of method code per package |
+| [Effective_lines_of_method_code_per_type.cypher](./Overview/Effective_lines_of_method_code_per_type.cypher) | Overview | Effective lines of method code per type |
+| [Number_of_packages_per_artifact.cypher](./Overview/Number_of_packages_per_artifact.cypher) | Overview | Number of packages per artifact |
+| [Number_of_types_per_artifact.cypher](./Overview/Number_of_types_per_artifact.cypher) | Overview | Number of types per artifact |
+| [Words_for_Wordcloud.cypher](./Overview/Words_for_Wordcloud.cypher) | Overview | Words for Wordcloud |
 | [Add_weight10PercentInterfaces_to_Package_DEPENDS_ON_relationships.cypher](./Package_Relationship_Weights/Add_weight10PercentInterfaces_to_Package_DEPENDS_ON_relationships.cypher) | Package_Relationship_Weights | Add weight10PercentInterfaces to Package DEPENDS_ON relationships |
 | [Add_weight25PercentInterfaces_to_Package_DEPENDS_ON_relationships.cypher](./Package_Relationship_Weights/Add_weight25PercentInterfaces_to_Package_DEPENDS_ON_relationships.cypher) | Package_Relationship_Weights | Add weight25PercentInterfaces to Package DEPENDS_ON relationships |
 | [Add_weight_property_for_Interface_Dependencies_to_Package_DEPENDS_ON_Relationship.cypher](./Package_Relationship_Weights/Add_weight_property_for_Interface_Dependencies_to_Package_DEPENDS_ON_Relationship.cypher) | Package_Relationship_Weights | Add weight property for Interface Dependencies to Package DEPENDS_ON Relationship |

--- a/cypher/External_Dependencies/External_package_usage_overall.cypher
+++ b/cypher/External_Dependencies/External_package_usage_overall.cypher
@@ -1,0 +1,29 @@
+// External package usage overall
+
+ MATCH (type:Type)
+  WITH count(type) as allTypes, collect(type) as typeList
+UNWIND typeList AS type
+ MATCH (type)-[externalDependency:DEPENDS_ON]->(externalType:Type)
+  WITH allTypes
+      ,replace(externalType.fqn, '.' + externalType.name, '') AS externalPackageName
+      ,externalType.name                              AS externalTypeName
+      ,externalDependency
+      ,(NOT externalType.fqn CONTAINS '.')            AS isPrimitiveType
+      ,(externalType.fqn STARTS WITH 'java.')         AS isJavaType
+      ,exists((externalType)-[:RESOLVES_TO]->(:Type)) AS isAlsoInternalType
+      ,(externalType.byteCodeVersion IS NULL)         AS isExternalType
+ WHERE isPrimitiveType    = false
+   AND isJavaType         = false
+   AND isAlsoInternalType = false
+   AND isExternalType     = true
+  WITH allTypes
+      ,externalPackageName
+      ,count(externalDependency)          AS numberOfExternalTypeCaller
+      ,sum(externalDependency.weight)     AS numberOfExternalTypeCalls
+      ,collect(DISTINCT externalTypeName) AS externalTypeNames
+RETURN externalPackageName
+      ,numberOfExternalTypeCaller
+      ,numberOfExternalTypeCalls
+      ,allTypes
+      ,externalTypeNames
+ ORDER BY numberOfExternalTypeCaller DESC, externalTypeNames ASC

--- a/cypher/External_Dependencies/External_package_usage_per_artifact.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact.cypher
@@ -1,0 +1,33 @@
+// External package usage per artifact 
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type)
+  WITH artifact, count(type) as numberOfTypesInArtifact, collect(type) as typeList
+UNWIND typeList as type
+ MATCH (type)-[externalDependency:DEPENDS_ON]->(externalType:Type)
+ WHERE externalType.byteCodeVersion IS NULL
+  WITH numberOfTypesInArtifact
+      ,externalDependency
+      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,type.fqn     AS fullTypeName
+      ,type.name    AS typeName
+      ,replace(externalType.fqn, '.' + externalType.name, '') AS externalPackageName
+      ,externalType.name                              AS externalTypeName
+      ,(NOT externalType.fqn CONTAINS '.')            AS isPrimitiveType
+      ,(externalType.fqn STARTS WITH 'java.')         AS isJavaType
+      ,exists((externalType)-[:RESOLVES_TO]->(:Type)) AS isAlsoInternalType
+ WHERE isPrimitiveType    = false
+   AND isJavaType         = false
+   AND isAlsoInternalType = false
+  WITH numberOfTypesInArtifact
+      ,artifactName
+      ,externalPackageName
+      ,count(externalDependency)          AS numberOfExternalTypeCaller
+      ,sum(externalDependency.weight)     AS numberOfExternalTypeCalls
+      ,collect(DISTINCT externalTypeName) AS externalTypeNames
+RETURN artifactName
+      ,externalPackageName
+      ,numberOfExternalTypeCaller
+      ,numberOfExternalTypeCalls
+      ,numberOfTypesInArtifact
+      ,externalTypeNames
+ORDER BY artifactName ASC, numberOfExternalTypeCaller DESC

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_and_package.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_and_package.cypher
@@ -1,0 +1,39 @@
+// External package usage per artifact and package 
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
+ MATCH (package)-[:CONTAINS]->(type:Type)
+  WITH artifact, package, count(type) AS numberOfTypesInPackage, collect(type) as typeList
+UNWIND typeList AS type
+ MATCH (type)-[externalDependency:DEPENDS_ON]->(externalType:Type)
+ WHERE externalType.byteCodeVersion IS NULL
+  WITH numberOfTypesInPackage
+      ,externalDependency
+      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,package.fqn  AS fullPackageName
+      ,package.name AS packageName
+      ,type.fqn     AS fullTypeName
+      ,type.name    AS typeName
+      ,replace(externalType.fqn, '.' + externalType.name, '') AS externalPackageName
+      ,externalType.name                              AS externalTypeName
+      ,(NOT externalType.fqn CONTAINS '.')            AS isPrimitiveType
+      ,(externalType.fqn STARTS WITH 'java.')         AS isJavaType
+      ,exists((externalType)-[:RESOLVES_TO]->(:Type)) AS isAlsoInternalType
+      ,exists((externalType)<-[:OF_TYPE]-()<-[:ANNOTATED_BY]-()) AS isAnnotation
+ WHERE isPrimitiveType    = false
+   AND isJavaType         = false
+   AND isAlsoInternalType = false
+   AND isAnnotation       = false
+  WITH numberOfTypesInPackage
+      ,artifactName
+      ,fullPackageName
+      ,packageName
+      ,externalPackageName
+      ,count(externalDependency)          AS numberOfExternalTypeCaller
+      ,sum(externalDependency.weight)     AS numberOfExternalTypeCalls
+      ,collect(DISTINCT externalTypeName) AS externalTypeNames
+RETURN artifactName, fullPackageName
+      ,externalPackageName
+      ,numberOfExternalTypeCaller, numberOfExternalTypeCalls, numberOfTypesInPackage
+      ,externalTypeNames
+      ,packageName
+ORDER BY numberOfExternalTypeCaller DESC, artifactName ASC, fullPackageName ASC

--- a/cypher/External_Dependencies/External_package_usage_per_type.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_type.cypher
@@ -1,0 +1,37 @@
+// External package usage per type
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
+ MATCH (package)-[:CONTAINS]->(type:Type)
+ MATCH (type)-[externalDependency:DEPENDS_ON]->(externalType:Type)
+ WHERE externalType.byteCodeVersion IS NULL
+  WITH externalDependency
+      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,package.fqn  AS fullPackageName
+      ,package.name AS packageName
+      ,type.fqn     AS fullTypeName
+      ,type.name    AS typeName
+      ,replace(externalType.fqn, '.' + externalType.name, '') AS externalPackageName
+      ,externalType.name                              AS externalTypeName
+      ,(NOT externalType.fqn CONTAINS '.')            AS isPrimitiveType
+      ,(externalType.fqn STARTS WITH 'java.')         AS isJavaType
+      ,exists((externalType)-[:RESOLVES_TO]->(:Type)) AS isAlsoInternalType
+ WHERE isPrimitiveType    = false
+   AND isJavaType         = false
+   AND isAlsoInternalType = false
+  WITH artifactName
+      ,fullPackageName
+      ,packageName
+      ,fullTypeName
+      ,typeName
+      ,count(externalDependency)             AS numberOfExternalTypeCaller
+      ,sum(externalDependency.weight)        AS numberOfExternalTypeCalls
+      ,count  (DISTINCT externalPackageName) AS numberOfExternalPackages
+      ,collect(DISTINCT externalPackageName) AS externalPackageNames
+      ,count  (DISTINCT externalPackageName + '.' + externalTypeName) AS numberOfExternalTypes
+      ,collect(DISTINCT externalPackageName + '.' + externalTypeName) AS externalTypeNames
+RETURN artifactName, fullPackageName, typeName
+      ,numberOfExternalTypeCaller, numberOfExternalTypeCalls, numberOfExternalPackages, numberOfExternalTypes
+      ,externalPackageNames, externalTypeNames
+      ,packageName
+      ,fullTypeName
+ORDER BY numberOfExternalPackages DESC, artifactName ASC, fullPackageName ASC

--- a/cypher/External_Dependencies/External_package_usage_per_type_distribution.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_type_distribution.cypher
@@ -1,0 +1,37 @@
+// External package usage per type distribution
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type)
+  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+      ,count(type)                                               AS artifactTypes
+      ,collect(type)                                             AS typeList
+UNWIND typeList AS type
+ MATCH (type)-[:DEPENDS_ON]->(externalType:Type)
+ WHERE externalType.byteCodeVersion IS NULL
+  WITH artifactName
+      ,artifactTypes
+      ,type.fqn                                                  AS fullTypeName
+      ,replace(externalType.fqn, '.' + externalType.name, '')    AS externalPackageName
+      ,(NOT externalType.fqn CONTAINS '.')                       AS isPrimitiveType
+      ,(externalType.fqn STARTS WITH 'java.')                    AS isJavaType
+      ,exists((externalType)-[:RESOLVES_TO]->(:Type))            AS isAlsoInternalType
+      ,exists((externalType)<-[:OF_TYPE]-()<-[:ANNOTATED_BY]-()) AS isAnnotation
+ WHERE isPrimitiveType    = false
+   AND isJavaType         = false
+   AND isAlsoInternalType = false
+   AND isAnnotation       = false
+  WITH artifactName
+      ,artifactTypes
+      ,fullTypeName
+      ,count(DISTINCT externalPackageName) AS numberOfExternalPackages    
+  WITH artifactName
+      ,artifactTypes
+      ,numberOfExternalPackages
+      ,count(DISTINCT fullTypeName)   AS numberOfTypes
+      ,COLLECT(DISTINCT fullTypeName) AS nameOfTypes
+RETURN artifactName
+      ,artifactTypes
+      ,numberOfExternalPackages
+      ,numberOfTypes
+      ,100.0 / artifactTypes * numberOfTypes AS numberOfTypesPercentage
+      ,nameOfTypes
+ORDER BY artifactName ASC, numberOfExternalPackages ASC

--- a/cypher/External_Dependencies/External_types_per_artifact_using_requires.cypher
+++ b/cypher/External_Dependencies/External_types_per_artifact_using_requires.cypher
@@ -1,0 +1,22 @@
+// External types per artifact using requires
+
+MATCH (artifact:Artifact)-[:REQUIRES]->(externalType:Type)
+MATCH (artifact)-[:CONTAINS]->(caller:Type)
+OPTIONAL MATCH (caller)-[callerDependency:DEPENDS_ON]->(externalType)
+WHERE NOT externalType.fqn STARTS WITH 'java.' // ignore 
+  AND externalType.fqn CONTAINS '.' // ignore primitives
+  AND NOT EXISTS((externalType)-[:RESOLVES_TO]->(:Type))
+ WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+     ,replace(externalType.fqn, '.' + externalType.name, '') AS externalTypePackage
+     ,COLLECT(DISTINCT externalType.name)   AS externalTypeNames
+     ,COUNT(callerDependency)               AS numberOfCaller
+     ,sum(callerDependency.weight)          AS numberOfCalls
+     ,COUNT(DISTINCT caller)                AS numberOfAllTypes
+WHERE numberOfCalls > 0
+RETURN artifactName
+      ,externalTypePackage
+      ,numberOfCaller
+      ,numberOfCalls
+      ,numberOfAllTypes
+      ,externalTypeNames
+ ORDER BY artifactName ASC, numberOfCaller DESC

--- a/cypher/External_Dependencies/Maven_POMs_and_their_declared_dependencies.cypher
+++ b/cypher/External_Dependencies/Maven_POMs_and_their_declared_dependencies.cypher
@@ -1,0 +1,5 @@
+// Maven POMs and their declared dependencies
+
+ MATCH (pom:Pom)-[r1:DECLARES_DEPENDENCY]->(dependency:Dependency)-[r2:TO_ARTIFACT]->(dependentArtifact) 
+RETURN pom.artifactId, pom.name, coalesce(dependency.scope, 'default') as scope, dependency.optional, dependentArtifact.group, dependentArtifact.name
+ ORDER BY pom.artifactId

--- a/cypher/Overview/Cyclomatic_Method_Complexity_Distribution.cypher
+++ b/cypher/Overview/Cyclomatic_Method_Complexity_Distribution.cypher
@@ -1,0 +1,9 @@
+// Cyclomatic Complexity Method Complexity Distribution
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type)-[:DECLARES]->(method:Method)
+ WHERE method.effectiveLineCount > 0
+  WITH last(split(artifact.fileName, '/')) AS artifactName
+       ,method.cyclomaticComplexity        AS cyclomaticComplexity
+       ,count(method)                      AS methods
+RETURN artifactName, cyclomaticComplexity, methods
+ ORDER BY artifactName asc, cyclomaticComplexity

--- a/cypher/Overview/Effective_Method_Line_Count_Distribution.cypher
+++ b/cypher/Overview/Effective_Method_Line_Count_Distribution.cypher
@@ -1,0 +1,9 @@
+// Effective Method Line Count Distribution
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type)-[:DECLARES]->(method:Method)
+ WHERE method.effectiveLineCount > 0
+  WITH last(split(artifact.fileName, '/'))     AS artifactName
+       ,method.effectiveLineCount              AS effectiveLineCount
+       ,count(method)                          AS methods
+RETURN artifactName, effectiveLineCount, methods
+ ORDER BY artifactName asc, effectiveLineCount

--- a/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
+++ b/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
@@ -25,13 +25,14 @@
             ELSE cmplx // otherwise keep the object as it was
           END 
         ) AS methodWithMaxCyclomaticComplexity
-RETURN artifactName, fullPackageName, packageName 
-      ,sumEffectiveLinesOfMethodCode
-      ,numberOfMethods
-      ,methodWithMaxLoc.max                          AS maxEffectiveLinesOfCode
-      ,methodWithMaxLoc.method.name                  AS maxEffectiveLinesOfCodeMethod
-      ,methodWithMaxLoc.type.fqn                     AS typeOfMaxEffectiveLinesOfCodeMethod
-      ,methodWithMaxCyclomaticComplexity.max         AS maxCyclomaticComplexity
-      ,methodWithMaxCyclomaticComplexity.method.name AS maxCyclomaticComplexityMethod
-      ,methodWithMaxCyclomaticComplexity.type.fqn    AS typeOfMaxCyclomaticComplexityMethod
-ORDER BY artifactName, fullPackageName
+RETURN artifactName, fullPackageName
+      ,sumEffectiveLinesOfMethodCode                 AS linesInPackage
+      ,numberOfMethods                               AS methodCount
+      ,methodWithMaxLoc.max                          AS maxLinesMethod
+      ,methodWithMaxLoc.type.name                    AS maxLinesMethodType
+      ,methodWithMaxLoc.method.name                  AS maxLinesMethodName
+      ,methodWithMaxCyclomaticComplexity.max         AS maxComplexity
+      ,methodWithMaxCyclomaticComplexity.type.name   AS maxComplexityType
+      ,methodWithMaxCyclomaticComplexity.method.name AS maxComplexityMethod
+      ,packageName 
+ORDER BY sumEffectiveLinesOfMethodCode DESC, artifactName ASC, fullPackageName

--- a/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
+++ b/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
@@ -1,0 +1,37 @@
+// Effective lines of method code per package
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
+ MATCH (package)-[:CONTAINS]->(type:Type)
+ MATCH (type)-[:DECLARES]->(method:Method)
+ WHERE method.effectiveLineCount > 0
+  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,package.fqn                                              AS fullPackageName
+      ,package.name                                             AS packageName
+      ,sum(method.effectiveLineCount)                           AS sumEffectiveLinesOfMethodCode
+      ,COUNT(DISTINCT method) AS numberOfMethods
+      ,reduce( // Get the max effectiveLineCount of all methods in the package with the name and type of the method
+        loc = {max:-1}, // initial object with max lines of code = -1
+        m IN collect({method:method, type:type}) | // collect all methods and their types as objects
+          CASE WHEN (m.method.effectiveLineCount > loc.max) // when there is a method with a higher line count...
+            THEN {max: m.method.effectiveLineCount, method: m.method, type: m.type} // then update the object
+            ELSE loc // otherwise keep the object as it was
+          END
+        ) AS methodWithMaxLoc
+      ,reduce( // Get the max cyclomaticComplexity of all methods in the package with the name and type of the method
+        cmplx = {max:-1}, // initial object with max cyclomatic complexity = -1
+        m IN collect({method:method, type:type}) | // collect all methods and their types as objects
+          CASE WHEN (m.method.cyclomaticComplexity > cmplx.max) 
+            THEN {max: m.method.cyclomaticComplexity, method: m.method, type: m.type} // then update the object
+            ELSE cmplx // otherwise keep the object as it was
+          END 
+        ) AS methodWithMaxCyclomaticComplexity
+RETURN artifactName, fullPackageName, packageName 
+      ,sumEffectiveLinesOfMethodCode
+      ,numberOfMethods
+      ,methodWithMaxLoc.max                          AS maxEffectiveLinesOfCode
+      ,methodWithMaxLoc.method.name                  AS maxEffectiveLinesOfCodeMethod
+      ,methodWithMaxLoc.type.fqn                     AS typeOfMaxEffectiveLinesOfCodeMethod
+      ,methodWithMaxCyclomaticComplexity.max         AS maxCyclomaticComplexity
+      ,methodWithMaxCyclomaticComplexity.method.name AS maxCyclomaticComplexityMethod
+      ,methodWithMaxCyclomaticComplexity.type.fqn    AS typeOfMaxCyclomaticComplexityMethod
+ORDER BY artifactName, fullPackageName

--- a/cypher/Overview/Effective_lines_of_method_code_per_type.cypher
+++ b/cypher/Overview/Effective_lines_of_method_code_per_type.cypher
@@ -1,0 +1,23 @@
+// Effective lines of method code per type
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
+ MATCH (package)-[:CONTAINS]->(type:Type)
+ MATCH (type)-[:DECLARES]->(method:Method)
+ WHERE method.effectiveLineCount > 0
+  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,package.fqn                                              AS packageName
+      ,type.name                                                AS typeName
+      ,sum(method.effectiveLineCount)                           AS sumEffectiveLinesOfMethodCode
+      ,reduce(loc = {max:-1}, m IN collect(method) | 
+       CASE WHEN (m.effectiveLineCount > loc.max) THEN {max: m.effectiveLineCount, method: m} ELSE loc END) 
+         AS methodWithMaxLoc
+      ,reduce(cmplx = {max:-1}, m IN collect(method) | 
+       CASE WHEN (m.cyclomaticComplexity > cmplx.max) THEN {max: m.cyclomaticComplexity, method: m} ELSE cmplx END) 
+         AS methodWithMaxCyclomaticComplexity
+RETURN artifactName, packageName, typeName
+      ,sumEffectiveLinesOfMethodCode
+      ,methodWithMaxLoc.max                          AS maxEffectiveLinesOfMethodCode
+      ,methodWithMaxLoc.method.name                  AS methodWithMaxEffectiveLinesOfMethodCode
+      ,methodWithMaxCyclomaticComplexity.max         AS maxCyclomaticComplexity
+      ,methodWithMaxCyclomaticComplexity.method.name AS methodWithMaxCyclomaticComplexity
+ORDER BY sumEffectiveLinesOfMethodCode DESC

--- a/cypher/Overview/Number_of_packages_per_artifact.cypher
+++ b/cypher/Overview/Number_of_packages_per_artifact.cypher
@@ -1,0 +1,6 @@
+// Number of packages per artifact
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)-[:CONTAINS]->(type:Type)
+  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,count(DISTINCT package.fqn) as numberOfPackages
+ RETURN artifactName, numberOfPackages

--- a/cypher/Overview/Number_of_types_per_artifact.cypher
+++ b/cypher/Overview/Number_of_types_per_artifact.cypher
@@ -1,0 +1,12 @@
+// Number of types per artifact
+
+ MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type) 
+  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,type
+      ,labels(type) AS typeLabels
+UNWIND typeLabels AS typeLabel
+  WITH artifactName, type, typeLabel
+ WHERE typeLabel IN ['Class', 'Interface', 'Annotation', 'Enum']
+RETURN artifactName
+      ,typeLabel    AS languageElement
+      ,count(type)  AS numberOfTypes

--- a/cypher/Overview/Words_for_Wordcloud.cypher
+++ b/cypher/Overview/Words_for_Wordcloud.cypher
@@ -1,0 +1,18 @@
+// Words for Wordcloud
+
+MATCH (package:Package)
+ WITH collect(package.name) AS packageNames
+MATCH (type:Type)
+WHERE type.byteCodeVersion IS NOT NULL  // no external types 
+  AND NOT type.fqn STARTS WITH 'java.'  // no java types
+  AND type.name <> 'package-info'       // not package-info files
+ WITH packageNames, split(type.name, '$') AS splittedInnerClasses
+UNWIND splittedInnerClasses AS splittedInnerClass
+ WITH packageNames
+     ,apoc.text.replace(splittedInnerClass, '(?<!^)([A-Z])', ' $1') AS splittedCamelCaseWord
+ WITH packageNames
+     ,split(apoc.text.replace(splittedCamelCaseWord, '[0-9]', ''), ' ') AS splittedCamelCaseWords
+UNWIND splittedCamelCaseWords AS splittedCamelCaseWord     
+ WITH packageNames, collect(splittedCamelCaseWord) AS typeNames
+UNWIND packageNames + typeNames AS word
+RETURN toLower(word) AS word

--- a/jupyter/ExternalDependencies.ipynb
+++ b/jupyter/ExternalDependencies.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# External Dependencies of Java Artifacts with Neo4j\n",
+    "<br>  \n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [py2neo](https://py2neo.org/2021.1/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4191f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from py2neo import Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "graph = Graph(\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename):\n",
+    "    return graph.run(get_cypher_query_from_file(filename)).to_data_frame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da9e8edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9deaabce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2496caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6705e06a",
+   "metadata": {},
+   "source": [
+    "## External Package Usage"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "334167e4",
+   "metadata": {},
+   "source": [
+    "### Table 1 - Top 20 most used external packages overall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff524ac7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "external_package_useage=query_cypher_to_data_frame(\"../cypher/External_Dependencies/External_package_usage_overall.cypher\")\n",
+    "\n",
+    "# Select columns and only show the first 20 entries (head)\n",
+    "external_package_useage.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7767f100",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "\n",
+    "# Set the name of the index to artifactName\n",
+    "external_package_useage_by_name=external_package_useage.set_index('externalPackageName')\n",
+    "\n",
+    "axis = external_package_useage_by_name.head(20).plot(\n",
+    "    y='numberOfExternalTypeCalls', \n",
+    "    kind='pie',\n",
+    "    title='External Package Usage',\n",
+    "    legend=True,\n",
+    "    labeldistance=None,\n",
+    "    cmap=main_color_map\n",
+    ")\n",
+    "axis.legend(bbox_to_anchor=(1, 1), loc='upper left')\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "29ec2211",
+   "metadata": {},
+   "source": [
+    "### Table 2 - Top 20 least used external packages overall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03641b8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sort by number of external type calls\n",
+    "external_package_least_used=external_package_useage.sort_values(by='numberOfExternalTypeCalls', ascending=True)\n",
+    "\n",
+    "# Reset index\n",
+    "external_package_least_used = external_package_least_used.reset_index(drop=True)\n",
+    "\n",
+    "# Select columns and only show the first 10 entries (head)\n",
+    "external_package_least_used[['externalPackageName','numberOfExternalTypeCalls']].head(20)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "33c3bb79",
+   "metadata": {},
+   "source": [
+    "### Table 3 - External usage per artifact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1637f8ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_cypher_to_data_frame(\"../cypher/External_Dependencies/External_package_usage_per_artifact.cypher\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "4fb87c8a",
+   "metadata": {},
+   "source": [
+    "### Table 4 - External usage per artifact and package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58a19ad7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "external_package_usage_per_package = query_cypher_to_data_frame(\"../cypher/External_Dependencies/External_package_usage_per_artifact_and_package.cypher\")\n",
+    "external_package_usage_per_package"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a3161e2b",
+   "metadata": {},
+   "source": [
+    "### Table 5 - Top 20 external package usage per type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2224d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "external_package_usage_per_type = query_cypher_to_data_frame(\"../cypher/External_Dependencies/External_package_usage_per_type.cypher\")\n",
+    "\n",
+    "external_package_usage_per_type.head(20)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5b420f59",
+   "metadata": {},
+   "source": [
+    "### Table 6 - External package usage distribution per type\n",
+    "\n",
+    "The table shown here only includes the first 20 rows at most which typically represents the most significant entries.\n",
+    "Have a look above to find out which types have the highest external package dependency usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d750524a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "external_package_usage_per_type_distribution = query_cypher_to_data_frame(\"../cypher/External_Dependencies/External_package_usage_per_type_distribution.cypher\")\n",
+    "external_package_usage_per_type_distribution[['artifactName', 'artifactTypes', 'numberOfExternalPackages', 'numberOfTypes', 'numberOfTypesPercentage']].head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a2ebcf9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Organize artifacts in columns with the number of types as values using pivot\n",
+    "# Every row represents the number of external packages\n",
+    "external_package_usage_per_type_distribution=external_package_usage_per_type_distribution.pivot(index='numberOfExternalPackages', columns='artifactName', values='numberOfTypesPercentage')\n",
+    "\n",
+    "# Fill missing values with zero\n",
+    "external_package_usage_per_type_distribution.fillna(0, inplace=True)\n",
+    "\n",
+    "# Convert to integer\n",
+    "# external_package_usage_per_type_distribution=external_package_usage_per_type_distribution.astype(int)\n",
+    "\n",
+    "external_package_usage_per_type_distribution.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58c9052a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "axes = external_package_usage_per_type_distribution.plot(\n",
+    "    kind='bar', \n",
+    "    grid=True,\n",
+    "    title='Relative External Package Usage', \n",
+    "    xlabel='external package count',\n",
+    "    ylabel='percentage of types',\n",
+    "    cmap=main_color_map,\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "c2a1d4b6",
+   "metadata": {},
+   "source": [
+    "## Maven POMs\n",
+    "\n",
+    "### Table 7 - Maven POMs and their declared dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4478ca3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_cypher_to_data_frame(\"../cypher/External_Dependencies/Maven_POMs_and_their_declared_dependencies.cypher\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "title": "Object Oriented Design Quality Metrics for Java with Neo4j"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter/Overview.ipynb
+++ b/jupyter/Overview.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Overview of Java Artifacts with Neo4j\n",
+    "<br>  \n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [py2neo](https://py2neo.org/2021.1/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4191f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from py2neo import Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "graph = Graph(\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename):\n",
+    "    return graph.run(get_cypher_query_from_file(filename)).to_data_frame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da9e8edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9deaabce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2496caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "91d80bf7",
+   "metadata": {},
+   "source": [
+    "## Artifacts"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e02f924a",
+   "metadata": {},
+   "source": [
+    "### Table 1 - Types per artifact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc682db6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "types_per_artifact = query_cypher_to_data_frame(\"../cypher/Overview/Number_of_types_per_artifact.cypher\")\n",
+    "types_per_artifact"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "b44c8a75",
+   "metadata": {},
+   "source": [
+    "### Table 2 - Types per artifact (grouped)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "390c40f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pivot the DataFrame to \n",
+    "# - group by the first column (artifactName) as new index\n",
+    "# - convert the values in the second column (typeLabel) \n",
+    "# - into columns with the value of the third column (numberOfTypes).\n",
+    "types_per_artifact_grouped = types_per_artifact.pivot(index='artifactName', columns='languageElement', values='numberOfTypes')\n",
+    "\n",
+    "# Fill missing values with zero\n",
+    "types_per_artifact_grouped.fillna(0, inplace=True)\n",
+    "\n",
+    "# Calculate the sum of values for each row\n",
+    "types_per_artifact_grouped['Total'] = types_per_artifact_grouped.sum(axis=1)\n",
+    "\n",
+    "# Sort the DataFrame by the sum of values\n",
+    "types_per_artifact_grouped.sort_values(by='Total', ascending=False, inplace=True)\n",
+    "\n",
+    "# Remove the 'Total' column\n",
+    "types_per_artifact_grouped.drop('Total', axis=1, inplace=True)\n",
+    "\n",
+    "# Sort the order of the columns by their sum\n",
+    "column_sum = types_per_artifact_grouped.sum()\n",
+    "types_per_artifact_grouped = types_per_artifact_grouped[column_sum.sort_values(ascending=False).index[:]]\n",
+    "\n",
+    "# Convert to integer\n",
+    "types_per_artifact_grouped.astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "982df680",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "types_per_artifact_grouped.plot(\n",
+    "    kind='bar', \n",
+    "    title='Types per Artifact',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Types',\n",
+    "    stacked=True, \n",
+    "    cmap=main_color_map\n",
+    ")\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec514eba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (Optional) Plot \"Types per Artifact\" and the normalized variation side by side\n",
+    "# plot.figure();\n",
+    "# fig, (axis_left, axis_right) = plot.subplots(nrows=1, ncols=2)\n",
+    "# types_per_artifact_grouped.plot(\n",
+    "#     ax=axis_left,\n",
+    "#     kind='bar', \n",
+    "#     title='Types per Artifact',\n",
+    "#     xlabel='Artifact',\n",
+    "#     ylabel='Types',\n",
+    "#     stacked=True, \n",
+    "#     cmap=main_color_map\n",
+    "# )\n",
+    "# types_per_artifact_grouped_normalized.plot(\n",
+    "#     ax=axis_right,\n",
+    "#     kind='bar', \n",
+    "#     title='Types per Artifact [%]',\n",
+    "#     xlabel='Artifact',\n",
+    "#     ylabel='Types %',\n",
+    "#     stacked=True, \n",
+    "#     cmap=main_color_map\n",
+    "# )\n",
+    "# plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "62268321",
+   "metadata": {},
+   "source": [
+    "### Table 3 - Types per artifact (grouped and normalized in %)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed887815",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide every value by the sum of the row to get horizontal normalized values.\n",
+    "# This makes it easier to compare the \"language element\" usage without taking the size of the artifact into account\n",
+    "types_per_artifact_grouped_normalized = types_per_artifact_grouped.div(types_per_artifact_grouped.sum(axis=1), axis=0).multiply(100)\n",
+    "types_per_artifact_grouped_normalized"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0e1b7bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide every value by the sum of the row to get horizontal normalized values.\n",
+    "# This makes it easier to compare the \"language element\" usage without taking the size of the artifact into account\n",
+    "types_per_artifact_grouped_normalized = types_per_artifact_grouped.div(types_per_artifact_grouped.sum(axis=1), axis=0).multiply(100)\n",
+    "\n",
+    "plot.figure();\n",
+    "types_per_artifact_grouped_normalized.plot(kind='bar', stacked=True, cmap=main_color_map)\n",
+    "plot.xlabel('Artifact')\n",
+    "plot.ylabel('Types %')\n",
+    "plot.title('Types [%] per Artifact')\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "85535e4f",
+   "metadata": {},
+   "source": [
+    "### Table 4 - Number of packages per artifact"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "969a5e0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "packages_per_artifact = query_cypher_to_data_frame(\"../cypher/Overview/Number_of_packages_per_artifact.cypher\")\n",
+    "\n",
+    "# Sort the DataFrame by the sum of values\n",
+    "types_per_artifact_sorted = packages_per_artifact.sort_values(by='numberOfPackages', ascending=False)\n",
+    "\n",
+    "# Set the name of the index to artifactName\n",
+    "types_per_artifact_sorted.set_index('artifactName', inplace=True)\n",
+    "\n",
+    "types_per_artifact_sorted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81250096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "types_per_artifact_sorted.plot(y='numberOfPackages', kind='pie', title='Packages per Artifact', labeldistance=None, cmap=main_color_map)\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "23fd8dfd",
+   "metadata": {},
+   "source": [
+    "## Effective Method Line Count"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5c49be47",
+   "metadata": {},
+   "source": [
+    "### Table 5 - Effective method line count distribution\n",
+    "\n",
+    "The table shown here only includes the first 10 rows which typically represents the most significant entries.\n",
+    "Have a look below to find out which packages and methods have the highest effective lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6dfbcb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "effective_method_line_count_distribution=query_cypher_to_data_frame(\"../cypher/Overview/Effective_Method_Line_Count_Distribution.cypher\")\n",
+    "effective_method_line_count_distribution=effective_method_line_count_distribution.pivot(index='effectiveLineCount', columns='artifactName', values='methods')\n",
+    "\n",
+    "# Fill missing values with zero\n",
+    "effective_method_line_count_distribution.fillna(0, inplace=True)\n",
+    "\n",
+    "# Convert to integer\n",
+    "effective_method_line_count_distribution=effective_method_line_count_distribution.astype(int)\n",
+    "\n",
+    "effective_method_line_count_distribution.head(10)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "69f80f6d",
+   "metadata": {},
+   "source": [
+    "### Table 6 - Effective method line count distribution (normalized)\n",
+    "\n",
+    "The table shown here only includes the first 10 rows which typically represents the most significant entries.\n",
+    "Have a look below to find out which packages and methods have the highest effective lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b389bbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide every value by the sum of all values in the same column to get vertical normalized values.\n",
+    "effective_method_line_count_distribution_normalized = effective_method_line_count_distribution.div(effective_method_line_count_distribution.sum(axis=0), axis=1).multiply(100)\n",
+    "effective_method_line_count_distribution_normalized.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a1ae2c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "method_line_count_x_ticks=range(1,11)\n",
+    "axes = effective_method_line_count_distribution_normalized.plot(\n",
+    "    kind='line', \n",
+    "    logx=True,\n",
+    "    grid=True,\n",
+    "    xlim=[1,20],\n",
+    "    xticks=method_line_count_x_ticks,\n",
+    "    title='Effective Method Line Count Distribution', \n",
+    "    xlabel='effective line count',\n",
+    "    ylabel='number of methods',\n",
+    "    cmap=main_color_map,\n",
+    ")\n",
+    "axes.set_xticklabels(method_line_count_x_ticks)\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8f811e86",
+   "metadata": {},
+   "source": [
+    "### Table 7 - Cyclomatic method complexity distribution\n",
+    "\n",
+    "The table shown here only includes the first 10 rows which typically represents the most significant entries.\n",
+    "Have a look below to find out which packages and methods have the highest effective lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf989acc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cyclomatic_method_complexity_distribution=query_cypher_to_data_frame(\"../cypher/Overview/Cyclomatic_Method_Complexity_Distribution.cypher\")\n",
+    "cyclomatic_method_complexity_distribution=cyclomatic_method_complexity_distribution.pivot(index='cyclomaticComplexity', columns='artifactName', values='methods')\n",
+    "\n",
+    "# Fill missing values with zero\n",
+    "cyclomatic_method_complexity_distribution.fillna(0, inplace=True)\n",
+    "\n",
+    "# Convert to integer\n",
+    "cyclomatic_method_complexity_distribution=cyclomatic_method_complexity_distribution.astype(int)\n",
+    "\n",
+    "cyclomatic_method_complexity_distribution.head(10)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "edd94088",
+   "metadata": {},
+   "source": [
+    "### Table 8 - Cyclomatic method complexity distribution (normalized)\n",
+    "\n",
+    "The table shown here only includes the first 10 rows which typically represents the most significant entries.\n",
+    "Have a look below to find out which packages and methods have the highest effective lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7aff1d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide every value by the sum of all values in the same column to get vertical normalized values.\n",
+    "cyclomatic_method_complexity_distribution_normalized = cyclomatic_method_complexity_distribution.div(cyclomatic_method_complexity_distribution.sum(axis=0), axis=1).multiply(100)\n",
+    "cyclomatic_method_complexity_distribution_normalized.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4e40ede",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot.figure();\n",
+    "method_line_count_x_ticks=range(1,11)\n",
+    "cyclomatic_complexity_y_ticks=[1, 2, 3, 4, 5, 7, 10, 20, 30, 40, 50, 100]\n",
+    "axes = cyclomatic_method_complexity_distribution_normalized.plot(\n",
+    "    kind='line', \n",
+    "    logx=True,\n",
+    "    logy=True,\n",
+    "    grid=True,\n",
+    "    xlim=[1,10],\n",
+    "    ylim=[1,100],\n",
+    "    xticks=method_line_count_x_ticks,\n",
+    "    yticks=cyclomatic_complexity_y_ticks,\n",
+    "    title='Cyclomatic Method Complexity Distribution', \n",
+    "    xlabel='cyclomatic complexity',\n",
+    "    ylabel='number of methods',\n",
+    "    cmap=main_color_map,\n",
+    ")\n",
+    "axes.set_xticklabels(method_line_count_x_ticks)\n",
+    "axes.set_yticklabels(cyclomatic_complexity_y_ticks)\n",
+    "plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "732618fb",
+   "metadata": {},
+   "source": [
+    "### Table 9 - Top 10 packages with highest effective line counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "101091d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query data from graph database\n",
+    "effective_line_count_per_package = query_cypher_to_data_frame(\"../cypher/Overview/Effective_lines_of_method_code_per_package.cypher\")\n",
+    "\n",
+    "# Select columns and top 10 rows (head)\n",
+    "effective_line_count_per_package[['artifactName', 'fullPackageName', 'linesInPackage', 'methodCount', 'maxLinesMethod','maxLinesMethodName']].head(10)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "558d0efe",
+   "metadata": {},
+   "source": [
+    "### Table 10 - Top 10 methods with highest effective line counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b81bc7ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sort by maxLinesMethod\n",
+    "effective_line_count_per_method=effective_line_count_per_package.sort_values(by='maxLinesMethod', ascending=False)\n",
+    "\n",
+    "# Reset index\n",
+    "effective_line_count_per_method = effective_line_count_per_method.reset_index()\n",
+    "\n",
+    "# Select columns and top 10 rows (head)\n",
+    "effective_line_count_per_method[['artifactName', 'fullPackageName', 'maxLinesMethodType', 'maxLinesMethodName', 'maxLinesMethod']].head(10)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "4c82a0fd",
+   "metadata": {},
+   "source": [
+    "### Table 11 - Top 10 methods with highest cyclomatic complexity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e000945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sort by maxComplexity\n",
+    "cyclomatic_complexity_per_method=effective_line_count_per_package.sort_values(by='maxComplexity', ascending=False)\n",
+    "\n",
+    "# Reset Index\n",
+    "cyclomatic_complexity_per_method = cyclomatic_complexity_per_method.reset_index()\n",
+    "\n",
+    "# Select columns and only the top 10 rows (head)\n",
+    "cyclomatic_complexity_per_method[['artifactName', 'fullPackageName', 'maxComplexityType', 'maxComplexityMethod', 'maxComplexity']].head(10)"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  },
+  "title": "Object Oriented Design Quality Metrics for Java with Neo4j"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter/Wordcloud.ipynb
+++ b/jupyter/Wordcloud.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Overview of Java Artifacts with Neo4j\n",
+    "<br>  \n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [py2neo](https://py2neo.org/2021.1/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4191f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from py2neo import Graph\n",
+    "from wordcloud import WordCloud, STOPWORDS, ImageColorGenerator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "graph = Graph(\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename):\n",
+    "    return graph.run(get_cypher_query_from_file(filename)).to_data_frame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da9e8edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9deaabce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2496caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "97cf6afa",
+   "metadata": {},
+   "source": [
+    "## Word Cloud"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ed729e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query data from graph database\n",
+    "words = query_cypher_to_data_frame(\"../cypher/Overview/Words_for_Wordcloud.cypher\")\n",
+    "words.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62328fe4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Join all words into one text separated by spaces\n",
+    "text = \" \".join(i for i in words.word)\n",
+    "print(\"There are {} words in the dataset.\".format(len(words.word)))\n",
+    "\n",
+    "# Define stop words\n",
+    "stopwords = set(STOPWORDS)\n",
+    "stopwords.update(['builder', 'exception', 'abstract', 'helper', 'util', 'callback', 'factory', 'handler', 'repository', 'result'])\n",
+    "wordcloud = WordCloud(stopwords=stopwords, background_color='white', colormap='viridis').generate(text)\n",
+    "\n",
+    "# Plot the word cloud\n",
+    "plot.figure(figsize=(15,10))\n",
+    "plot.imshow(wordcloud, interpolation='bilinear')\n",
+    "plot.axis(\"off\")\n",
+    "plot.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "title": "Object Oriented Design Quality Metrics for Java with Neo4j"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter/environment.yml
+++ b/jupyter/environment.yml
@@ -4,13 +4,13 @@ channels:
 dependencies:
   - python=3.11.*
   - jupyter=1.0.*
-  - matplotlib=3.7.*
-  - nbconvert=7.3.*
-  - nbconvert-webpdf=7.3.*
-  - numpy=1.24.*
-  - pandas=2.0.*
-  - pip=23.1.*
+  - matplotlib=3.6.*
+  - nbconvert=7.2.*
+  - nbconvert-webpdf=7.2.*
+  - numpy=1.23.*
+  - pandas=1.5.*
+  - pip=22.3.*
   - pip:
-      - monotonic==1.6
+      - monotonic==1.*
       - py2neo==2021.2.*
       - wordcloud==1.9.*

--- a/jupyter/environment.yml
+++ b/jupyter/environment.yml
@@ -2,11 +2,15 @@ name: codegraph
 channels:
   - conda-forge
 dependencies:
-  - jupyter
-  - matplotlib
-  - monotonic
-  - nbconvert
-  - nbconvert-webpdf
-  - numpy
-  - pandas
-  - py2neo
+  - python=3.11.*
+  - jupyter=1.0.*
+  - matplotlib=3.7.*
+  - nbconvert=7.3.*
+  - nbconvert-webpdf=7.3.*
+  - numpy=1.24.*
+  - pandas=2.0.*
+  - pip=23.1.*
+  - pip:
+      - monotonic==1.6
+      - py2neo==2021.2.*
+      - wordcloud==1.9.*

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -14,17 +14,22 @@ Script | Directory | Description
 | [executeQuery.sh](./executeQuery.sh) |  | Utilizes Neo4j's HTTP API to execute a Cypher query from an input file and provides the results in CSV format. |
 | [executeQueryFunctions.sh](./executeQueryFunctions.sh) |  | Provides functions to execute Cypher queries using either "executeQuery.sh" or Neo4j's "cypher-shell".  |
 | [generateCypherReference.sh](./generateCypherReference.sh) |  | Generates "CYPHER.md" containing a reference to all Cypher files in this directory and its subdirectories. |
-| [generateMarkdownReference.sh](./generateMarkdownReference.sh) |  | Generates "REPORTS.md" containing a reference to all Markdown files in this directory and its sub directories. |
+| [generateMarkdownReference.sh](./generateMarkdownReference.sh) |  | Generates "REPORTS.md" containing a reference to all scripts in this directory and its subdirectories. |
 | [generateScriptReference.sh](./generateScriptReference.sh) |  | Generates "SCRIPTS.md" containing a reference to all scripts in this directory and its subdirectories. |
 | [CentralityCsv.sh](./reports/CentralityCsv.sh) | reports | Looks for centrality using the Graph Data Science Library of Neo4j and creates CSV reports. |
 | [CommunityCsv.sh](./reports/CommunityCsv.sh) | reports | Detects communities using the Graph Data Science Library of Neo4j and creates CSV reports. |
+| [ExternalDependenciesCsv.sh](./reports/ExternalDependenciesCsv.sh) | reports | Executes "Package_Usage" Cypher queries to get the "package-dependencies" CSV reports. |
+| [ExternalDependenciesJupyter.sh](./reports/ExternalDependenciesJupyter.sh) | reports | Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb". |
 | [ObjectOrientedDesignMetricsCsv.sh](./reports/ObjectOrientedDesignMetricsCsv.sh) | reports | Executes "Metrics" Cypher queries to get the "object-oriented-design-metrics" CSV reports. |
 | [ObjectOrientedDesignMetricsJupyter.sh](./reports/ObjectOrientedDesignMetricsJupyter.sh) | reports | Creates the "object-oriented-design-metrics" report (ipynb, md, pdf) based on the Jupyter Notebook "ObjectOrientedDesignMetrics.ipynb". |
+| [OverviewCsv.sh](./reports/OverviewCsv.sh) | reports | Executes "Package_Usage" Cypher queries to get the "package-dependencies" CSV reports. |
+| [OverviewJupyter.sh](./reports/OverviewJupyter.sh) | reports | Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb". |
 | [PackageDependenciesCsv.sh](./reports/PackageDependenciesCsv.sh) | reports | Executes "Package_Usage" Cypher queries to get the "package-dependencies" CSV reports. |
 | [PackageDependenciesJupyter.sh](./reports/PackageDependenciesJupyter.sh) | reports | Creates the "package-dependencies" report (ipynb, md, pdf) based on the Jupyter Notebook "PackageDependencies.ipynb". |
 | [SimilarityCsv.sh](./reports/SimilarityCsv.sh) | reports | Looks for similarity using the Graph Data Science Library of Neo4j and creates CSV reports. |
 | [VisibilityMetricsCsv.sh](./reports/VisibilityMetricsCsv.sh) | reports | Executes "Visibility" Cypher queries to get the "visibility-metrics" CSV reports. |
 | [VisibilityMetricsJupyter.sh](./reports/VisibilityMetricsJupyter.sh) | reports | Creates the "visibility-metrics" report (ipynb, md, pdf) based on the Jupyter Notebook "VisibilityMetrics.ipynb". |
+| [WordcloudJupyter.sh](./reports/WordcloudJupyter.sh) | reports | Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb". |
 | [AllReports.sh](./reports/compilations/AllReports.sh) | compilations | Runs all report scripts. |
 | [CsvReports.sh](./reports/compilations/CsvReports.sh) | compilations | Runs all CSV report scripts (no Python and Chromium required). |
 | [JupyterReports.sh](./reports/compilations/JupyterReports.sh) | compilations | Runs all Jupyter Notebook report scripts. |
@@ -35,6 +40,4 @@ Script | Directory | Description
 | [setupNeo4jInitialPassword.sh](./setupNeo4jInitialPassword.sh) |  | Sets the initial password for the local Neo4j Graph Database (https://neo4j.com/download-center/#community). |
 | [startNeo4j.sh](./startNeo4j.sh) |  | Starts the local Neo4j Graph Database.  |
 | [stopNeo4j.sh](./stopNeo4j.sh) |  | Stops the local Neo4j Graph Database.  |
-| [test.sh](./test.sh) |  | This is just a temporary test script with changing contents. |
-| [testAnother.sh](./testAnother.sh) |  | This is just a temporary test script with changing contents. |
 | [waitForNeo4jHttp.sh](./waitForNeo4jHttp.sh) |  | Waits until the HTTP Transactions API of Neo4j Graph Database is available. |

--- a/scripts/copyReportsIntoResults.sh
+++ b/scripts/copyReportsIntoResults.sh
@@ -16,13 +16,26 @@ echo "copyReportsIntoResults: SCRIPTS_DIR=$SCRIPTS_DIR"
 RESULTS_DIRECTORY=${RESULTS_DIRECTORY:-"results"}
 echo "copyReportsIntoResults: RESULTS_DIRECTORY=${RESULTS_DIRECTORY}"
 
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+echo "copyReportsIntoResults: REPORTS_DIRECTORY=${REPORTS_DIRECTORY}"
+
+FULL_RESULTS_DIRECTORY="./../${RESULTS_DIRECTORY}"
+echo "copyReportsIntoResults: FULL_RESULTS_DIRECTORY=${FULL_RESULTS_DIRECTORY}"
+
 # Create the results directory if it is missing
-mkdir -p "./../${RESULTS_DIRECTORY}"
+mkdir -p "${FULL_RESULTS_DIRECTORY}"
 
 # Move all reports directories to the results directory preserving their surrounding directory
-for report_source_folder in **/reports; do 
-    reportTargetDirectory="./../${RESULTS_DIRECTORY}/$(dirname -- "${report_source_folder}")"
-    cp -RpPf "${report_source_folder}" "${reportTargetDirectory}"
+for report_source_folder in **/"${REPORTS_DIRECTORY}"; do 
+    reportMainSourceDirectory=$(dirname -- "${report_source_folder}")
+    echo "copyReportsIntoResults: reportMainSourceDirectory=${reportMainSourceDirectory}"
+
+    reportTargetDirectory="${FULL_RESULTS_DIRECTORY}/${reportMainSourceDirectory}"
+    echo "copyReportsIntoResults: report_source_folder=${report_source_folder}"
+    echo "copyReportsIntoResults: Deleting reportTargetDirectory ${reportTargetDirectory} before copying the files..."
+    
+    rm -rf "${reportTargetDirectory}"
+    cp -Rp "${report_source_folder}" "${reportTargetDirectory}"
 done
 
 # Generate REPORTS.md containing a reference to all Markdown Reports in the "results" directory and its subdirectories.

--- a/scripts/executeJupyterNotebook.sh
+++ b/scripts/executeJupyterNotebook.sh
@@ -89,7 +89,7 @@ backupCondaEnvironment=$CONDA_DEFAULT_ENV
 if [ ! "$backupCondaEnvironment" = "$CODEGRAPH_CONDA_ENVIRONMENT" ] ; then
     backupCondaEnvironment=$CONDA_DEFAULT_ENV
 
-    if { ${pathToConda}conda env list | grep "$CODEGRAPH_CONDA_ENVIRONMENT"; } >/dev/null 2>&1; then
+    if { ${pathToConda}conda env list | grep "$CODEGRAPH_CONDA_ENVIRONMENT "; } >/dev/null 2>&1; then
         echo "executeJupyterNotebook: Conda environment $CODEGRAPH_CONDA_ENVIRONMENT already created"
     else
         if [ ! -f "${jupyter_notebook_file_path}/environment.yml" ] ; then

--- a/scripts/executeQuery.sh
+++ b/scripts/executeQuery.sh
@@ -99,9 +99,9 @@ fi
 
 # Output results in CSV format
 if [ "${no_source_reference}" = true ] ; then
-  echo -n "${cyper_query_result}" | jq -r '(.results[0])? | .columns,(.data[].row)?|flatten | @csv'
+  echo -n "${cyper_query_result}" | jq -r '(.results[0])? | .columns,(.data[].row)? | map(if type == "array" then join(",") else . end) | flatten | @csv'
 else
   cypher_query_file_basename=$(basename -- "${cypher_query_file_name}")
   sourceFileReferenceInfo="Source Cypher File: ${cypher_query_file_basename}"
-  echo -n "${cyper_query_result}" | jq -r --arg sourceReference "${sourceFileReferenceInfo}" '(.results[0])? | .columns + [$sourceReference], (.data[].row)? + [""] | @csv'
+  echo -n "${cyper_query_result}" | jq -r --arg sourceReference "${sourceFileReferenceInfo}" '(.results[0])? | .columns + [$sourceReference], (.data[].row)? + [[""], ""]  | map(if type == "array" then join(",") else . end) | flatten | @csv'
 fi

--- a/scripts/executeQuery.sh
+++ b/scripts/executeQuery.sh
@@ -9,6 +9,10 @@
 # Using "cypher-shell" that comes with Neo4j server is much simpler to use:
 # cat $cypher_query_file_name | $NEO4J_HOME/bin/cypher-shell -u neo4j -p password --format plain
 
+# Note: These command line arguments are supported:
+# -> "filename" of the cypher query file (required, unnamed first argument)
+# -> "--no_source_reference" to not append the cypher query file name as last CSV column
+
 # Overrideable Defaults
 NEO4J_HTTP_PORT=${NEO4J_HTTP_PORT:-"7474"}
 
@@ -18,20 +22,47 @@ if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then
     exit 1
 fi
 
-# Read the first input argument containing the name of the cypher file
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <cypher file>" >&2
-  exit 1
-fi
+# Input Arguments: Initialize arguments and set default values for optional ones
+cypher_query_file_name=""
+no_source_reference=false
 
-# Check the first input argument to be a valid file
-if [ ! -f "$1" ] ; then
-    echo "$1 not found" >&2
-    exit 1
-fi
+# Input Arguments: Function to print usage information
+print_usage() {
+    echo "Usage: $0 <filename> [--no-source-reference-column]"
+    echo "Options:"
+    echo "  --no-source-reference-column: Exclude the source reference column"
+}
 
-cypher_query_file_name=$1
-#echo "Cypher File: $cypher_query_file_name"
+# Input Arguments: Parse the command-line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+        --no-source-reference-column)
+            no_source_reference=true
+            shift
+            ;;
+        *)
+            if [[ -z "$cypher_query_file_name" ]]; then
+                # Input Arguments: Read the first unnamed input argument containing the name of the cypher file
+                cypher_query_file_name="$key"
+                #echo "Cypher File: $cypher_query_file_name"
+                
+                # Input Arguments: Check the first input argument to be a valid file
+                if [ ! -f "${cypher_query_file_name}" ] ; then
+                  echo "Error: Please provide a valid filename."
+                  print_usage
+                  exit 1
+                fi
+            else
+                echo "Error: Unknown option: $key"
+                print_usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
 
 # Read the file that contains the Cypher query
 original_cypher_query=$(<"${cypher_query_file_name}")
@@ -66,5 +97,11 @@ if [[ -n "${error_message}" ]]; then
   echo -e "${redColor}${error_message}${noColor}" >&2
 fi
 
-# Output results iun CSV format
-echo -n "${cyper_query_result}" | jq -r '(.results[0])? | .columns,(.data[].row)?|flatten | @csv'
+# Output results in CSV format
+if [ "${no_source_reference}" = true ] ; then
+  echo -n "${cyper_query_result}" | jq -r '(.results[0])? | .columns,(.data[].row)?|flatten | @csv'
+else
+  cypher_query_file_basename=$(basename -- "${cypher_query_file_name}")
+  sourceFileReferenceInfo="Source Cypher File: ${cypher_query_file_basename}"
+  echo -n "${cyper_query_result}" | jq -r --arg sourceReference "${sourceFileReferenceInfo}" '(.results[0])? | .columns + [$sourceReference], (.data[].row)? + [""] | @csv'
+fi

--- a/scripts/executeQueryFunctions.sh
+++ b/scripts/executeQueryFunctions.sh
@@ -25,10 +25,6 @@ execute_cypher_http() {
 
     # (Neo4j HTTP API Script) Execute the Cyper query contained in the file and print the results as CSV
     source $SCRIPTS_DIR/executeQuery.sh "${cypherFileName}" || exit 1
-
-    # Display the name of the Cypher file without its path at the bottom of the CSV (or console) separated by an empty line
-    echo ""
-    echo "\"Source Cypher Query:\",\"$(basename -- "${cypherFileName}")\""
 }
 
 # Function to execute a cypher query from the given file (first and only argument) with a summarized (console) output using Neo4j's HTTP API
@@ -62,8 +58,9 @@ execute_cypher_shell() {
     cat $cypherFileName | NEO4J_HOME="${NEO4J_DIRECTORY}" ${NEO4J_BIN}/cypher-shell -u neo4j -p "${NEO4J_INITIAL_PASSWORD}" --format plain || exit 1
 
     # Display the name of the Cypher file without its path at the bottom of the CSV (or console) separated by an empty line
+    # TODO Find a solution to move the source reference to the last column name
     echo ""
-    echo "\"Source Cypher Query:\",\"$(basename -- "${cypherFileName}")\""
+    echo "\"Source Cypher File:\",\"$(basename -- "${cypherFileName}")\""
 }
 
 # Function to execute a cypher query from the given file (first and only argument) with a summarized (console) output using "cypher-shell" provided by Neo4j

--- a/scripts/reports/ExternalDependenciesCsv.sh
+++ b/scripts/reports/ExternalDependenciesCsv.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Executes "Package_Usage" Cypher queries to get the "package-dependencies" CSV reports.
+# It contains lists of e.g. incoming and outgoing package dependencies,
+# abstractness, instability and the distance to the so called "main sequence".
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "ExternalDependenciesCsv: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."}
+echo "ExternalDependenciesCsv SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "cypher" directory by taking the path of this script and going two directory up and then to "cypher".
+CYPHER_DIR=${CYPHER_DIR:-"${REPORTS_SCRIPT_DIR}/../../cypher"}
+echo "ExternalDependenciesCsv CYPHER_DIR=${CYPHER_DIR}"
+
+# Define functions to execute cypher queries from within a given file
+source "${SCRIPTS_DIR}/executeQueryFunctions.sh"
+
+# Create report directory
+REPORT_NAME="external-dependencies-csv"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Local Constants
+EXTERNAL_DEPENDENCIES_CYPHER_DIR="${CYPHER_DIR}/External_Dependencies"
+
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_package_usage_overall.cypher" > "${FULL_REPORT_DIRECTORY}/External_package_usage_overall.csv"
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_package_usage_per_type.cypher" > "${FULL_REPORT_DIRECTORY}/External_package_usage_per_type.csv"
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_package_usage_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/External_package_usage_per_artifact.csv"
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_package_usage_per_type_distribution.cypher" > "${FULL_REPORT_DIRECTORY}/External_package_usage_per_type_distribution.csv"
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_package_usage_per_artifact_and_package.cypher" > "${FULL_REPORT_DIRECTORY}/External_package_usage_per_artifact_and_package.csv"
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/Maven_POMs_and_their_declared_dependencies.cypher" > "${FULL_REPORT_DIRECTORY}/Maven_POM_dependencies.csv"

--- a/scripts/reports/ExternalDependenciesJupyter.sh
+++ b/scripts/reports/ExternalDependenciesJupyter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb".
+# It contains a basic overview on how many Classes, Interfaces, Enums and Annotations earch artifact contains,
+# how they relate to each other, distribution of Methods and their effective lines of code
+# and how the cyclomatic complexity is distributed across all Methods per artifact.
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "OverviewJupyter: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."}
+echo "OverviewJupyter: SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "jupyter" directory by taking the path of this script and going two directory up and then to "jupyter".
+JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY:-"${SCRIPTS_DIR}/../jupyter"}
+echo "OverviewJupyter: JUPYTER_NOTEBOOK_DIRECTORY=$JUPYTER_NOTEBOOK_DIRECTORY"
+
+# Create report directory
+REPORT_NAME="external-dependencies"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Execute and convert the following Jupyter Notebook within the given reports directory
+(cd "${FULL_REPORT_DIRECTORY}" && exec ${SCRIPTS_DIR}/executeJupyterNotebook.sh ${JUPYTER_NOTEBOOK_DIRECTORY}/ExternalDependencies.ipynb) || exit 1

--- a/scripts/reports/OverviewCsv.sh
+++ b/scripts/reports/OverviewCsv.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Executes "Package_Usage" Cypher queries to get the "package-dependencies" CSV reports.
+# It contains lists of e.g. incoming and outgoing package dependencies,
+# abstractness, instability and the distance to the so called "main sequence".
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "OverviewCsv: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."}
+echo "OverviewCsv SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "cypher" directory by taking the path of this script and going two directory up and then to "cypher".
+CYPHER_DIR=${CYPHER_DIR:-"${REPORTS_SCRIPT_DIR}/../../cypher"}
+echo "OverviewCsv CYPHER_DIR=${CYPHER_DIR}"
+
+# Define functions to execute cypher queries from within a given file
+source "${SCRIPTS_DIR}/executeQueryFunctions.sh"
+
+# Create report directory
+REPORT_NAME="overview-csv"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Local Constants
+OVERVIEW_CYPHER_DIR="${CYPHER_DIR}/Overview"
+
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Cyclomatic_Method_Complexity_Distribution.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclomatic_Method_Complexity.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_lines_of_method_code_per_package.cypher" > "${FULL_REPORT_DIRECTORY}/Effective_lines_of_method_code_per_package.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_lines_of_method_code_per_type.cypher" > "${FULL_REPORT_DIRECTORY}/Effective_lines_of_method_code_per_type.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_Method_Line_Count_Distribution.cypher" > "${FULL_REPORT_DIRECTORY}/Effective_Method_Line_Count.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_packages_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_packages_per_artifact.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_types_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_types_per_artifact.csv"

--- a/scripts/reports/OverviewJupyter.sh
+++ b/scripts/reports/OverviewJupyter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb".
+# It contains a basic overview on how many Classes, Interfaces, Enums and Annotations earch artifact contains,
+# how they relate to each other, distribution of Methods and their effective lines of code
+# and how the cyclomatic complexity is distributed across all Methods per artifact.
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "OverviewJupyter: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."}
+echo "OverviewJupyter: SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "jupyter" directory by taking the path of this script and going two directory up and then to "jupyter".
+JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY:-"${SCRIPTS_DIR}/../jupyter"}
+echo "OverviewJupyter: JUPYTER_NOTEBOOK_DIRECTORY=$JUPYTER_NOTEBOOK_DIRECTORY"
+
+# Create report directory
+REPORT_NAME="overview"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Execute and convert the following Jupyter Notebook within the given reports directory
+(cd "${FULL_REPORT_DIRECTORY}" && exec ${SCRIPTS_DIR}/executeJupyterNotebook.sh ${JUPYTER_NOTEBOOK_DIRECTORY}/Overview.ipynb) || exit 1

--- a/scripts/reports/WordcloudJupyter.sh
+++ b/scripts/reports/WordcloudJupyter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Creates the "overview" report (ipynb, md, pdf) based on the Jupyter Notebook "Overview.ipynb".
+# It contains a basic overview on how many Classes, Interfaces, Enums and Annotations earch artifact contains,
+# how they relate to each other, distribution of Methods and their effective lines of code
+# and how the cyclomatic complexity is distributed across all Methods per artifact.
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "WordcloudJupyter: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."}
+echo "WordcloudJupyter: SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "jupyter" directory by taking the path of this script and going two directory up and then to "jupyter".
+JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY:-"${SCRIPTS_DIR}/../jupyter"}
+echo "WordcloudJupyter: JUPYTER_NOTEBOOK_DIRECTORY=$JUPYTER_NOTEBOOK_DIRECTORY"
+
+# Create report directory
+REPORT_NAME="wordcloud"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Execute and convert the following Jupyter Notebook within the given reports directory
+(cd "${FULL_REPORT_DIRECTORY}" && exec ${SCRIPTS_DIR}/executeJupyterNotebook.sh ${JUPYTER_NOTEBOOK_DIRECTORY}/Wordcloud.ipynb) || exit 1


### PR DESCRIPTION
### New Reports

- **Overview** of the project size with [Cypher queries](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/8e5d37054c02191b5775b9007012367740046483) and [Jupyter Notebook](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/f36700cd38e5fe4406a8a90026130a5b84efebe6)
- **External dependencies** with [Cypher queries](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/9b9bb20fa4fc8a987058b724b6f8eed2ad9318c0) and [Jupyter Notebook](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/3055be4a6ad41c0ee04b05f3f77c2b67cff7b6a5)
- **[Wordcloud](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/c9dc97af0d4d082fd77411ab5cde9d0d4dbb8514)** with package and classnames

### Features

- [Add cypher file source reference as last CSV column](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/e2eeaceffcd0b50649840579d57a870a864de606) instead of appending it at the end of the CSV file which leads to non standard CSVs that e.g. can't directly be viewed on GitHub
- [Support array columns in CSV reports](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/e31603680621dd44b8364d03467d281add26aa57) to support columns that use the Cypher keyword `COLLECT` to aggregate values in a sub array

### Minor Changes

- [Update documentation](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/a8b9c322db596bec1550de8066f3c0892e5584c5)
- [Use stable conda dependency versions](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/cfd294c710cdd0977000e07f8176aa1de116c973) and pin at least the major and minor version number to improve build reproducibility
- [Update conda package cache on workflow changes](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/10074baaf109ecd8cb6b4f1b5609aaef355c8378) to assure that the cache is also cleared when the workflow definition itself is changed
- [Output more details when copying the results](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/abcdb0f8e4dde3f6f523ac13299dfd4d2c9c50cb)
- [Rename upload archive to a more generic name](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/ce4263013a61c9eddbd73abbdc5a919d9f5e6a98) since the archive contains all analysis reports
- [Assure that conda environment name matches exactly](https://github.com/JohT/code-graph-analysis-pipeline/pull/3/commits/be1e3f5fad4588acb0bb7c2de3f91dd64b4a438d). If the environment `codegraph` doesn't exist, it needs to be created, even if there might be an environment like `codegraph-backup`. 