### PR TITLE
Use pnpm as package manager for react-router

### DIFF
--- a/.github/workflows/typescript-code-analysis.yml
+++ b/.github/workflows/typescript-code-analysis.yml
@@ -65,7 +65,7 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
 
-    - name: Setup Node.js for Graph Visualization
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version-file: 'graph-visualization/.nvmrc'
@@ -111,6 +111,11 @@ jobs:
         path: ./temp/downloads
         key:
           ${{ runner.os }}-${{ hashFiles('**/*.sh') }}
+
+    - name: Setup pnpm for react-router
+      uses: pnpm/action-setup@v3.0.0
+      with:
+        version: 8.10.5
 
     - name: Download ${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}
       working-directory: temp

--- a/jupyter/NodeEmbeddingsTypescript.ipynb
+++ b/jupyter/NodeEmbeddingsTypescript.ipynb
@@ -243,7 +243,7 @@
    "source": [
     "def prepare_node_embeddings_for_2d_visualization(embeddings: pd.DataFrame) -> pd.DataFrame:\n",
     "    \"\"\"\n",
-    "    Reduces the dimensionality of the node embeddings (e.g. 64 floating point numbers in an array)\n",
+    "    Reduces the dimensionality of the node embeddings (e.g. 32 floating point numbers in an array)\n",
     "    to two dimensions for 2D visualization.\n",
     "    see https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html#sklearn.manifold.TSNE\n",
     "    \"\"\"\n",
@@ -448,7 +448,7 @@
     "    \"dependencies_projection_node\": \"Module\",\n",
     "    \"dependencies_projection_weight_property\": \"lowCouplingElement25PercentWeight\",\n",
     "    \"dependencies_projection_write_property\": \"embeddingsHashGNN\",\n",
-    "    \"dependencies_projection_embedding_dimension\":\"64\"\n",
+    "    \"dependencies_projection_embedding_dimension\":\"32\"\n",
     "}\n",
     "embeddings = create_node_embeddings(\"../cypher/Node_Embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher\", typescript_module_embeddings_parameters)\n",
     "node_embeddings_for_visualization = prepare_node_embeddings_for_2d_visualization(embeddings)\n",

--- a/jupyter/OverviewJava.ipynb
+++ b/jupyter/OverviewJava.ipynb
@@ -492,6 +492,7 @@
     "name": "JohT"
    }
   ],
+  "code_graph_analysis_pipeline_data_validation": "ValidateJavaTypes",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/scripts/reports/NodeEmbeddingsCsv.sh
+++ b/scripts/reports/NodeEmbeddingsCsv.sh
@@ -190,7 +190,7 @@ MODULE_PROJECTION="dependencies_projection=typescript-module-embeddings"
 MODULE_NODE="dependencies_projection_node=Module" 
 MODULE_WEIGHT="dependencies_projection_weight_property=lowCouplingElement25PercentWeight" 
 MODULE_DIMENSIONS="dependencies_projection_embedding_dimension=32" 
-MODULE_DIMENSIONS_HASHGNN="dependencies_projection_embedding_dimension=64"
+MODULE_DIMENSIONS_HASHGNN="dependencies_projection_embedding_dimension=32"
 
 if createUndirectedDependencyProjection "${MODULE_PROJECTION}" "${MODULE_NODE}" "${MODULE_WEIGHT}"; then
     time nodeEmbeddingsWithFastRandomProjection "${MODULE_PROJECTION}" "${MODULE_NODE}" "${MODULE_WEIGHT}" "${MODULE_DIMENSIONS}"


### PR DESCRIPTION
### 🛠 Fix

- [Use pnpm as package manager for react-router.](https://github.com/JohT/code-graph-analysis-pipeline/pull/148/commits/1fe5f830f8245ae1bdb35eb36fd734c0154988de), because [react-router](https://github.com/remix-run/react-router) recently [switched from yarn to pnpm](https://github.com/remix-run/react-router/pull/11358).
- [Define data validation for Java Overview Report](https://github.com/JohT/code-graph-analysis-pipeline/pull/148/commits/6cd422ce554f50e79b8c11a822e6077d4bafeff4). Otherwise, this report would also be created for Typescript projects and wouldn't had any valuable content.
- [Use only 32 dimensions for all Typescript node embeddings.](https://github.com/JohT/code-graph-analysis-pipeline/pull/148/commits/98b50c0d526860b57727e5a66677cc33427209ac) until https://github.com/scikit-learn/scikit-learn/issues/29127 is resolved. Otherwise, node embeddings would cause a Kernel crash in the Jupyter Notebook report for the Typescript project "react-router".