### PR TITLE
Optimize centrality reports using in-memory mutate

### DIFF
--- a/cypher/Centrality/Centrality_10_Summary.cypher
+++ b/cypher/Centrality/Centrality_10_Summary.cypher
@@ -1,0 +1,17 @@
+// Centrality Summary
+
+MATCH (codeUnit)
+WHERE (codeUnit.incomingDependencies > 0 OR codeUnit.outgoingDependencies > 0)
+  AND $dependencies_projection_node IN LABELS(codeUnit) 
+RETURN coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name)      AS name
+      ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortName
+      ,codeUnit.centralityPageRank                  AS pageRank
+      ,codeUnit.centralityArticleRank               AS articleRank
+      ,codeUnit.centralityBetweenness               AS betweenness
+      ,codeUnit.centralityCostEffectiveLazyForward  AS costEffectiveLazyForward                   
+      ,codeUnit.centralityHarmonic                  AS harmonicCloseness
+      ,codeUnit.centralityCloseness                 AS closeness
+      ,codeUnit.centralityHyperlinkInducedTopicSearchAuthority AS hyperlinkInducedTopicSearchAuthority
+      ,codeUnit.centralityHyperlinkInducedTopicSearchHub       AS hyperlinkInducedTopicSearchHub
+      ,codeUnit.incomingDependencies                AS incomingDependencies
+      ,codeUnit.outgoingDependencies                AS outgoingDependencies

--- a/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
@@ -1,7 +1,7 @@
 // Centrality 2a Page Rank Estimate Memory
 
 CALL gds.pageRank.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    writeProperty: $dependencies_projection_write_property
   ,maxIterations: 50
   ,dampingFactor: 0.85

--- a/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
@@ -6,7 +6,7 @@ CALL gds.pageRank.write.estimate(
   ,maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L1Norm"
 })
  YIELD nodeCount, relationshipCount, bytesMin, bytesMax, heapPercentageMin, heapPercentageMax, treeView

--- a/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_2a_Page_Rank_Estimate.cypher
@@ -1,4 +1,4 @@
-//Centrality 2a Page Rank Estimate Memory
+// Centrality 2a Page Rank Estimate Memory
 
 CALL gds.pageRank.write.estimate(
  $dependencies_projection + '-without-empty', {

--- a/cypher/Centrality/Centrality_2b_Page_Rank_Statistics.cypher
+++ b/cypher/Centrality/Centrality_2b_Page_Rank_Statistics.cypher
@@ -5,7 +5,7 @@ CALL gds.pageRank.stats(
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L1Norm"
 })
  YIELD ranIterations

--- a/cypher/Centrality/Centrality_2b_Page_Rank_Statistics.cypher
+++ b/cypher/Centrality/Centrality_2b_Page_Rank_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 2b Page Rank Statistics
 
 CALL gds.pageRank.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
@@ -1,23 +1,28 @@
-// Centrality 2b Page Rank Statistics
+// Centrality 3c Page Rank Mutate
 
-CALL gds.pageRank.stats(
+CALL gds.pageRank.mutate(
  $dependencies_projection + '-without-empty', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
+  ,scaler: "L2Norm"
   ,relationshipWeightProperty: $dependencies_projection_weight_property
-  ,scaler: "L1Norm"
+  ,mutateProperty: $dependencies_projection_write_property
 })
- YIELD ranIterations
+ YIELD nodePropertiesWritten
       ,didConverge
+      ,ranIterations
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution
-RETURN ranIterations
+RETURN nodePropertiesWritten
       ,didConverge
+      ,ranIterations
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution.min
       ,centralityDistribution.mean
@@ -27,3 +32,4 @@ RETURN ranIterations
       ,centralityDistribution.p90
       ,centralityDistribution.p95
       ,centralityDistribution.p99
+      ,centralityDistribution.p999

--- a/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 3c Page Rank Mutate
 
 CALL gds.pageRank.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_3c_Page_Rank_Mutate.cypher
@@ -6,7 +6,7 @@ CALL gds.pageRank.mutate(
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
   ,scaler: "L2Norm"
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,mutateProperty: $dependencies_projection_write_property
 })
  YIELD nodePropertiesWritten

--- a/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
@@ -1,7 +1,7 @@
 // Centrality 3d Page Rank Stream
 
 CALL gds.pageRank.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
@@ -1,8 +1,8 @@
-//Centrality 4c Article Rank Stream
+// Centrality 3d Page Rank Stream
 
-CALL gds.articleRank.stream(
+CALL gds.pageRank.stream(
  $dependencies_projection + '-without-empty', {
-   maxIterations: 30
+   maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
   ,relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_3d_Page_Rank_Stream.cypher
@@ -5,7 +5,7 @@ CALL gds.pageRank.stream(
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L2Norm"
 })
  YIELD nodeId, score

--- a/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
@@ -5,7 +5,7 @@ CALL gds.pageRank.write(
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L2Norm"
   ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
@@ -1,4 +1,4 @@
-//Centrality 3d Page Rank Write
+// Centrality 3e Page Rank Write
 
 CALL gds.pageRank.write(
  $dependencies_projection + '-without-empty', {

--- a/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_3e_Page_Rank_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 3e Page Rank Write
 
 CALL gds.pageRank.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
@@ -6,7 +6,7 @@ CALL gds.articleRank.write.estimate(
   ,maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L1Norm"
 })
  YIELD nodeCount, relationshipCount, bytesMin, bytesMax, heapPercentageMin, heapPercentageMax, treeView

--- a/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
@@ -1,7 +1,7 @@
 // Centrality 4a Article Rank Estimate Memory
 
 CALL gds.articleRank.write.estimate(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
    writeProperty: $dependencies_projection_write_property
   ,maxIterations: 30
   ,dampingFactor: 0.85

--- a/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
+++ b/cypher/Centrality/Centrality_4a_Article_Rank_Estimate.cypher
@@ -1,4 +1,5 @@
-//Centrality 4a Article Rank Estimate Memory
+// Centrality 4a Article Rank Estimate Memory
+
 CALL gds.articleRank.write.estimate(
   $dependencies_projection + '-without-empty', {
    writeProperty: $dependencies_projection_write_property

--- a/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
+++ b/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
@@ -1,4 +1,5 @@
-//Centrality 4b Article Rank Statistics
+// Centrality 4b Article Rank Statistics
+
 CALL gds.articleRank.stats(
  $dependencies_projection + '-without-empty', {
    maxIterations: 30

--- a/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
+++ b/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 4b Article Rank Statistics
 
 CALL gds.articleRank.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
+++ b/cypher/Centrality/Centrality_4b_Article_Rank_Statistics.cypher
@@ -5,7 +5,7 @@ CALL gds.articleRank.stats(
    maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L1Norm"
 })
  YIELD ranIterations

--- a/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
@@ -6,7 +6,7 @@ CALL gds.articleRank.mutate(
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
   ,scaler: "L2Norm"
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,mutateProperty: $dependencies_projection_write_property
 })
  YIELD nodePropertiesWritten

--- a/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
@@ -1,7 +1,7 @@
 //Centrality 4c Article Rank Mutate
 
 CALL gds.articleRank.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
+++ b/cypher/Centrality/Centrality_4c_Article_Rank_Mutate.cypher
@@ -1,23 +1,28 @@
-// Centrality 2b Page Rank Statistics
+//Centrality 4c Article Rank Mutate
 
-CALL gds.pageRank.stats(
+CALL gds.articleRank.mutate(
  $dependencies_projection + '-without-empty', {
-   maxIterations: 50
+   maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
+  ,scaler: "L2Norm"
   ,relationshipWeightProperty: $dependencies_projection_weight_property
-  ,scaler: "L1Norm"
+  ,mutateProperty: $dependencies_projection_write_property
 })
- YIELD ranIterations
+ YIELD nodePropertiesWritten
       ,didConverge
+      ,ranIterations
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution
-RETURN ranIterations
+RETURN nodePropertiesWritten
       ,didConverge
+      ,ranIterations
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution.min
       ,centralityDistribution.mean
@@ -27,3 +32,4 @@ RETURN ranIterations
       ,centralityDistribution.p90
       ,centralityDistribution.p95
       ,centralityDistribution.p99
+      ,centralityDistribution.p999

--- a/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
@@ -1,7 +1,7 @@
 //Centrality 4d Article Rank Stream
 
 CALL gds.articleRank.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
@@ -1,8 +1,12 @@
-// Centrality 5c Betweeness Stream
+//Centrality 4d Article Rank Stream
 
-CALL gds.betweenness.stream(
+CALL gds.articleRank.stream(
  $dependencies_projection + '-without-empty', {
-   relationshipWeightProperty: $dependencies_projection_weight_property
+   maxIterations: 30
+  ,dampingFactor: 0.85
+  ,tolerance: 0.00000001
+  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,scaler: "L2Norm"
 })
  YIELD nodeId, score
   WITH gds.util.asNode(nodeId) AS member, score

--- a/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
+++ b/cypher/Centrality/Centrality_4d_Article_Rank_Stream.cypher
@@ -5,7 +5,7 @@ CALL gds.articleRank.stream(
    maxIterations: 30
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L2Norm"
 })
  YIELD nodeId, score

--- a/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
@@ -1,7 +1,7 @@
 //Centrality 4e Article Rank Write
 
 CALL gds.articleRank.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001

--- a/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
@@ -5,7 +5,7 @@ CALL gds.articleRank.write(
    maxIterations: 50
   ,dampingFactor: 0.85
   ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,scaler: "L2Norm"
   ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
+++ b/cypher/Centrality/Centrality_4e_Article_Rank_Write.cypher
@@ -1,17 +1,25 @@
-// Centrality 5d Betweeness Write
+//Centrality 4e Article Rank Write
 
-CALL gds.betweenness.write(
+CALL gds.articleRank.write(
  $dependencies_projection + '-without-empty', {
-    relationshipWeightProperty: $dependencies_projection_weight_property
-   ,writeProperty: $dependencies_projection_write_property
+   maxIterations: 50
+  ,dampingFactor: 0.85
+  ,tolerance: 0.00000001
+  ,relationshipWeightProperty: $dependencies_projection_weight_property
+  ,scaler: "L2Norm"
+  ,writeProperty: $dependencies_projection_write_property
 })
 YIELD nodePropertiesWritten
+     ,ranIterations
+     ,didConverge
      ,preProcessingMillis
      ,computeMillis
      ,postProcessingMillis
      ,writeMillis
      ,centralityDistribution
 RETURN nodePropertiesWritten
+      ,ranIterations
+      ,didConverge
       ,preProcessingMillis
       ,computeMillis
       ,postProcessingMillis

--- a/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
+++ b/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
@@ -1,7 +1,7 @@
 // Centrality 5a Betweeness Estimate
 
 CALL gds.betweenness.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
     ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
+++ b/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
@@ -1,4 +1,4 @@
-//Centrality 5a Betweeness Estimate
+// Centrality 5a Betweeness Estimate
 
 CALL gds.betweenness.write.estimate(
  $dependencies_projection + '-without-empty', {

--- a/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
+++ b/cypher/Centrality/Centrality_5a_Betweeness_Estimate.cypher
@@ -2,7 +2,7 @@
 
 CALL gds.betweenness.write.estimate(
  $dependencies_projection + '-without-empty', {
-     relationshipWeightProperty: $dependencies_projection_weight_property
+     relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
     ,writeProperty: $dependencies_projection_write_property
 })
  YIELD nodeCount, relationshipCount, bytesMin, bytesMax, heapPercentageMin, heapPercentageMax, treeView

--- a/cypher/Centrality/Centrality_5b_Betweeness_Statistics.cypher
+++ b/cypher/Centrality/Centrality_5b_Betweeness_Statistics.cypher
@@ -2,7 +2,7 @@
 
  CALL gds.betweenness.stats(
   $dependencies_projection + '-without-empty', {
-     relationshipWeightProperty: $dependencies_projection_weight_property
+     relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
     })
  YIELD preProcessingMillis
       ,computeMillis

--- a/cypher/Centrality/Centrality_5b_Betweeness_Statistics.cypher
+++ b/cypher/Centrality/Centrality_5b_Betweeness_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 5b Betweeness Statistics
 
  CALL gds.betweenness.stats(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
     })
  YIELD preProcessingMillis

--- a/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
@@ -2,7 +2,7 @@
 
 CALL gds.betweenness.mutate(
  $dependencies_projection + '-without-empty', {
-   relationshipWeightProperty: $dependencies_projection_weight_property
+   relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,mutateProperty: $dependencies_projection_write_property
 })
  YIELD nodePropertiesWritten

--- a/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 5c Betweeness Mutate
 
 CALL gds.betweenness.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
   ,mutateProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_5c_Betweeness_Mutate.cypher
@@ -1,23 +1,20 @@
-// Centrality 2b Page Rank Statistics
+// Centrality 5c Betweeness Mutate
 
-CALL gds.pageRank.stats(
+CALL gds.betweenness.mutate(
  $dependencies_projection + '-without-empty', {
-   maxIterations: 50
-  ,dampingFactor: 0.85
-  ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
-  ,scaler: "L1Norm"
+   relationshipWeightProperty: $dependencies_projection_weight_property
+  ,mutateProperty: $dependencies_projection_write_property
 })
- YIELD ranIterations
-      ,didConverge
+ YIELD nodePropertiesWritten
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution
-RETURN ranIterations
-      ,didConverge
+RETURN nodePropertiesWritten
       ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution.min
       ,centralityDistribution.mean
@@ -27,3 +24,4 @@ RETURN ranIterations
       ,centralityDistribution.p90
       ,centralityDistribution.p95
       ,centralityDistribution.p99
+      ,centralityDistribution.p999

--- a/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
@@ -2,7 +2,7 @@
 
 CALL gds.betweenness.stream(
  $dependencies_projection + '-without-empty', {
-   relationshipWeightProperty: $dependencies_projection_weight_property
+   relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
 })
  YIELD nodeId, score
   WITH gds.util.asNode(nodeId) AS member, score

--- a/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
@@ -1,7 +1,7 @@
 // Centrality 5d Betweeness Stream
 
 CALL gds.betweenness.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
 })
  YIELD nodeId, score

--- a/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_5d_Betweeness_Stream.cypher
@@ -1,12 +1,8 @@
-//Centrality 3c Page Rank Stream
+// Centrality 5d Betweeness Stream
 
-CALL gds.pageRank.stream(
+CALL gds.betweenness.stream(
  $dependencies_projection + '-without-empty', {
-   maxIterations: 50
-  ,dampingFactor: 0.85
-  ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
-  ,scaler: "L2Norm"
+   relationshipWeightProperty: $dependencies_projection_weight_property
 })
  YIELD nodeId, score
   WITH gds.util.asNode(nodeId) AS member, score

--- a/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
+++ b/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
@@ -2,7 +2,7 @@
 
 CALL gds.betweenness.write(
  $dependencies_projection + '-without-empty', {
-    relationshipWeightProperty: $dependencies_projection_weight_property
+    relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
    ,writeProperty: $dependencies_projection_write_property
 })
 YIELD nodePropertiesWritten

--- a/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
+++ b/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
@@ -1,25 +1,17 @@
-//Centrality 4d Article Rank Write
+// Centrality 5e Betweeness Write
 
-CALL gds.articleRank.write(
+CALL gds.betweenness.write(
  $dependencies_projection + '-without-empty', {
-   maxIterations: 50
-  ,dampingFactor: 0.85
-  ,tolerance: 0.00000001
-  ,relationshipWeightProperty: $dependencies_projection_weight_property
-  ,scaler: "L2Norm"
-  ,writeProperty: $dependencies_projection_write_property
+    relationshipWeightProperty: $dependencies_projection_weight_property
+   ,writeProperty: $dependencies_projection_write_property
 })
 YIELD nodePropertiesWritten
-     ,ranIterations
-     ,didConverge
      ,preProcessingMillis
      ,computeMillis
      ,postProcessingMillis
      ,writeMillis
      ,centralityDistribution
 RETURN nodePropertiesWritten
-      ,ranIterations
-      ,didConverge
       ,preProcessingMillis
       ,computeMillis
       ,postProcessingMillis

--- a/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
+++ b/cypher/Centrality/Centrality_5e_Betweeness_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 5e Betweeness Write
 
 CALL gds.betweenness.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     relationshipWeightProperty: CASE $dependencies_projection_weight_property WHEN '' THEN null ELSE $dependencies_projection_weight_property END
    ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_6a_Cost_effective_Lazy_Forward_CELF_Estimate.cypher
+++ b/cypher/Centrality/Centrality_6a_Cost_effective_Lazy_Forward_CELF_Estimate.cypher
@@ -1,7 +1,7 @@
 // Centrality 6a Cost-effective Lazy Forward (CELF) Estimate
 
   CALL gds.influenceMaximization.celf.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      seedSetSize: 5
     ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_6a_Cost_effective_Lazy_Forward_CELF_Estimate.cypher
+++ b/cypher/Centrality/Centrality_6a_Cost_effective_Lazy_Forward_CELF_Estimate.cypher
@@ -1,6 +1,6 @@
-// Centrality 6c Cost-effective Lazy Forward (CELF) Estimate
+// Centrality 6a Cost-effective Lazy Forward (CELF) Estimate
 
-  CALL gds.beta.influenceMaximization.celf.write.estimate(
+  CALL gds.influenceMaximization.celf.write.estimate(
  $dependencies_projection + '-without-empty', {
      seedSetSize: 5
     ,writeProperty: $dependencies_projection_write_property

--- a/cypher/Centrality/Centrality_6b_Cost_effective_Lazy_Forward_CELF_Statistics.cypher
+++ b/cypher/Centrality/Centrality_6b_Cost_effective_Lazy_Forward_CELF_Statistics.cypher
@@ -1,6 +1,6 @@
-// Centrality 6b Cost-effective Lazy Forward (CELF) Estimate
+// Centrality 6b Cost-effective Lazy Forward (CELF) Statistics
 
-CALL gds.beta.influenceMaximization.celf.stats(
+CALL gds.influenceMaximization.celf.stats(
   $dependencies_projection + '-without-empty', {
     seedSetSize: 5
   })

--- a/cypher/Centrality/Centrality_6b_Cost_effective_Lazy_Forward_CELF_Statistics.cypher
+++ b/cypher/Centrality/Centrality_6b_Cost_effective_Lazy_Forward_CELF_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 6b Cost-effective Lazy Forward (CELF) Statistics
 
 CALL gds.influenceMaximization.celf.stats(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
     seedSetSize: 5
   })
  YIELD computeMillis

--- a/cypher/Centrality/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Mutate.cypher
+++ b/cypher/Centrality/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Mutate.cypher
@@ -1,0 +1,17 @@
+// Centrality 6c Cost-effective Lazy Forward (CELF) Mutate
+
+  CALL gds.influenceMaximization.celf.mutate(
+   $dependencies_projection + '-without-empty', {
+      seedSetSize: 5
+     ,mutateProperty: $dependencies_projection_write_property
+ })
+ YIELD nodePropertiesWritten
+      ,nodeCount
+      ,totalSpread
+      ,computeMillis
+      ,mutateMillis
+RETURN nodePropertiesWritten
+      ,nodeCount
+      ,totalSpread
+      ,computeMillis
+      ,mutateMillis

--- a/cypher/Centrality/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Mutate.cypher
+++ b/cypher/Centrality/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 6c Cost-effective Lazy Forward (CELF) Mutate
 
   CALL gds.influenceMaximization.celf.mutate(
-   $dependencies_projection + '-without-empty', {
+   $dependencies_projection + '-cleaned', {
       seedSetSize: 5
      ,mutateProperty: $dependencies_projection_write_property
  })

--- a/cypher/Centrality/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Stream.cypher
+++ b/cypher/Centrality/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Stream.cypher
@@ -1,6 +1,6 @@
-// Centrality 6c Cost-effective Lazy Forward (CELF) Stream
+// Centrality 6d Cost-effective Lazy Forward (CELF) Stream
 
-  CALL gds.beta.influenceMaximization.celf.stream(
+  CALL gds.influenceMaximization.celf.stream(
    $dependencies_projection + '-without-empty', {
       seedSetSize: 5
  })

--- a/cypher/Centrality/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Stream.cypher
+++ b/cypher/Centrality/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Stream.cypher
@@ -1,7 +1,7 @@
 // Centrality 6d Cost-effective Lazy Forward (CELF) Stream
 
   CALL gds.influenceMaximization.celf.stream(
-   $dependencies_projection + '-without-empty', {
+   $dependencies_projection + '-cleaned', {
       seedSetSize: 5
  })
  YIELD nodeId, spread

--- a/cypher/Centrality/Centrality_6e_Cost_effective_Lazy_Forward_CELF_Write.cypher
+++ b/cypher/Centrality/Centrality_6e_Cost_effective_Lazy_Forward_CELF_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 6e Cost-effective Lazy Forward (CELF) Write
 
   CALL gds.influenceMaximization.celf.write(
-    $dependencies_projection + '-without-empty', {
+    $dependencies_projection + '-cleaned', {
       seedSetSize: 5
      ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_6e_Cost_effective_Lazy_Forward_CELF_Write.cypher
+++ b/cypher/Centrality/Centrality_6e_Cost_effective_Lazy_Forward_CELF_Write.cypher
@@ -1,6 +1,6 @@
-// Centrality 6d Cost-effective Lazy Forward (CELF) Write
+// Centrality 6e Cost-effective Lazy Forward (CELF) Write
 
-  CALL gds.beta.influenceMaximization.celf.write(
+  CALL gds.influenceMaximization.celf.write(
     $dependencies_projection + '-without-empty', {
       seedSetSize: 5
      ,writeProperty: $dependencies_projection_write_property

--- a/cypher/Centrality/Centrality_7b_Harmonic_Closeness_Statistics.cypher
+++ b/cypher/Centrality/Centrality_7b_Harmonic_Closeness_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 7b Harmonic Closeness Statistics
 
 CALL gds.closeness.harmonic.stats(
- $dependencies_projection + '-without-empty', {})
+ $dependencies_projection + '-cleaned', {})
  YIELD preProcessingMillis
       ,computeMillis
       ,postProcessingMillis

--- a/cypher/Centrality/Centrality_7c_Harmonic_Closeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_7c_Harmonic_Closeness_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 7c Harmonic Closeness Mutate
 
 CALL gds.closeness.harmonic.mutate(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
     mutateProperty: $dependencies_projection_write_property
 })
  YIELD nodePropertiesWritten

--- a/cypher/Centrality/Centrality_7c_Harmonic_Closeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_7c_Harmonic_Closeness_Mutate.cypher
@@ -1,15 +1,19 @@
-// Centrality 5b Betweeness Statistics
+// Centrality 7c Harmonic Closeness Mutate
 
- CALL gds.betweenness.stats(
+CALL gds.closeness.harmonic.mutate(
   $dependencies_projection + '-without-empty', {
-     relationshipWeightProperty: $dependencies_projection_weight_property
-    })
- YIELD preProcessingMillis
+    mutateProperty: $dependencies_projection_write_property
+})
+ YIELD nodePropertiesWritten
+      ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution
-RETURN preProcessingMillis
+RETURN nodePropertiesWritten
+      ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution.min
       ,centralityDistribution.mean
@@ -19,3 +23,4 @@ RETURN preProcessingMillis
       ,centralityDistribution.p90
       ,centralityDistribution.p95
       ,centralityDistribution.p99
+      ,centralityDistribution.p999

--- a/cypher/Centrality/Centrality_7d_Harmonic_Closeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_7d_Harmonic_Closeness_Stream.cypher
@@ -1,6 +1,6 @@
 // Centrality 7a Harmonic Closeness Stream
 
-CALL gds.closeness.harmonic.stream($dependencies_projection + '-without-empty', {})
+CALL gds.closeness.harmonic.stream($dependencies_projection + '-cleaned', {})
  YIELD nodeId, centrality
   WITH gds.util.asNode(nodeId) AS member, centrality
 RETURN coalesce(member.fqn, member.fileName, member.name) AS memberName

--- a/cypher/Centrality/Centrality_7d_Harmonic_Closeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_7d_Harmonic_Closeness_Stream.cypher
@@ -1,6 +1,6 @@
 // Centrality 7a Harmonic Closeness Stream
 
-CALL gds.alpha.closeness.harmonic.stream($dependencies_projection + '-without-empty', {})
+CALL gds.closeness.harmonic.stream($dependencies_projection + '-without-empty', {})
  YIELD nodeId, centrality
   WITH gds.util.asNode(nodeId) AS member, centrality
 RETURN coalesce(member.fqn, member.fileName, member.name) AS memberName

--- a/cypher/Centrality/Centrality_7e_Harmonic_Closeness_Write.cypher
+++ b/cypher/Centrality/Centrality_7e_Harmonic_Closeness_Write.cypher
@@ -1,6 +1,6 @@
 // Centrality 7d Harmonic Closeness Write
 
-CALL gds.alpha.closeness.harmonic.write(
+CALL gds.closeness.harmonic.write(
     $dependencies_projection + '-without-empty', {
     ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_7e_Harmonic_Closeness_Write.cypher
+++ b/cypher/Centrality/Centrality_7e_Harmonic_Closeness_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 7d Harmonic Closeness Write
 
 CALL gds.closeness.harmonic.write(
-    $dependencies_projection + '-without-empty', {
+    $dependencies_projection + '-cleaned', {
     ,writeProperty: $dependencies_projection_write_property
 })
 YIELD nodes

--- a/cypher/Centrality/Centrality_8b_Closeness_Statistics.cypher
+++ b/cypher/Centrality/Centrality_8b_Closeness_Statistics.cypher
@@ -1,7 +1,7 @@
 //Centrality 8b Closeness Statistics
 
 CALL gds.closeness.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
    useWassermanFaust: true
 })
 YIELD preProcessingMillis

--- a/cypher/Centrality/Centrality_8b_Closeness_Statistics.cypher
+++ b/cypher/Centrality/Centrality_8b_Closeness_Statistics.cypher
@@ -1,6 +1,6 @@
 //Centrality 8b Closeness Statistics
 
-CALL gds.beta.closeness.stats(
+CALL gds.closeness.stats(
  $dependencies_projection + '-without-empty', {
    useWassermanFaust: true
 })

--- a/cypher/Centrality/Centrality_8c_Closeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_8c_Closeness_Mutate.cypher
@@ -1,15 +1,20 @@
-// Centrality 5b Betweeness Statistics
+// Centrality 8c Closeness Mutate
 
- CALL gds.betweenness.stats(
+CALL gds.closeness.mutate(
   $dependencies_projection + '-without-empty', {
-     relationshipWeightProperty: $dependencies_projection_weight_property
-    })
- YIELD preProcessingMillis
+   useWassermanFaust: true
+  ,mutateProperty: $dependencies_projection_write_property
+})
+ YIELD nodePropertiesWritten
+      ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution
-RETURN preProcessingMillis
+RETURN nodePropertiesWritten
+      ,preProcessingMillis
       ,computeMillis
+      ,mutateMillis
       ,postProcessingMillis
       ,centralityDistribution.min
       ,centralityDistribution.mean
@@ -19,3 +24,4 @@ RETURN preProcessingMillis
       ,centralityDistribution.p90
       ,centralityDistribution.p95
       ,centralityDistribution.p99
+      ,centralityDistribution.p999

--- a/cypher/Centrality/Centrality_8c_Closeness_Mutate.cypher
+++ b/cypher/Centrality/Centrality_8c_Closeness_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 8c Closeness Mutate
 
 CALL gds.closeness.mutate(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
    useWassermanFaust: true
   ,mutateProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_8d_Closeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_8d_Closeness_Stream.cypher
@@ -1,7 +1,7 @@
 // Centrality 8c Closeness Stream
 
 CALL gds.closeness.stream(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
    useWassermanFaust: true
 })
  YIELD nodeId, score

--- a/cypher/Centrality/Centrality_8d_Closeness_Stream.cypher
+++ b/cypher/Centrality/Centrality_8d_Closeness_Stream.cypher
@@ -1,6 +1,6 @@
 // Centrality 8c Closeness Stream
 
-CALL gds.beta.closeness.stream(
+CALL gds.closeness.stream(
   $dependencies_projection + '-without-empty', {
    useWassermanFaust: true
 })

--- a/cypher/Centrality/Centrality_8e_Closeness_Write.cypher
+++ b/cypher/Centrality/Centrality_8e_Closeness_Write.cypher
@@ -1,6 +1,6 @@
 // Centrality 8d Closeness Write
 
-CALL gds.beta.closeness.write(
+CALL gds.closeness.write(
  $dependencies_projection + '-without-empty', {
     useWassermanFaust: true
    ,writeProperty: $dependencies_projection_write_property

--- a/cypher/Centrality/Centrality_8e_Closeness_Write.cypher
+++ b/cypher/Centrality/Centrality_8e_Closeness_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 8d Closeness Write
 
 CALL gds.closeness.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     useWassermanFaust: true
    ,writeProperty: $dependencies_projection_write_property
 })

--- a/cypher/Centrality/Centrality_9a_Hyperlink_Induced_Topic_Search_HITS_Estimate.cypher
+++ b/cypher/Centrality/Centrality_9a_Hyperlink_Induced_Topic_Search_HITS_Estimate.cypher
@@ -3,8 +3,8 @@
   CALL gds.alpha.hits.write.estimate(
  $dependencies_projection + '-without-empty', {
      hitsIterations: 20
-    ,authProperty: $dependencies_projection_write_property
-    ,hubProperty: 'centralityHyperlinkInducedTopicSearchHub'
+    ,authProperty: $dependencies_projection_write_property + 'Authority'
+    ,hubProperty: $dependencies_projection_write_property + 'Hub'
 })
  YIELD nodeCount, relationshipCount, bytesMin, bytesMax, heapPercentageMin, heapPercentageMax, treeView
 RETURN nodeCount, relationshipCount, bytesMin, bytesMax, heapPercentageMin, heapPercentageMax, treeView

--- a/cypher/Centrality/Centrality_9a_Hyperlink_Induced_Topic_Search_HITS_Estimate.cypher
+++ b/cypher/Centrality/Centrality_9a_Hyperlink_Induced_Topic_Search_HITS_Estimate.cypher
@@ -1,7 +1,7 @@
 // Centrality 9a Hyperlink-Induced Topic Search (HITS) Memory Estimation
 
   CALL gds.alpha.hits.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      hitsIterations: 20
     ,authProperty: $dependencies_projection_write_property + 'Authority'
     ,hubProperty: $dependencies_projection_write_property + 'Hub'

--- a/cypher/Centrality/Centrality_9b_Hyperlink_Induced_Topic_Search_HITS_Statistics.cypher
+++ b/cypher/Centrality/Centrality_9b_Hyperlink_Induced_Topic_Search_HITS_Statistics.cypher
@@ -1,7 +1,7 @@
 // Centrality 9b Hyperlink-Induced Topic Search (HITS) Statistics
 
   CALL gds.alpha.hits.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     hitsIterations: 20
 })
  YIELD ranIterations, didConverge, preProcessingMillis, computeMillis

--- a/cypher/Centrality/Centrality_9b_Hyperlink_Induced_Topic_Search_HITS_Statistics.cypher
+++ b/cypher/Centrality/Centrality_9b_Hyperlink_Induced_Topic_Search_HITS_Statistics.cypher
@@ -1,4 +1,4 @@
-// Centrality 9b Hyperlink-Induced Topic Search (HITS) Memory Statistics
+// Centrality 9b Hyperlink-Induced Topic Search (HITS) Statistics
 
   CALL gds.alpha.hits.stats(
  $dependencies_projection + '-without-empty', {

--- a/cypher/Centrality/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Mutate.cypher
+++ b/cypher/Centrality/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Mutate.cypher
@@ -1,7 +1,7 @@
 // Centrality 9c Hyperlink-Induced Topic Search (HITS) Mutate
 
   CALL gds.alpha.hits.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      hitsIterations: 20
     ,authProperty: $dependencies_projection_write_property + 'Authority'
     ,hubProperty: $dependencies_projection_write_property + 'Hub'

--- a/cypher/Centrality/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Mutate.cypher
+++ b/cypher/Centrality/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Mutate.cypher
@@ -1,0 +1,20 @@
+// Centrality 9c Hyperlink-Induced Topic Search (HITS) Mutate
+
+  CALL gds.alpha.hits.mutate(
+ $dependencies_projection + '-without-empty', {
+     hitsIterations: 20
+    ,authProperty: $dependencies_projection_write_property + 'Authority'
+    ,hubProperty: $dependencies_projection_write_property + 'Hub'
+})
+ YIELD nodePropertiesWritten
+      ,didConverge
+      ,ranIterations
+      ,preProcessingMillis
+      ,computeMillis
+      ,mutateMillis
+RETURN nodePropertiesWritten
+      ,didConverge
+      ,ranIterations
+      ,preProcessingMillis
+      ,computeMillis
+      ,mutateMillis

--- a/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher
+++ b/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher
@@ -1,4 +1,4 @@
-// Centrality 9c Hyperlink-Induced Topic Search (HITS) Memory Stream
+// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream
 
   CALL gds.alpha.hits.stream(
  $dependencies_projection + '-without-empty', {

--- a/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher
+++ b/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher
@@ -1,7 +1,7 @@
 // Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream
 
   CALL gds.alpha.hits.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     hitsIterations: 20
 })
  YIELD nodeId, values

--- a/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
+++ b/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
@@ -1,0 +1,19 @@
+// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream Mutated
+
+CALL gds.graph.nodeProperties.stream(
+     $dependencies_projection + '-cleaned'
+    ,[
+         $dependencies_projection_write_property + 'Authority'  
+        ,$dependencies_projection_write_property + 'Hub'
+     ]
+)
+YIELD nodeId, propertyValue
+ WITH gds.util.asNode(nodeId) AS codeUnit
+     ,collect(propertyValue)  AS values
+RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
+     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))      AS shortCodeUnitName
+     ,values[0] AS centralityHyperlinkInducedTopicSearchAuthority
+     ,values[1] AS centralityHyperlinkInducedTopicSearchHub
+     ,codeUnit.incomingDependencies AS incomingDependencies
+     ,codeUnit.outgoingDependencies AS outgoingDependencies
+ORDER BY centralityHyperlinkInducedTopicSearchAuthority DESCENDING, codeUnitName ASCENDING

--- a/cypher/Centrality/Centrality_9e_Hyperlink_Induced_Topic_Search_HITS_Write.cypher
+++ b/cypher/Centrality/Centrality_9e_Hyperlink_Induced_Topic_Search_HITS_Write.cypher
@@ -1,10 +1,10 @@
-// Centrality 9d Hyperlink-Induced Topic Search (HITS) Memory Write
+// Centrality 9e Hyperlink-Induced Topic Search (HITS) Write
 
   CALL gds.alpha.hits.write(
  $dependencies_projection + '-without-empty', {
      hitsIterations: 20
-    ,authProperty: $dependencies_projection_write_property
-    ,hubProperty: 'centralityHyperlinkInducedTopicSearchHub'
+    ,authProperty: $dependencies_projection_write_property + 'Authority'
+    ,hubProperty: $dependencies_projection_write_property + 'Hub'
 })
 YIELD nodePropertiesWritten, ranIterations, didConverge, preProcessingMillis, computeMillis, writeMillis
 RETURN nodePropertiesWritten, ranIterations, didConverge, preProcessingMillis, computeMillis, writeMillis

--- a/cypher/Centrality/Centrality_9e_Hyperlink_Induced_Topic_Search_HITS_Write.cypher
+++ b/cypher/Centrality/Centrality_9e_Hyperlink_Induced_Topic_Search_HITS_Write.cypher
@@ -1,7 +1,7 @@
 // Centrality 9e Hyperlink-Induced Topic Search (HITS) Write
 
   CALL gds.alpha.hits.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      hitsIterations: 20
     ,authProperty: $dependencies_projection_write_property + 'Authority'
     ,hubProperty: $dependencies_projection_write_property + 'Hub'

--- a/cypher/Community_Detection/Community_Detection_1a_Louvain_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_1a_Louvain_Estimate.cypher
@@ -1,7 +1,7 @@
 //Community Detection Louvain Estimate Memory
 
 CALL gds.louvain.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   tolerance: 0.00001,
   relationshipWeightProperty: $dependencies_projection_weight_property,
   writeProperty: $dependencies_projection_write_property,

--- a/cypher/Community_Detection/Community_Detection_1b_Louvain_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_1b_Louvain_Statistics.cypher
@@ -1,7 +1,7 @@
 //Community Detection Louvain Statistics
 
 CALL gds.louvain.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   tolerance: 0.00001,
   relationshipWeightProperty: $dependencies_projection_weight_property,
   includeIntermediateCommunities: true

--- a/cypher/Community_Detection/Community_Detection_1c_Louvain_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_1c_Louvain_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Louvain Mutate
 
 CALL gds.louvain.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     tolerance: 0.00001,
     consecutiveIds: NOT toBoolean($dependencies_include_intermediate_communities),
     includeIntermediateCommunities: toBoolean($dependencies_include_intermediate_communities),

--- a/cypher/Community_Detection/Community_Detection_1d_Louvain_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_1d_Louvain_Stream.cypher
@@ -1,7 +1,7 @@
 //Community Detection Louvain Stream
 
 CALL gds.louvain.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     tolerance: 0.00001,
     includeIntermediateCommunities: true,
     relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Community_Detection/Community_Detection_1d_Stream_Intermediate_Mutated.cypher
+++ b/cypher/Community_Detection/Community_Detection_1d_Stream_Intermediate_Mutated.cypher
@@ -1,7 +1,7 @@
 // Community Detection Stream Intermediate Mutated for hierarchical algorithmns (Louvain, Leiden)
 
 CALL gds.graph.nodeProperty.stream(
-     $dependencies_projection + '-without-empty'
+     $dependencies_projection + '-cleaned'
     ,$dependencies_projection_write_property
 )
  YIELD nodeId, propertyValue

--- a/cypher/Community_Detection/Community_Detection_1e_Louvain_Write_intermediateLouvainCommunityId.cypher
+++ b/cypher/Community_Detection/Community_Detection_1e_Louvain_Write_intermediateLouvainCommunityId.cypher
@@ -1,7 +1,7 @@
 //Community Detection Louvain Write communityLouvainIntermediateIds
 
 CALL gds.louvain.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     tolerance: 0.00001,
     includeIntermediateCommunities: true,
     relationshipWeightProperty: $dependencies_projection_weight_property,

--- a/cypher/Community_Detection/Community_Detection_1e_Louvain_Write_louvainCommunityId.cypher
+++ b/cypher/Community_Detection/Community_Detection_1e_Louvain_Write_louvainCommunityId.cypher
@@ -1,7 +1,7 @@
 //Community Detection Louvain write node property communityLouvainId
 
 CALL gds.louvain.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     tolerance: 0.00001,
     consecutiveIds: true,
     relationshipWeightProperty: $dependencies_projection_weight_property,

--- a/cypher/Community_Detection/Community_Detection_2a_Leiden_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_2a_Leiden_Estimate.cypher
@@ -1,7 +1,7 @@
 //Community Detection Leiden Estimate Memory
 
 CALL gds.beta.leiden.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   gamma: toFloat($dependencies_leiden_gamma),
   theta: 0.001,
   tolerance: 0.0000001,

--- a/cypher/Community_Detection/Community_Detection_2b_Leiden_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_2b_Leiden_Statistics.cypher
@@ -1,7 +1,7 @@
 //Community Detection Leiden Statistics
 
 CALL gds.beta.leiden.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   gamma: toFloat($dependencies_leiden_gamma),
   theta: 0.001,
   tolerance: 0.0000001,

--- a/cypher/Community_Detection/Community_Detection_2c_Leiden_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_2c_Leiden_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Leiden Mutate
 
 CALL gds.leiden.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     tolerance: 0.00001,
     consecutiveIds: NOT toBoolean($dependencies_include_intermediate_communities),
     includeIntermediateCommunities: toBoolean($dependencies_include_intermediate_communities),

--- a/cypher/Community_Detection/Community_Detection_2d_Leiden_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_2d_Leiden_Stream.cypher
@@ -1,7 +1,7 @@
 //Community Detection Leiden Stream
 
 CALL gds.beta.leiden.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   gamma: toFloat($dependencies_leiden_gamma),
   theta: 0.001,
   tolerance: 0.0000001,

--- a/cypher/Community_Detection/Community_Detection_2d_Leiden_Write_Node_Property.cypher
+++ b/cypher/Community_Detection/Community_Detection_2d_Leiden_Write_Node_Property.cypher
@@ -1,7 +1,7 @@
 //Community Detection Leiden Write property communityLeidenId
 
 CALL gds.beta.leiden.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
   gamma: toFloat($dependencies_leiden_gamma),
   theta: 0.001,
   tolerance: 0.0000001,

--- a/cypher/Community_Detection/Community_Detection_3a_WeaklyConnectedComponents_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_3a_WeaklyConnectedComponents_Estimate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Estimate
 
 CALL gds.labelPropagation.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property
      ,writeProperty: $dependencies_projection_write_property
      ,consecutiveIds: true

--- a/cypher/Community_Detection/Community_Detection_3b_WeaklyConnectedComponents_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_3b_WeaklyConnectedComponents_Statistics.cypher
@@ -1,7 +1,7 @@
 // Community Detection Weakly Connected Components Statistics
 
 CALL gds.wcc.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property
      ,consecutiveIds: true
 })

--- a/cypher/Community_Detection/Community_Detection_3c_WeaklyConnectedComponents_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_3c_WeaklyConnectedComponents_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Weakly Connected Components Mutate
 
 CALL gds.wcc.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property
      ,mutateProperty: $dependencies_projection_write_property
      ,consecutiveIds: true

--- a/cypher/Community_Detection/Community_Detection_3d_WeaklyConnectedComponents_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_3d_WeaklyConnectedComponents_Stream.cypher
@@ -1,7 +1,7 @@
 // Community Detection Weakly Connected Components Stream
 
 CALL gds.wcc.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property,
       consecutiveIds: true
 })

--- a/cypher/Community_Detection/Community_Detection_3e_WeaklyConnectedComponents_Write.cypher
+++ b/cypher/Community_Detection/Community_Detection_3e_WeaklyConnectedComponents_Write.cypher
@@ -1,7 +1,7 @@
 // Community Detection Weakly Connected Components write node property communityWeaklyConnectedComponentId
 
 CALL gds.wcc.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
        relationshipWeightProperty: $dependencies_projection_weight_property
       ,consecutiveIds: true
       ,writeProperty: 'communityWeaklyConnectedComponentId'

--- a/cypher/Community_Detection/Community_Detection_4a_Label_Propagation_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_4a_Label_Propagation_Estimate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Estimate
 
 CALL gds.labelPropagation.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,writeProperty: $dependencies_projection_write_property
     ,consecutiveIds: true

--- a/cypher/Community_Detection/Community_Detection_4b_Label_Propagation_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_4b_Label_Propagation_Statistics.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Statistics
 
 CALL gds.labelPropagation.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,consecutiveIds: true
 })

--- a/cypher/Community_Detection/Community_Detection_4c_Label_Propagation_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_4c_Label_Propagation_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Mutate
 
 CALL gds.labelPropagation.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,mutateProperty: $dependencies_projection_write_property
     ,consecutiveIds: true

--- a/cypher/Community_Detection/Community_Detection_4d_Label_Propagation_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_4d_Label_Propagation_Stream.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Stream
 
 CALL gds.labelPropagation.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,consecutiveIds: true
 })

--- a/cypher/Community_Detection/Community_Detection_4e_Label_Propagation_Write.cypher
+++ b/cypher/Community_Detection/Community_Detection_4e_Label_Propagation_Write.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation write node property communityLabelPropagationId
 
 CALL gds.labelPropagation.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,consecutiveIds: true
     ,writeProperty: 'communityLabelPropagationId'

--- a/cypher/Community_Detection/Community_Detection_5a_K_Core_Decomposition_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_5a_K_Core_Decomposition_Estimate.cypher
@@ -1,7 +1,7 @@
 // Community Detection K-Core Decomposition Estimate
 
 CALL gds.kcore.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     writeProperty: $dependencies_projection_write_property
 })
  YIELD requiredMemory

--- a/cypher/Community_Detection/Community_Detection_5b_K_Core_Decomposition_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_5b_K_Core_Decomposition_Statistics.cypher
@@ -1,7 +1,7 @@
 // Community Detection K-Core Decomposition Statistics
 
 CALL gds.kcore.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
 })
  YIELD degeneracy, preProcessingMillis, computeMillis, postProcessingMillis
 RETURN degeneracy, preProcessingMillis, computeMillis, postProcessingMillis

--- a/cypher/Community_Detection/Community_Detection_5c_K_Core_Decomposition_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_5c_K_Core_Decomposition_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection K-Core Decomposition Mutate
 
 CALL gds.kcore.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     mutateProperty: $dependencies_projection_write_property
 })
  YIELD degeneracy, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, mutateMillis

--- a/cypher/Community_Detection/Community_Detection_5d_K_Core_Decomposition_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_5d_K_Core_Decomposition_Stream.cypher
@@ -1,7 +1,7 @@
 // Community Detection K-Core Decomposition Stream
 
 CALL gds.kcore.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
 })
  YIELD nodeId, coreValue
   WITH gds.util.asNode(nodeId) AS member

--- a/cypher/Community_Detection/Community_Detection_5e_K_Core_Decomposition_Write.cypher
+++ b/cypher/Community_Detection/Community_Detection_5e_K_Core_Decomposition_Write.cypher
@@ -1,7 +1,7 @@
 // Community Detection K-Core Decomposition write node property communitykCoreDecompositionValue
 
 CALL gds.kcore.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     writeProperty: $dependencies_projection_write_property
 })
 YIELD degeneracy

--- a/cypher/Community_Detection/Community_Detection_6a_Approximate_Maximum_k_cut_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_6a_Approximate_Maximum_k_cut_Estimate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Approximate Maximum k-cut Estimate
 
 CALL gds.maxkcut.mutate.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,mutateProperty: $dependencies_projection_write_property
     ,k: toInteger($dependencies_maxkcut)

--- a/cypher/Community_Detection/Community_Detection_6c_Approximate_Maximum_k_cut_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_6c_Approximate_Maximum_k_cut_Mutate.cypher
@@ -1,7 +1,7 @@
 // Community Detection Approximate Maximum k-cut Mutate
 
 CALL gds.maxkcut.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,mutateProperty: $dependencies_projection_write_property
     ,k: toInteger($dependencies_maxkcut)

--- a/cypher/Community_Detection/Community_Detection_6d_Approximate_Maximum_k_cut_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_6d_Approximate_Maximum_k_cut_Stream.cypher
@@ -1,7 +1,7 @@
 // Community Detection Approximate Maximum k-cut Stream
 
 CALL gds.maxkcut.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
 })
  YIELD nodeId, communityId
   WITH gds.util.asNode(nodeId) AS member

--- a/cypher/Community_Detection/Community_Detection_7d_Modularity.cypher
+++ b/cypher/Community_Detection/Community_Detection_7d_Modularity.cypher
@@ -1,7 +1,7 @@
 // Community Detection Modularity
 
 CALL gds.alpha.modularity.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,communityProperty: $dependencies_projection_write_property
 })

--- a/cypher/Community_Detection/Community_Detection_7d_Modularity_Members.cypher
+++ b/cypher/Community_Detection/Community_Detection_7d_Modularity_Members.cypher
@@ -1,7 +1,7 @@
 // Community Detection Modularity Members
 
 CALL gds.modularity.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,communityProperty: $dependencies_projection_write_property
 })

--- a/cypher/Community_Detection/Community_Detection_7e_Write_Modularity.cypher
+++ b/cypher/Community_Detection/Community_Detection_7e_Write_Modularity.cypher
@@ -1,7 +1,7 @@
 // Community Detection Modularity Write
 
 CALL gds.modularity.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,communityProperty: $dependencies_projection_write_property
 })

--- a/cypher/Dependencies_Projection/Dependencies_2_Delete_Subgraph.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_2_Delete_Subgraph.cypher
@@ -1,5 +1,5 @@
 // Delete filtered subgraph projection if exists. Variables: dependencies_projection
 
-  CALL gds.graph.drop($dependencies_projection + '-without-empty', false)
+  CALL gds.graph.drop($dependencies_projection + '-cleaned', false)
  YIELD graphName, nodeCount, relationshipCount, creationTime, modificationTime
 RETURN graphName, nodeCount, relationshipCount, creationTime, modificationTime

--- a/cypher/Dependencies_Projection/Dependencies_5_Create_Subgraph.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_5_Create_Subgraph.cypher
@@ -1,7 +1,7 @@
 //Create filtered subgraph projection without zero-degree nodes. Variables: dependencies_projection, dependencies_projection_node
 
 CALL gds.beta.graph.project.subgraph(
-  $dependencies_projection + '-without-empty',
+  $dependencies_projection + '-cleaned',
   $dependencies_projection,
   'n.outgoingDependencies > 0 OR n.incomingDependencies > 0',
   '*'

--- a/cypher/Dependencies_Projection/Dependencies_6_Check_Projection_Nodes.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_6_Check_Projection_Nodes.cypher
@@ -1,7 +1,7 @@
 // Check Projection Node Properties
 
 CALL gds.graph.nodeProperties.stream(
-   $dependencies_projection + '-without-empty'
+   $dependencies_projection + '-cleaned'
   ,['incomingDependencies', 'outgoingDependencies']
 )
 YIELD nodeId, targetNodeId, propertyValue, relationshipType

--- a/cypher/Dependencies_Projection/Dependencies_7_Check_Projection_Relationships.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_7_Check_Projection_Relationships.cypher
@@ -1,7 +1,7 @@
 // Check Projection Relationships
 
 CALL gds.graph.relationshipProperty.stream(
-   $dependencies_projection + '-without-empty',
+   $dependencies_projection + '-cleaned',
   ,$dependencies_projection_weight_property
   ,['DEPENDS_ON']
 )

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
@@ -1,7 +1,7 @@
 // Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.stream(
-     $dependencies_projection + '-without-empty'
+     $dependencies_projection + '-cleaned'
     ,[$dependencies_projection_write_property]
 )
 YIELD nodeId, nodeProperty, propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
@@ -1,7 +1,7 @@
 // Read a property from the projection into the Graph. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.stream(
-     $dependencies_projection + '-without-empty'
+     $dependencies_projection + '-cleaned'
     ,[$dependencies_projection_write_property]
 )
 YIELD nodeId, nodeProperty, propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
@@ -1,7 +1,7 @@
 // Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.stream(
-     $dependencies_projection + '-without-empty'
+     $dependencies_projection + '-cleaned'
     ,[$dependencies_projection_write_property]
 )
 YIELD nodeId, nodeProperty, propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
@@ -1,7 +1,7 @@
 // Read a property from the projection and order it by its value descending. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.stream(
-     $dependencies_projection + '-without-empty'
+     $dependencies_projection + '-cleaned'
     ,[$dependencies_projection_write_property]
 )
 YIELD nodeId, nodeProperty, propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property
+// Read a property from the projection and order it by its value descending. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-without-empty'
@@ -12,3 +12,4 @@ RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, co
      ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))      AS shortCodeUnitName
      ,propertyName
      ,propertyValue
+ORDER BY propertyValue DESCENDING, codeUnitName ASCENDING

--- a/cypher/Dependencies_Projection/Dependencies_9_Write_Mutated.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_9_Write_Mutated.cypher
@@ -1,7 +1,7 @@
 // Write a property from the projection into the Graph. Variables: dependencies_projection, dependencies_projection_write_property
 
 CALL gds.graph.nodeProperties.write(
-   $dependencies_projection + '-without-empty'
+   $dependencies_projection + '-cleaned'
   ,[$dependencies_projection_write_property]
 )
  YIELD propertiesWritten, nodeProperties, writeMillis

--- a/cypher/Method_Projection/Methods_1_Delete_Projection.cypher
+++ b/cypher/Method_Projection/Methods_1_Delete_Projection.cypher
@@ -1,5 +1,5 @@
 // Delete projection if existing. Variables: dependencies_projection
 
-  CALL gds.graph.drop($dependencies_projection + '-without-empty', false)
+  CALL gds.graph.drop($dependencies_projection + '-cleaned', false)
  YIELD graphName, nodeCount, relationshipCount, creationTime, modificationTime
 RETURN graphName, nodeCount, relationshipCount, creationTime, modificationTime

--- a/cypher/Method_Projection/Methods_1_Delete_Projection.cypher
+++ b/cypher/Method_Projection/Methods_1_Delete_Projection.cypher
@@ -1,0 +1,5 @@
+// Delete projection if existing. Variables: dependencies_projection
+
+  CALL gds.graph.drop($dependencies_projection + '-without-empty', false)
+ YIELD graphName, nodeCount, relationshipCount, creationTime, modificationTime
+RETURN graphName, nodeCount, relationshipCount, creationTime, modificationTime

--- a/cypher/Method_Projection/Methods_2_Create_Projection.cypher
+++ b/cypher/Method_Projection/Methods_2_Create_Projection.cypher
@@ -7,7 +7,7 @@
    AND target.visibility = 'public'
    AND source.name <> '<init>'
    AND target.name <> '<init>'
-  WITH gds.graph.project($dependencies_projection + '-without-empty', source, target) AS projection
+  WITH gds.graph.project($dependencies_projection + '-cleaned', source, target) AS projection
 RETURN projection.graphName         AS graphName
       ,projection.nodeCount         AS nodeCount
       ,projection.relationshipCount AS relationshipCount

--- a/cypher/Method_Projection/Methods_2_Create_Projection.cypher
+++ b/cypher/Method_Projection/Methods_2_Create_Projection.cypher
@@ -1,0 +1,13 @@
+// Create directed projection for methods. Variables: dependencies_projection, dependencies_projection_weight_property
+
+ MATCH (source:Method)-[r:INVOKES]->(target:Method)
+ WHERE source.effectiveLineCount > 1
+   AND target.effectiveLineCount > 1
+   AND source.visibility = 'public'
+   AND target.visibility = 'public'
+   AND source.name <> '<init>'
+   AND target.name <> '<init>'
+  WITH gds.graph.project($dependencies_projection + '-without-empty', source, target) AS projection
+RETURN projection.graphName         AS graphName
+      ,projection.nodeCount         AS nodeCount
+      ,projection.relationshipCount AS relationshipCount

--- a/cypher/Node_Embeddings/Node_Embeddings_1a_Fast_Random_Projection_Estimate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1a_Fast_Random_Projection_Estimate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 1a using Fast Random Projection: Estimate
 
 CALL gds.fastRP.stream.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,relationshipWeightProperty: $dependencies_projection_weight_property
   }

--- a/cypher/Node_Embeddings/Node_Embeddings_1b_Fast_Random_Projection_Statistics.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1b_Fast_Random_Projection_Statistics.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 1b using Fast Random Projection: Statistics
 
 CALL gds.fastRP.stats(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,relationshipWeightProperty: $dependencies_projection_weight_property
   }

--- a/cypher/Node_Embeddings/Node_Embeddings_1c_Fast_Random_Projection_Mutate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1c_Fast_Random_Projection_Mutate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 1c using Fast Random Projection: Mutate
 
 CALL gds.fastRP.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,relationshipWeightProperty: $dependencies_projection_weight_property
      ,mutateProperty: $dependencies_projection_write_property

--- a/cypher/Node_Embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 1d using Fast Random Projection: Stream
 
 CALL gds.fastRP.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,relationshipWeightProperty: $dependencies_projection_weight_property
   }

--- a/cypher/Node_Embeddings/Node_Embeddings_1e_Fast_Random_Projection_Write.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1e_Fast_Random_Projection_Write.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 1d using Fast Random Projection: Write
 
 CALL gds.fastRP.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
       embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,relationshipWeightProperty: $dependencies_projection_weight_property
      ,writeProperty: $dependencies_projection_write_property

--- a/cypher/Node_Embeddings/Node_Embeddings_2a_Hash_GNN_Estimate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_2a_Hash_GNN_Estimate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 2a using Hash GNN (Graph Neural Networks): Estimate
 
 CALL gds.beta.hashgnn.stream.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDensity: toInteger($dependencies_projection_embedding_dimension) * 2
      ,iterations: 3
      ,generateFeatures: {

--- a/cypher/Node_Embeddings/Node_Embeddings_2c_Hash_GNN_Mutate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_2c_Hash_GNN_Mutate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 2b using Hash GNN (Graph Neural Networks): Mutate
 
 CALL gds.beta.hashgnn.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDensity: toInteger($dependencies_projection_embedding_dimension) * 2
      ,iterations: 3
      ,generateFeatures: {

--- a/cypher/Node_Embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 2c using Hash GNN (Graph Neural Networks): Stream
 
 CALL gds.beta.hashgnn.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDensity: toInteger($dependencies_projection_embedding_dimension) * 2
      ,iterations: 3
      ,generateFeatures: {

--- a/cypher/Node_Embeddings/Node_Embeddings_3a_Node2Vec_Estimate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_3a_Node2Vec_Estimate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 3a using Node2Vec: Estimate
 
 CALL gds.node2vec.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,iterations: 3
      ,relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Node_Embeddings/Node_Embeddings_3c_Node2Vec_Mutate.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_3c_Node2Vec_Mutate.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 3c using Node2Vec: Mutate
 
 CALL gds.node2vec.mutate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,iterations: 3
      ,relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Node_Embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 3c using Node2Vec: Stream
 
 CALL gds.node2vec.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,iterations: 3
      ,relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Node_Embeddings/Node_Embeddings_3e_Node2Vec_Write.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_3e_Node2Vec_Write.cypher
@@ -1,7 +1,7 @@
 // Node Embeddings 3d using Node2Vec: Write
 
 CALL gds.node2vec.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      ,embeddingDimension: toInteger($dependencies_projection_embedding_dimension)
      ,iterations: 3
      ,relationshipWeightProperty: $dependencies_projection_weight_property

--- a/cypher/Similarity/Similarity_1a_Estimate.cypher
+++ b/cypher/Similarity/Similarity_1a_Estimate.cypher
@@ -1,7 +1,7 @@
 // Similarity Estimate Memory
 
 CALL gds.nodeSimilarity.write.estimate(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,writeRelationshipType: 'SIMILAR'
     ,writeProperty: 'score'

--- a/cypher/Similarity/Similarity_1b_Statistics.cypher
+++ b/cypher/Similarity/Similarity_1b_Statistics.cypher
@@ -1,7 +1,7 @@
 // Similarity Statistics
 
 CALL gds.nodeSimilarity.stats(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property
      ,topK: 3
  })

--- a/cypher/Similarity/Similarity_1c_Stream.cypher
+++ b/cypher/Similarity/Similarity_1c_Stream.cypher
@@ -1,7 +1,7 @@
 // Similarity Stream
 
  CALL gds.nodeSimilarity.stream(
-  $dependencies_projection + '-without-empty', {
+  $dependencies_projection + '-cleaned', {
       relationshipWeightProperty: $dependencies_projection_weight_property
      ,topK: 3
  })

--- a/cypher/Similarity/Similarity_1e_Write.cypher
+++ b/cypher/Similarity/Similarity_1e_Write.cypher
@@ -1,7 +1,7 @@
 // Similarity Write
 
 CALL gds.nodeSimilarity.write(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
      relationshipWeightProperty: $dependencies_projection_weight_property
     ,writeRelationshipType: 'SIMILAR'
     ,writeProperty: 'score'

--- a/cypher/Topological_Sort/Topological_Sort_List.cypher
+++ b/cypher/Topological_Sort/Topological_Sort_List.cypher
@@ -2,7 +2,7 @@
 // Needs graph-data-science plugin version >= 2.5.0
 
 CALL gds.dag.topologicalSort.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     computeMaxDistanceFromSource: true
 }) YIELD nodeId, maxDistanceFromSource
    WITH nodeId

--- a/cypher/Topological_Sort/Topological_Sort_Write.cypher
+++ b/cypher/Topological_Sort/Topological_Sort_Write.cypher
@@ -2,7 +2,7 @@
 // Needs graph-data-science plugin version >= 2.5.0
 
 CALL gds.dag.topologicalSort.stream(
- $dependencies_projection + '-without-empty', {
+ $dependencies_projection + '-cleaned', {
     computeMaxDistanceFromSource: true
 }) YIELD nodeId, maxDistanceFromSource
    WITH nodeId

--- a/scripts/analysis/analyze.sh
+++ b/scripts/analysis/analyze.sh
@@ -71,7 +71,7 @@ while [[ $# -gt 0 ]]; do
       usage
       ;;
   esac
-  shift
+  shift || true # ignore error when there are no more arguments
 done
 
 # Assure that the analysis report compilation only consists of letters and numbers
@@ -91,6 +91,10 @@ if [ ! -d "${ARTIFACTS_DIRECTORY}" ] ; then
     echo "analyze: The ${ARTIFACTS_DIRECTORY} directory doesn't exist. Please download artifacts first."
     exit 1
 fi
+
+echo "analyze: analysisReportCompilation=${analysisReportCompilation}"
+echo "analyze: settingsProfile=${settingsProfile}"
+echo "analyze: exploreMode=${exploreMode}"
 
 ## Get this "scripts/analysis" directory if not already set
 # Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 

--- a/scripts/configuration/template-neo4j-v4.conf
+++ b/scripts/configuration/template-neo4j-v4.conf
@@ -16,7 +16,7 @@ dbms.memory.pagecache.size=1g
 dbms.jvm.additional=-XX:+ExitOnOutOfMemoryError
 
 # Memory: Limit the amount of memory that all of the running transaction can consume.
-dbms.memory.transaction.global_max_size=2g
+dbms.memory.transaction.global_max_size=3g
 
 # Memory: Limit the amount of memory that a single transaction can consume.
-dbms.memory.transaction.max_size=2g
+dbms.memory.transaction.max_size=3g

--- a/scripts/configuration/template-neo4j.conf
+++ b/scripts/configuration/template-neo4j.conf
@@ -16,7 +16,7 @@ server.memory.pagecache.size=1g
 server.jvm.additional=-XX:+ExitOnOutOfMemoryError
 
 # Memory: Limit the amount of memory that all of the running transaction can consume.
-db.memory.transaction.total.max=2g
+db.memory.transaction.total.max=3g
 
 # Memory: Limit the amount of memory that a single transaction can consume.
-db.memory.transaction.max=2g
+db.memory.transaction.max=3g

--- a/scripts/reports/CentralityCsv.sh
+++ b/scripts/reports/CentralityCsv.sh
@@ -36,18 +36,18 @@ REPORT_NAME="centrality-csv"
 FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
 mkdir -p "${FULL_REPORT_DIRECTORY}"
 
-# Centrality Preparation
-# Selects the nodes and relationships for the algorithm and creates an in-memory projection.
+# Centrality preparation for dependencies between Artifacts, Packages and Types.
+# Selects the dependent nodes and relationships for the algorithm and creates an in-memory projection.
 # Nodes without incoming and outgoing dependencies will be filtered out with a subgraph.
 #
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
-createProjection() {
+createDependencyProjection() {
     local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_1_Delete_Projection.cypher" "${@}"
@@ -56,13 +56,27 @@ createProjection() {
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_5_Create_Subgraph.cypher" "${@}"
 }
 
+# Centrality preparation for method calls 
+# Selects the method nodes and relationships for the algorithm and creates an in-memory projection.
+# Nodes without incoming and outgoing dependencies will be filtered out with a subgraph.
+#
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+createMethodProjection() {
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Method_Projection"
+
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Methods_1_Delete_Projection.cypher" "${@}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Methods_2_Create_Projection.cypher" "${@}"
+}
+
 # Apply the centrality algorithm "Page Rank".
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithPageRank() {
@@ -97,9 +111,9 @@ centralityWithPageRank() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithArticleRank() {
@@ -134,9 +148,9 @@ centralityWithArticleRank() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithBetweenness() {
@@ -171,9 +185,9 @@ centralityWithBetweenness() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithCostEffectiveLazyForwardCELF() {
@@ -208,9 +222,9 @@ centralityWithCostEffectiveLazyForwardCELF() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithHarmonic() {
@@ -246,9 +260,9 @@ centralityWithHarmonic() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "Package"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithCloseness() {
@@ -284,9 +298,9 @@ centralityWithCloseness() {
 # 
 # Required Parameters:
 # - dependencies_projection=...
-#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-centrality"
 # - dependencies_projection_node=...
-#   Label of the nodes that will be used for the projection. Example: "centralityPageRank"
+#   Label of the nodes that will be used for the projection. Example: "Type"
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithHyperlinkInducedTopicSearchHITS() {
@@ -334,7 +348,6 @@ centralityWithHyperlinkInducedTopicSearchHITS() {
 # - dependencies_projection_weight_property=...
 #   Name of the node property that contains the dependency weight. Example: "weight"
 runCentralityAlgorithms() {
-    createProjection "${@}"
     time centralityWithPageRank "${@}"
     time centralityWithArticleRank "${@}"
     time centralityWithBetweenness "${@}"
@@ -353,6 +366,7 @@ ARTIFACT_WEIGHT="dependencies_projection_weight_property=weight"
 
 # Artifact Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing artifact dependencies..."
+createDependencyProjection "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
 runCentralityAlgorithms "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
 
 # ---------------------------------------------------------------
@@ -364,6 +378,7 @@ PACKAGE_WEIGHT="dependencies_projection_weight_property=weight25PercentInterface
 
 # Package Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing package dependencies..."
+createDependencyProjection "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
 runCentralityAlgorithms "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
 
 # ---------------------------------------------------------------
@@ -375,6 +390,21 @@ TYPE_WEIGHT="dependencies_projection_weight_property=weight"
 
 # Type Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing type dependencies..."
+createDependencyProjection "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
 runCentralityAlgorithms "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
+
+# ---------------------------------------------------------------
+
+# Method Query Parameters
+METHOD_PROJECTION="dependencies_projection=method-centrality" 
+METHOD_NODE="dependencies_projection_node=Method" 
+METHOD_WEIGHT="dependencies_projection_weight_property=" 
+
+# Method Centrality
+echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing method dependencies..."
+createMethodProjection "${METHOD_PROJECTION}"
+runCentralityAlgorithms "${METHOD_PROJECTION}" "${METHOD_NODE}" "${METHOD_WEIGHT}"
+
+# ---------------------------------------------------------------
 
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Successfully finished"

--- a/scripts/reports/CentralityCsv.sh
+++ b/scripts/reports/CentralityCsv.sh
@@ -67,6 +67,7 @@ createProjection() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithPageRank() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -76,13 +77,18 @@ centralityWithPageRank() {
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_2a_Page_Rank_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_2b_Page_Rank_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_3c_Page_Rank_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_3c_Page_Rank_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Page_Rank.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Page_Rank.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_3d_Page_Rank_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Page_Rank.csv"
     
-    # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_3d_Page_Rank_Write.cypher" "${@}" "${writePropertyName}"
+    # Update Graph (node properties and labels) using the already mutated property projection
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_3e_Page_Rank_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -98,6 +104,7 @@ centralityWithPageRank() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithArticleRank() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
     
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -107,13 +114,18 @@ centralityWithArticleRank() {
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4a_Article_Rank_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4b_Article_Rank_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4c_Article_Rank_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4c_Article_Rank_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Article_Rank.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Article_Rank.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4d_Article_Rank_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Article_Rank.csv"
     
-    # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4d_Article_Rank_Write.cypher" "${@}" "${writePropertyName}"
+    # Update Graph (node properties and labels) using the already mutated property projection
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_4e_Article_Rank_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -129,6 +141,7 @@ centralityWithArticleRank() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithBetweenness() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
     
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -138,13 +151,18 @@ centralityWithBetweenness() {
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5a_Betweeness_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5b_Betweeness_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5c_Betweeness_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5c_Betweeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Betweeness.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Betweeness.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5d_Betweeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Betweeness.csv"
     
     # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5d_Betweeness_Write.cypher" "${@}" "${writePropertyName}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_5e_Betweeness_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -160,6 +178,7 @@ centralityWithBetweenness() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithCostEffectiveLazyForwardCELF() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -169,13 +188,18 @@ centralityWithCostEffectiveLazyForwardCELF() {
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6a_Cost_effective_Lazy_Forward_CELF_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6b_Cost_effective_Lazy_Forward_CELF_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6c_Cost_effective_Lazy_Forward_CELF_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Cost_effective_Lazy_Forward_CELF.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Cost_Effective_Lazy_Forward_CELF.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Cost_effective_Lazy_Forward_CELF.csv"
     
     # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6d_Cost_effective_Lazy_Forward_CELF_Write.cypher" "${@}" "${writePropertyName}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_6e_Cost_effective_Lazy_Forward_CELF_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -191,6 +215,7 @@ centralityWithCostEffectiveLazyForwardCELF() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithHarmonic() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -201,13 +226,18 @@ centralityWithHarmonic() {
     # execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7a_Harmonic_Closeness_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7b_Harmonic_Closeness_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7c_Harmonic_Closeness_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7c_Harmonic_Closeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Harmonic.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Harmonic_Closeness.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7d_Harmonic_Closeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Harmonic.csv"
     
     # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7d_Harmonic_Closeness_Write.cypher" "${@}" "${writePropertyName}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_7e_Harmonic_Closeness_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -223,6 +253,7 @@ centralityWithHarmonic() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithCloseness() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
@@ -233,13 +264,18 @@ centralityWithCloseness() {
     # execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8a_Closeness_Estimate.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8b_Closeness_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8c_Closeness_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8c_Closeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Closeness.csv"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Betweeness.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8d_Closeness_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Closeness.csv"
     
     # Update Graph (node properties and labels)
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8d_Closeness_Write.cypher" "${@}" "${writePropertyName}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_8e_Closeness_Write.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
 }
@@ -255,26 +291,57 @@ centralityWithCloseness() {
 #   Name of the node property that contains the dependency weight. Example: "weight"
 centralityWithHyperlinkInducedTopicSearchHITS() {
     local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+    local PROJECTION_CYPHER_DIR="$CYPHER_DIR/Dependencies_Projection"
 
     # Name of the property that will be written to the nodes containing the centrality score.
     # This is also used as a name with the first letter capitalized as a label for the top centraliy nodes.
-    local writePropertyName="dependencies_projection_write_property=centralityHyperlinkInducedTopicSearchAuthority" 
+    local writePropertyName="dependencies_projection_write_property=centralityHyperlinkInducedTopicSearch" 
 
     # Statistics
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9a_Hyperlink_Induced_Topic_Search_HITS_Estimate.cypher" "${@}" "${writePropertyName}"
     # Note: There is an issue in gds version 2.5.0-preview3: https://github.com/neo4j/graph-data-science/issues/285
     #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9b_Hyperlink_Induced_Topic_Search_HITS_Statistics.cypher" "${@}"
     
+    # Run the algorithm and write the result into the in-memory projection ("mutate")
+    # Note: There is an issue in gds version 2.5.0-preview3: https://github.com/neo4j/graph-data-science/issues/285
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Mutate.cypher" "${@}" "${writePropertyName}"
+
     # Stream to CSV
     local nodeLabel
     nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9c_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Hyperlink_Induced_Topic_Search_HITS.csv"
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Hyperlink_Induced_Topic_Search_HITS.csv"
+    #execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_8_Stream_Mutated_Value_Descending.cypher" "${@}" "${writePropertyName}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Hyperlink_Induced_Topic_Search_HITS.csv"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_Hyperlink_Induced_Topic_Search_HITS.csv"
     
     # Update Graph (node properties and labels)
     # Note: There is an issue in gds version 2.5.0-preview3: https://github.com/neo4j/graph-data-science/issues/285
-    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Write.cypher" "${@}" "${writePropertyName}"
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}"
-    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}"
+    #execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_9e_Hyperlink_Induced_Topic_Search_HITS_Write.cypher" "${@}" "${writePropertyName}"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}Authority"
+    execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyName}Hub"
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}Authority"
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1c_Label_Delete.cypher" "${@}" "${writePropertyName}Hub"
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}Authority"
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}Hub"
+}
+
+# Run all contained centrality algorithms.
+# 
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+# - dependencies_projection_node=...
+#   Label of the nodes that will be used for the projection. Example: "centralityPageRank"
+# - dependencies_projection_weight_property=...
+#   Name of the node property that contains the dependency weight. Example: "weight"
+runCentralityAlgorithms() {
+    createProjection "${@}"
+    time centralityWithPageRank "${@}"
+    time centralityWithArticleRank "${@}"
+    time centralityWithBetweenness "${@}"
+    time centralityWithCostEffectiveLazyForwardCELF "${@}"
+    time centralityWithHarmonic "${@}"
+    time centralityWithCloseness "${@}"
+    time centralityWithHyperlinkInducedTopicSearchHITS "${@}"
 }
 
 # ---------------------------------------------------------------
@@ -286,14 +353,7 @@ ARTIFACT_WEIGHT="dependencies_projection_weight_property=weight"
 
 # Artifact Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing artifact dependencies..."
-createProjection "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithPageRank "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithArticleRank "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithBetweenness "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithCostEffectiveLazyForwardCELF "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithHarmonic "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithCloseness "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
-time centralityWithHyperlinkInducedTopicSearchHITS "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
+runCentralityAlgorithms "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
 
 # ---------------------------------------------------------------
 
@@ -304,14 +364,7 @@ PACKAGE_WEIGHT="dependencies_projection_weight_property=weight25PercentInterface
 
 # Package Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing package dependencies..."
-createProjection "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithPageRank "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithArticleRank "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithBetweenness "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithCostEffectiveLazyForwardCELF "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithHarmonic "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithCloseness "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
-time centralityWithHyperlinkInducedTopicSearchHITS "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
+runCentralityAlgorithms "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
 
 # ---------------------------------------------------------------
 
@@ -322,13 +375,6 @@ TYPE_WEIGHT="dependencies_projection_weight_property=weight"
 
 # Type Centrality
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing type dependencies..."
-createProjection "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithPageRank "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithArticleRank "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithBetweenness "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithCostEffectiveLazyForwardCELF "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithHarmonic "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithCloseness "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
-time centralityWithHyperlinkInducedTopicSearchHITS "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
+runCentralityAlgorithms "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
 
 echo "centralityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Successfully finished"

--- a/scripts/reports/CentralityCsv.sh
+++ b/scripts/reports/CentralityCsv.sh
@@ -338,6 +338,14 @@ centralityWithHyperlinkInducedTopicSearchHITS() {
     execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_1d_Label_Add.cypher" "${@}" "${writePropertyName}Hub"
 }
 
+listAllResults() {
+    local CENTRALITY_CYPHER_DIR="$CYPHER_DIR/Centrality"
+
+    local nodeLabel
+    nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
+    execute_cypher "${CENTRALITY_CYPHER_DIR}/Centrality_10_Summary.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_Centrality_All.csv"
+}
+
 # Run all contained centrality algorithms.
 # 
 # Required Parameters:
@@ -355,6 +363,7 @@ runCentralityAlgorithms() {
     time centralityWithHarmonic "${@}"
     time centralityWithCloseness "${@}"
     time centralityWithHyperlinkInducedTopicSearchHITS "${@}"
+    listAllResults "${@}"
 }
 
 # ---------------------------------------------------------------

--- a/scripts/reports/CommunityCsv.sh
+++ b/scripts/reports/CommunityCsv.sh
@@ -99,7 +99,6 @@ detectCommunitiesWithLouvain() {
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyNameIntermediate}"
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_10_Delete_Label.cypher" "${@}" "${writePropertyName}" "${writeLabelName}"
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_11_Add_Label.cypher" "${@}" "${writePropertyName}" "${writeLabelName}"
-    execute_cypher "${COMMUNITY_DETECTION_CYPHER_DIR}/Community_Detection_7e_Write_Modularity.cypher" "${@}" "${writePropertyName}"
 }
 
 # Community Detection using the Leiden Algorithm
@@ -144,6 +143,18 @@ detectCommunitiesWithLeiden() {
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_9_Write_Mutated.cypher" "${@}" "${writePropertyNameIntermediate}"
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_10_Delete_Label.cypher" "${@}" "${writePropertyName}" "${writeLabelName}"
     execute_cypher "${PROJECTION_CYPHER_DIR}/Dependencies_11_Add_Label.cypher" "${@}" "${writePropertyName}" "${writeLabelName}"
+}
+
+# Write modularity for Leiden communities
+# 
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "package"
+# - dependencies_projection_weight_property=...
+#   Name of the node property that contains the dependency weight. Example: "weight"
+writeLeidenModularity() {
+    local COMMUNITY_DETECTION_CYPHER_DIR="${CYPHER_DIR}/Community_Detection"
+    local writePropertyName="dependencies_projection_write_property=communityLeidenId" 
     execute_cypher "${COMMUNITY_DETECTION_CYPHER_DIR}/Community_Detection_7e_Write_Modularity.cypher" "${@}" "${writePropertyName}"
 }
 
@@ -320,6 +331,7 @@ ARTIFACT_KCUT="dependencies_maxkcut=5" # default = 2
 # Artifact Community Detection
 echo "communityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing artifact dependencies..."
 detectCommunities "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}" "${ARTIFACT_GAMMA}" "${ARTIFACT_KCUT}"
+writeLeidenModularity "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
 
 # ---------------------------------------------------------------
 
@@ -333,6 +345,7 @@ PACKAGE_KCUT="dependencies_maxkcut=20" # default = 2
 # Package Community Detection
 echo "communityCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') communityCsv: Processing package dependencies..."
 detectCommunities "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}" "${PACKAGE_GAMMA}" "${PACKAGE_KCUT}"
+writeLeidenModularity "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
 
 # Package Community Detection - Special CSV Queries after update
 execute_cypher "${CYPHER_DIR}/Community_Detection/Which_package_community_spans_several_artifacts_and_how_are_the_packages_distributed.cypher" > "${FULL_REPORT_DIRECTORY}/Package_Communities_Leiden_That_Span_Multiple_Artifacts.csv"

--- a/scripts/setupNeo4j.sh
+++ b/scripts/setupNeo4j.sh
@@ -15,7 +15,7 @@ NEO4J_APOC_PLUGIN_VERSION=${NEO4J_APOC_PLUGIN_VERSION:-"5.12.0"} #Awesome Proced
 NEO4J_APOC_PLUGIN_EDITION=${NEO4J_APOC_PLUGIN_EDITION:-"core"} #Awesome Procedures for Neo4j Plugin Edition (Neo4j v4.4.x "all", Neo4j >= v5 "core")
 NEO4J_APOC_PLUGIN_GITHUB=${NEO4J_APOC_PLUGIN_GITHUB:-"neo4j/apoc"} #Awesome Procedures for Neo4j Plugin GitHub User/Repository (Neo4j v4.4.x "neo4j-contrib/neo4j-apoc-procedures", Neo4j >= v5 "neo4j/apoc")
 NEO4J_GDS_PLUGIN_VERSION=${NEO4J_GDS_PLUGIN_VERSION:-"2.5.0"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
-NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.5.0-alpha03"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
+NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.5.0"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
 NEO4J_GDS_PLUGIN_EDITION=${NEO4J_GDS_PLUGIN_EDITION:-"open"} # Graph Data Science Plugin Edition: "open" for OpenGDS, "full" for the full version with Neo4j license
 NEO4J_DATA_PATH=${NEO4J_DATA_PATH:-"$( pwd -P )/data"} # Path where Neo4j writes its data to (outside tools dir)
 NEO4J_RUNTIME_PATH=${NEO4J_RUNTIME_PATH:-"$( pwd -P )/runtime"} # Path where Neo4j puts runtime data to (e.g. logs) (outside tools dir)


### PR DESCRIPTION
### 🎉 Reports

- [Add centrality summary containing all values](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/44dfc6ff83d32f6dde587d348e9df671633ea064): After each projection, all calculated centrality values are written to a new report file to be able to compare them and have them all in one CSV.

### 🚀 Features

- [Support empty=no relationship weight parameter](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/0215a8898ae28083c4bcf69208a9d383a2f35d85): To be able to run Centrality algorithms with and without a relationship weight property, the query parameter is converted to null when containing an empty string. Since only string query parameters are supported for now, null can't be passed directly.
- [Add centrality for methods](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/8b367950ad8afbc4397b2c1f95e546fb32b0831d): Now, method invocations are also examined by the Centrality algorithms.

### ⚙️ Optimization

- [Optimize centrality reports using in-memory mutate](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/5f444a86fef386687e139071f18e37c0e9e5c71e): Instead of running every algorithm twice (stream & write) they now run only once (mutate). The results are then streamed or written from the in memory projection without recalculating them.
- [Raise transaction memory to 3 GB](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/f68d1e632f290026c2f4c5efaecf20399144dde5): Fixes problems when preparing large graphs for analysis.
- [Write Modularity only for Artifacts & Packages](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/fa12929d3ce5c1ff1551cb2fac5fdc660381a1f9): Writing the Modularity metric values to each node still takes lots of resources in large graphs. Therefore it is only done for artifact and package nodes and only for Leiden communities.
- [Rename "without-empty" to "cleaned"](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/2fa1342c4e951fdceea52af7b814abb47a343fc2): This focusses more on the "what" instead of the "how" and is more general for different use cases.

### 📦 Updates

- [Update open graph data science to v2.5.0](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/8376ed4be6bd179bee94d2ace478642d33a2ded4)

### 🛠 Fixes

- [Fix command line input error for explore mode](https://github.com/JohT/code-graph-analysis-pipeline/pull/55/commits/22b14861a162cba35a09eb2d28b00b629a48c4ed): Starting an analysis in `--explore` mode didn't do anything. The `shift` command, that is used to read the next command line argument, fails when there are no more arguments left. Since activating fail-fast the program stopped right after parsing the command line arguments. Ignoring that specific error fixes this problem.
- 