### PR TITLE
Small Improvements

### DIFF
--- a/scripts/detectChangedArtifacts.sh
+++ b/scripts/detectChangedArtifacts.sh
@@ -2,10 +2,44 @@
 
 # Detect changed files in the artifacts directory with a text file containing the last hash code of the contents.
 # The hash value is generated based on all files (their names and properties) within the artifacts directory.
-# A change is detected when the current hash and the stored one differ.
+# A change is detected when the current hash and the stored differ.
+#
+# Command line options:
+# --readonly Detect changes without creating or updating the change detection file (stateless).
+#            A second call without this option will be needed for the change detection to work.
+#            This is helpful to decide if an operation should be done based on changes while waiting for its success to finally save the change state.
 
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
+
+# Function to display script usage
+usage() {
+  echo "Usage: $0 [--readonly]"
+  exit 1
+}
+
+# Default values
+readonlyMode=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --readonly)
+      readonlyMode=true
+      shift
+      ;;
+    *)
+      echo "detectChangedArtifacts: Error: Unknown option: ${key}"
+      usage
+      ;;
+  esac
+  shift || true # ignore error when there are no more arguments
+done
+
+if ${readonlyMode}; then
+  echo "detectChangedArtifacts: Readonly mode activated. Change detection file won't be created." >&2
+fi
 
 ARTIFACTS_DIRECTORY=${ARTIFACTS_DIRECTORY:-"artifacts"}
 ARTIFACTS_CHANGE_DETECTION_HASH_FILE=${ARTIFACTS_CHANGE_DETECTION_HASH_FILE:-"artifactsChangeDetectionHash.txt"} # Name of the file that contains the hash code of the file list for change detection
@@ -25,8 +59,11 @@ CURRENT_ARTIFACTS_HASH="$( find "./$ARTIFACTS_DIRECTORY" -type f -not -name "${A
 
 # Assume that the files where changed if the file containing the hash of the file list does not exist yet.
 if [ ! -f "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}" ] ; then
-    # Create the file containing the hash of the files list to a new file for the next call
-    echo "${CURRENT_ARTIFACTS_HASH}" > "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}"
+    if ! ${readonlyMode}; then
+        # Create the file containing the hash of the files list to a new file for the next call
+        echo "${CURRENT_ARTIFACTS_HASH}" > "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}"
+        echo "detectChangedArtifacts: Change detection file created" >&2
+    fi
     echo 1
     exit 0
 fi
@@ -36,7 +73,10 @@ fi
 if [[ $(< "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}") == "$CURRENT_ARTIFACTS_HASH" ]] ; then
     echo 0
 else
-    # Write the updated hash into the file containing the hash of the files list for the next call
-    echo "$CURRENT_ARTIFACTS_HASH" > "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}"
+    if ! ${readonlyMode}; then
+        # Write the updated hash into the file containing the hash of the files list for the next call
+        echo "$CURRENT_ARTIFACTS_HASH" > "${ARTIFACTS_CHANGE_DETECTION_HASH_FILE_PATH}"
+        echo "detectChangedArtifacts: Change detection file updated" >&2
+    fi
     echo 2
 fi

--- a/scripts/resetAndScan.sh
+++ b/scripts/resetAndScan.sh
@@ -32,8 +32,7 @@ echo "resetAndScan: SCRIPTS_DIR=${SCRIPTS_DIR}"
 # Internal constants
 JQASSISTANT_DIRECTORY="${TOOLS_DIRECTORY}/${JQASSISTANT_CLI_ARTIFACT}-${JQASSISTANT_CLI_VERSION}"
 JQASSISTANT_BIN="${JQASSISTANT_DIRECTORY}/bin"
-#JQASSISTANT_NEO4J_OPTIONS="-D jqassistant.store.uri=${NEO4J_BOLT_URI} -D jqassistant.store.remote.username=${NEO4J_USER} -D jqassistant.store.remote.password=${NEO4J_INITIAL_PASSWORD}"
-#JQASSISTANT_NEO4J_OPTIONS=-configurationLocations "${JQASSISTANT_CONFIG}/.jqassistant.yaml"
+JQASSISTANT_CONFIG_TEMPLATE_PATH="${SCRIPTS_DIR}/configuration/${JQASSISTANT_CONFIG_TEMPLATE}"
 
 # Check if environment variable is set
 if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then
@@ -55,9 +54,16 @@ else
     echo "resetAndScan: Using jQAssistant binary directory ${JQASSISTANT_BIN}"
 fi
 
-# Create jQAssistant configuration YAML file by copying a template for it
+# Create jQAssistant configuration YAML file by copying it from a corresponding template
 mkdir -p "./.jqassistant"
-cp "${SCRIPTS_DIR}/configuration/${JQASSISTANT_CONFIG_TEMPLATE}" "./.jqassistant/"
+
+echo "resetAndScan: Check if ./.jqassistant/${JQASSISTANT_CONFIG_TEMPLATE} needs to be copied."
+if [ ! -f "./.jqassistant/${JQASSISTANT_CONFIG_TEMPLATE}" ]; then
+    cp "${JQASSISTANT_CONFIG_TEMPLATE_PATH}" "./.jqassistant/"
+    echo "resetAndScan: jQAssistant configuration copied from configuration template"
+else
+    echo "resetAndScan: jQAssistant configuration won't be changed since it already exists."
+fi
 
 # Use jQAssistant to scan the downloaded artifacts and write the results into the separate, local Neo4j Graph Database
 echo "resetAndScan: Scanning ${ARTIFACTS_DIRECTORY} with jQAssistant CLI version ${JQASSISTANT_CLI_VERSION}"

--- a/scripts/resetAndScanChanged.sh
+++ b/scripts/resetAndScanChanged.sh
@@ -14,13 +14,14 @@ set -o errexit -o pipefail
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 SCRIPTS_DIR=${SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )} # Repository directory containing the shell scripts
-echo "resetAndScanChanged SCRIPTS_DIR=$SCRIPTS_DIR"
+echo "resetAndScanChanged SCRIPTS_DIR=${SCRIPTS_DIR}"
 
 # Scan and analyze Artifacts when they were changed
-changeDetectionReturnCode=$( source "$SCRIPTS_DIR/detectChangedArtifacts.sh" )
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedArtifacts.sh" --readonly)
 if [[ "${changeDetectionReturnCode}" == "0" ]] ; then
     echo "resetAndScanChanged: Artifacts unchanged. Scan skipped."
 else
     echo "resetAndScanChanged: Detected change (${changeDetectionReturnCode}). Resetting database and scanning artifacts."
     source "${SCRIPTS_DIR}/resetAndScan.sh"
+    changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedArtifacts.sh")
 fi


### PR DESCRIPTION
### ⚙️ Optimization

- [Create jQAssistant configuration only if missing](https://github.com/JohT/code-graph-analysis-pipeline/pull/117/commits/438007e7026c89b101c61458a7c1c9dfd9ad3344). With this change it is now possible to customize the jQAssistant configuration YAML file within an analysis workspace. It will not be overwritten by the template on a rescan any more.
- [Write change detection file AFTER successful scan](https://github.com/JohT/code-graph-analysis-pipeline/pull/117/commits/e5241a9ad2384a701b9ac6c0b44278cffabdf602). If the scan of the artifacts fails, it will now be restarted upon the next analysis. Previously, the change detection file was written and the scan hadn't been repeated.