### PR TITLE
Ignore duplicate Typescript analysis json files scan

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,33 +10,35 @@ Please read through the [Prerequisites](./README.md#hammer_and_wrench-prerequisi
 
 ## Start an analysis
 
-1. Create a directory for all analysis projects
+1. Create a directory for all analysis projects.
 
     ```shell
     mkdir temp
     cd temp
     ```
 
-1. Create a working directory for your specific analysis
+1. Create a working directory for your specific analysis.
   
     ```shell
     mkdir MyFirstAnalysis
     cd MyFirstAnalysis
     ```
 
-1. Choose an initial password for Neo4j if not already done
+1. Choose an initial password for Neo4j if not already done.
 
     ```shell
     export NEO4J_INITIAL_PASSWORD=theinitialpasswordthatihavechosenforneo4j
     ```
 
-1. Create the `artifacts` directory for the code to be analyzed (without `cd` afterwards)
+1. Create the `artifacts` directory for the code to be analyzed (without `cd` afterwards).
 
     ```shell
     mkdir artifacts
     ```
 
-1. Move the artifacts (Java jar or Typescript analysis json files) you want to analyze into the `artifacts` directory
+1. Move the artifacts (e.g. Java jars json files) you want to analyze into the `artifacts` directory.
+
+1. Optionally, create a subdirectory `typescript` inside the `artifacts` directory and move the Typescript analysis json files you want to analyze into it.
 
 1. Optionally, create a `source` directory and clone the corresponding source code into it to also gather git log data.
 
@@ -46,9 +48,9 @@ Please read through the [Prerequisites](./README.md#hammer_and_wrench-prerequisi
     ./../../scripts/downloader/downloadAxonFramework.sh <version>
     ```
 
-1. Optionally use a script to download artifacts from Maven ([details](./COMMANDS.md#download-maven-artifacts-to-analyze))
+1. Optionally use a script to download artifacts from Maven ([details](./COMMANDS.md#download-maven-artifacts-to-analyze)).
 
-1. Start the analysis
+1. Start the analysis.
 
    - Without any additional dependencies:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This could be as simple as running the following command in your Typescript proj
 
 - It is recommended to put the cloned source code repository into a directory called `source` within the analysis workspace so that it will also be picked up to import git log data.
 
-- Copy the resulting json file (e.g. `.reports/jqa/ts-output.json`) into the `artifacts` directory for your analysis work directory. Custom subdirectories within `artifacts` are also supported.
+- Copy the resulting json file (e.g. `.reports/jqa/ts-output.json`) into the `artifacts/typescript` directory for your analysis work directory. Create the directory, if it doesn't exists. Custom subdirectories within `artifacts/typescript` are also supported.
 
 ## :rocket: Getting Started
 

--- a/scripts/configuration/template-neo4jv4-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv4-jqassistant.yaml
@@ -88,6 +88,7 @@ jqassistant:
       #
       # -Djqassistant.store.properties
       properties:
+        json.file.exclude: "*/typescript/*.json"
 
   # The Scanner configuration
   scan:

--- a/scripts/configuration/template-neo4jv5-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv5-jqassistant.yaml
@@ -124,6 +124,7 @@ jqassistant:
     # -Djqassistant.scan.properties
     properties:
       # plugin.property.key: value
+      json.file.exclude: "*/typescript/*.json"
 
   # The analyze configuration
   analyze:

--- a/scripts/downloader/downloadAntDesign.sh
+++ b/scripts/downloader/downloadAntDesign.sh
@@ -47,6 +47,6 @@ fi
   echo "download${ANALYSIS_NAME}: Analyzing source..."
   npx --yes @jqassistant/ts-lce >./../runtime/logs/jqassistant-typescript-scan.log 2>&1 || exit
 )
-mkdir -p artifacts
-mv -nv "${SOURCE_DIRECTORY}/.reports/jqa/ts-output.json" "artifacts/ts-ant-design-${PROJECT_VERSION}.json"
+mkdir -p artifacts/typescript
+mv -nv "${SOURCE_DIRECTORY}/.reports/jqa/ts-output.json" "artifacts/typescript/ant-design-${PROJECT_VERSION}.json"
 ################################################################

--- a/scripts/downloader/downloadReactRouter.sh
+++ b/scripts/downloader/downloadReactRouter.sh
@@ -46,6 +46,6 @@ git clone https://github.com/remix-run/react-router.git "${SOURCE_DIRECTORY}"
   pnpm install --frozen-lockfile || exit
   npx --yes @jqassistant/ts-lce >./../runtime/logs/jqassistant-typescript-scan.log 2>&1 || exit
 )
-mkdir -p artifacts
-mv -nv "${SOURCE_DIRECTORY}/.reports/jqa/ts-output.json" "artifacts/ts-react-router-${PROJECT_VERSION}.json"
+mkdir -p artifacts/typescript
+mv -nv "${SOURCE_DIRECTORY}/.reports/jqa/ts-output.json" "artifacts/typescript/react-router-${PROJECT_VERSION}.json"
 ################################################################

--- a/scripts/downloader/downloadReactRouter.sh
+++ b/scripts/downloader/downloadReactRouter.sh
@@ -39,11 +39,14 @@ mkdir -p ./runtime/logs
 ################################################################
 # Download react-router source files to be analyzed
 ################################################################
-git clone https://github.com/remix-run/react-router.git "${SOURCE_DIRECTORY}"
+if [ ! -d "${SOURCE_DIRECTORY}" ] ; then # only clone if source doesn't exist
+git clone --branch "react-router@${PROJECT_VERSION}" https://github.com/remix-run/react-router.git "${SOURCE_DIRECTORY}"
+fi
 (
   cd "${SOURCE_DIRECTORY}" || exit
-  git checkout "react-router@${PROJECT_VERSION}" || exit
+  echo "download${ANALYSIS_NAME}: Installing dependencies..."
   pnpm install --frozen-lockfile || exit
+  echo "download${ANALYSIS_NAME}: Analyzing source..."
   npx --yes @jqassistant/ts-lce >./../runtime/logs/jqassistant-typescript-scan.log 2>&1 || exit
 )
 mkdir -p artifacts/typescript

--- a/scripts/findTypescriptDataFiles.sh
+++ b/scripts/findTypescriptDataFiles.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
 
-# Echoes a list of Typescript data files starting with "ts-" and having extension "json" in the artifacts directory of sub directories. 
+# Echoes a list of Typescript analysis data json files in the directory "artifacts/typescript" or subdirectories and having extension "json". 
 # Each name will be prefixed by "typescript:project::"and separated by one space character.
 # This list is meant to be used after the "-f" line command option for the jQAssistant scan command to include Typescript data files.
+# Note: The directory name "typescript" (env TYPESCRIPT_ARTIFACTS_DIRECTORY) within "artifacts" is a convention 
+#       that is then also used to exclude those json files from being analyzed by the json plugin.
 
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
-ARTIFACTS_DIRECTORY=${ARTIFACTS_DIRECTORY:-"artifacts"}
+ARTIFACTS_DIRECTORY=${ARTIFACTS_DIRECTORY:-"artifacts"} # Working directory containing the artifacts to be analyzed
+TYPESCRIPT_ARTIFACTS_DIRECTORY=${TYPESCRIPT_ARTIFACTS_DIRECTORY:-"typescript"} # Subdirectory of "artifacts" containing the typescript analysis result json files for import
 
 # Check if the artifacts directory exists
 if [ ! -d "./${ARTIFACTS_DIRECTORY}" ] ; then
-    echo "" # The artifact directory doesn't exist. There is no file at all.
-    exit 0
+    echo "findTypescriptDataFiles: No files to analyze because of missing directory ${ARTIFACTS_DIRECTORY}" >&2
+    echo "" # The artifact directory doesn't exist. There is no file to analyze.
+    return 0
 fi
 
-find "./${ARTIFACTS_DIRECTORY}" -type f -name 'ts-*.json' -exec echo {} \; | sed 's/^/typescript:project::/' | tr '\n' ' ' 
+# Check if there is a typescript directory within the artifacts directory
+if [ ! -d "./${ARTIFACTS_DIRECTORY}/${TYPESCRIPT_ARTIFACTS_DIRECTORY}" ] ; then
+    echo "findTypescriptDataFiles: No files to analyze because of missing directory ${ARTIFACTS_DIRECTORY}/${TYPESCRIPT_ARTIFACTS_DIRECTORY}" >&2
+    echo "" # The directory artifact/typescript doesn't exist. There is no file to analyze.
+    return 0
+fi
+
+find "./${ARTIFACTS_DIRECTORY}/${TYPESCRIPT_ARTIFACTS_DIRECTORY}" -type f -name '*.json' -exec echo {} \; | sed 's/^/typescript:project::/' | tr '\n' ' ' 


### PR DESCRIPTION
### ⚙️ Optimization

- [Update react-router download to act similar to ant-design download](https://github.com/JohT/code-graph-analysis-pipeline/pull/173/commits/9d511f156037f80e74e0b2c8dffabddc27b30395)

### 🛠 Fix

- [Use 'artifacts/typescript' for Typescript analysis json files.](https://github.com/JohT/code-graph-analysis-pipeline/pull/173/commits/7b98efc80497db72cf72c2005c53c6588d50571a). Configure the jQAssistant json plugin so that it ignores those files. Otherwise they will be imported as json and as Typescript nodes (duplicate data).

**BREAKING CHANGE**: Now, Typescript analysis result json files need to be copied into the new directory `artifacts/typescript`. They don't need to start with `ts-` in their name anymore. If the directory doesn't exist, create it.