### PR TITLE
Update to open graph-data-science v2.6.0+51

### DIFF
--- a/scripts/profiles/Neo4jv5.sh
+++ b/scripts/profiles/Neo4jv5.sh
@@ -18,7 +18,7 @@ NEO4J_APOC_PLUGIN_EDITION=${NEO4J_APOC_PLUGIN_EDITION:-"core"} # Since Neo4j v5 
 NEO4J_APOC_PLUGIN_GITHUB=${NEO4J_APOC_PLUGIN_GITHUB:-"neo4j/apoc"} # Core edition was moved to "neo4j/apoc" for Neo4j v5
 
 NEO4J_GDS_PLUGIN_VERSION=${NEO4J_GDS_PLUGIN_VERSION:-"2.5.7"}  # Version 2.4.0 is the newest version of june 2023 and compatible with Neo4j v5
-NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.6.0-alpha01"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
+NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.6.0+51"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
 NEO4J_GDS_PLUGIN_EDITION=${NEO4J_GDS_PLUGIN_EDITION:-"open"}  # Graph Data Science Plugin Edition: "open" for OpenGDS, "full" for the full version with Neo4j license
 
 JQASSISTANT_CLI_VERSION=${JQASSISTANT_CLI_VERSION:-"2.0.10"}  # Version 2.0.3 is the newest version (june 2023) compatible with Neo4j v5

--- a/scripts/setupNeo4j.sh
+++ b/scripts/setupNeo4j.sh
@@ -15,7 +15,7 @@ NEO4J_APOC_PLUGIN_VERSION=${NEO4J_APOC_PLUGIN_VERSION:-"5.15.0"} #Awesome Proced
 NEO4J_APOC_PLUGIN_EDITION=${NEO4J_APOC_PLUGIN_EDITION:-"core"} #Awesome Procedures for Neo4j Plugin Edition (Neo4j v4.4.x "all", Neo4j >= v5 "core")
 NEO4J_APOC_PLUGIN_GITHUB=${NEO4J_APOC_PLUGIN_GITHUB:-"neo4j/apoc"} #Awesome Procedures for Neo4j Plugin GitHub User/Repository (Neo4j v4.4.x "neo4j-contrib/neo4j-apoc-procedures", Neo4j >= v5 "neo4j/apoc")
 NEO4J_GDS_PLUGIN_VERSION=${NEO4J_GDS_PLUGIN_VERSION:-"2.5.7"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
-NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.6.0-alpha01"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
+NEO4J_OPEN_GDS_PLUGIN_VERSION=${NEO4J_OPEN_GDS_PLUGIN_VERSION:-"2.6.0+51"} # Graph Data Science Plugin Version 2.4.x of is compatible with Neo4j 5.x
 NEO4J_GDS_PLUGIN_EDITION=${NEO4J_GDS_PLUGIN_EDITION:-"open"} # Graph Data Science Plugin Edition: "open" for OpenGDS, "full" for the full version with Neo4j license
 NEO4J_DATA_PATH=${NEO4J_DATA_PATH:-"$( pwd -P )/data"} # Path where Neo4j writes its data to (outside tools dir)
 NEO4J_RUNTIME_PATH=${NEO4J_RUNTIME_PATH:-"$( pwd -P )/runtime"} # Path where Neo4j puts runtime data to (e.g. logs) (outside tools dir)

--- a/scripts/setupNeo4j.sh
+++ b/scripts/setupNeo4j.sh
@@ -195,13 +195,7 @@ fi
 # Download and install the Neo4j plugin "Graph Data Science" (GDS)
 if [[ ${NEO4J_GDS_PLUGIN_EDITION} == "open" ]]; then
     neo4jGraphDataScienceDownloadUrl="https://github.com/JohT/open-graph-data-science-packaging/releases/download/v${NEO4J_OPEN_GDS_PLUGIN_VERSION}"
-    # TODO Maybe it would be a better solution to release open graph data science packages just with the major release version
-    if [[ "$NEO4J_MAJOR_VERSION_NUMBER" -ge 5 ]]; then
-        neo4jGraphDataScienceNeo4jVersion="5.9.0"
-    else
-        neo4jGraphDataScienceNeo4jVersion="4.4.23"
-    fi
-    neo4jGraphDataScienceReleaseArtifact="open-graph-data-science-${NEO4J_OPEN_GDS_PLUGIN_VERSION}-for-neo4j-${neo4jGraphDataScienceNeo4jVersion}.jar"
+    neo4jGraphDataScienceReleaseArtifact="open-graph-data-science-${NEO4J_OPEN_GDS_PLUGIN_VERSION}-for-neo4j-${NEO4J_MAJOR_VERSION_NUMBER}.jar"
 else
     neo4jGraphDataScienceDownloadUrl="https://github.com/neo4j/graph-data-science/releases/download/${NEO4J_GDS_PLUGIN_VERSION}"
     neo4jGraphDataScienceReleaseArtifact="neo4j-graph-data-science-${NEO4J_GDS_PLUGIN_VERSION}-${NEO4J_GDS_PLUGIN_EDITION}.jar"


### PR DESCRIPTION
📦 Updates

- [Update open-graph-data-science to 2.6.0+51](https://github.com/JohT/code-graph-analysis-pipeline/pull/107/commits/981d2a71c65408562c34738916dfe97a4854a81d)

⚙️ Optimizations

- [Only use Neo4j major version number for open GDS release artifact name](https://github.com/JohT/code-graph-analysis-pipeline/pull/107/commits/fa5b3fdc90d359da28e887a4b4643fa86386c082) since it had been simplified with [open-graph-data-science-packaging v2.6.0+51](https://github.com/JohT/open-graph-data-science-packaging/releases/tag/v2.6.0%2B51)