### PR TITLE
Add Overview reports

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -233,7 +233,7 @@ Use [importGitLog.sh](./scripts/importGitLog.sh) to import git log data into the
 It uses `git log` to extract commits, their authors and the names of the files changed with them. These are stored in an intermediate CSV file and are then imported into Neo4j with the following schema:
 
 ```Cypher
-(Git:Log:Author)-[:AUTHORED]->(Git:Log:Commit)->[:CONTAINS]->(Git:Log:File)
+(Git:Log:Author)-[:AUTHORED]->(Git:Log:Commit)->[:CONTAINS_CHANGED]->(Git:Log:File)
 (Git:Log:Commit)->[:HAS_PARENT]-(Git:Log:Commit)
 ```
 
@@ -254,7 +254,7 @@ You can use [List_unresolved_git_files.cypher](./cypher/GitLog/List_unresolved_g
 Use [importAggregatedGitLog.sh](./scripts/importAggregatedGitLog.sh) to import git log data in an aggregated form into the Graph. It works similar to the [full git log version above](#import-git-log). The only difference is that not every single commit is imported. Instead, changes are grouped per month including their commit count. This is in many cases sufficient and reduces data size and processing time significantly. Here is the resulting schema:
 
 ```Cypher
-(Git:Log:Author)-[:AUTHORED]->(Git:Log:ChangeSpan)-[:CONTAINS]->(Git:Log:File)
+(Git:Log:Author)-[:AUTHORED]->(Git:Log:ChangeSpan)-[:CONTAINS_CHANGED]->(Git:Log:File)
 ```
 
 ## Database Queries

--- a/cypher/Centrality/Centrality_1c_Label_Delete.cypher
+++ b/cypher/Centrality/Centrality_1c_Label_Delete.cypher
@@ -1,7 +1,7 @@
 // Centrality Label Delete
 
   CALL db.labels() YIELD label
- WHERE label = 'Top' + apoc.text.capitalize($dependencies_projection_write_property)
+ WHERE label = 'Mark4Top' + apoc.text.capitalize($dependencies_projection_write_property)
   WITH collect(label) AS selectedLabels
  MATCH (member)
  WHERE $dependencies_projection_node IN LABELS(member) 

--- a/cypher/Centrality/Centrality_1d_Label_Add.cypher
+++ b/cypher/Centrality/Centrality_1d_Label_Add.cypher
@@ -10,7 +10,7 @@ UNWIND members AS member
  ORDER BY member[$dependencies_projection_write_property] DESCENDING    
   WITH memberCount2Percent
       ,collect(DISTINCT member)[0..memberCount2Percent] AS topMembers
-      ,'Top' + apoc.text.capitalize($dependencies_projection_write_property) AS labelName
+      ,'Mark4Top' + apoc.text.capitalize($dependencies_projection_write_property) AS labelName
 UNWIND topMembers AS topMember
   CALL apoc.create.addLabels(topMember, [labelName]) YIELD node
 RETURN count(node) AS nodesCount

--- a/cypher/Community_Detection/Community_Detection_10a_LocalClusteringCoefficient_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_10a_LocalClusteringCoefficient_Estimate.cypher
@@ -1,0 +1,23 @@
+// Community Detection - Local Clustering Coefficient - Estimate
+
+CALL gds.localClusteringCoefficient.write.estimate(
+ $dependencies_projection + '-cleaned', {
+    writeProperty: $dependencies_projection_write_property
+})
+ YIELD requiredMemory
+      ,nodeCount
+      ,relationshipCount
+      ,bytesMin
+      ,bytesMax
+      ,heapPercentageMin
+      ,heapPercentageMax
+      ,treeView
+      ,mapView
+RETURN requiredMemory
+      ,nodeCount
+      ,relationshipCount
+      ,bytesMin
+      ,bytesMax
+      ,heapPercentageMin
+      ,heapPercentageMax
+      ,treeView

--- a/cypher/Community_Detection/Community_Detection_10b_LocalClusteringCoefficient_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_10b_LocalClusteringCoefficient_Statistics.cypher
@@ -1,0 +1,7 @@
+// Community Detection - Local Clustering Coefficient - Statistics
+
+CALL gds.localClusteringCoefficient.stats(
+ $dependencies_projection + '-cleaned', {
+})
+ YIELD averageClusteringCoefficient, nodeCount, preProcessingMillis, computeMillis, postProcessingMillis
+RETURN averageClusteringCoefficient, nodeCount, preProcessingMillis, computeMillis, postProcessingMillis

--- a/cypher/Community_Detection/Community_Detection_10c_LocalClusteringCoefficient_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_10c_LocalClusteringCoefficient_Mutate.cypher
@@ -1,0 +1,8 @@
+// Community Detection - Local Clustering Coefficient - Mutate
+
+CALL gds.localClusteringCoefficient.mutate(
+ $dependencies_projection + '-cleaned', {
+    mutateProperty: $dependencies_projection_write_property
+})
+ YIELD averageClusteringCoefficient, nodeCount, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, mutateMillis
+RETURN averageClusteringCoefficient, nodeCount, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, mutateMillis

--- a/cypher/Community_Detection/Community_Detection_10d_LocalClusteringCoefficient_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_10d_LocalClusteringCoefficient_Stream.cypher
@@ -1,0 +1,13 @@
+// Community Detection - Local Clustering Coefficient - Stream
+
+CALL gds.localClusteringCoefficient.stream(
+ $dependencies_projection + '-cleaned', {
+})
+ YIELD nodeId, localClusteringCoefficient
+  WITH gds.util.asNode(nodeId) AS member
+      ,localClusteringCoefficient
+  WITH coalesce(member.fqn, member.fileName, member.name) AS memberName
+      ,localClusteringCoefficient
+RETURN localClusteringCoefficient
+      ,memberName
+ ORDER BY localClusteringCoefficient DESC, memberName ASC

--- a/cypher/Community_Detection/Community_Detection_10d_LocalClusteringCoefficient_Stream_Aggregated.cypher
+++ b/cypher/Community_Detection/Community_Detection_10d_LocalClusteringCoefficient_Stream_Aggregated.cypher
@@ -1,0 +1,17 @@
+// Community Detection - Local Clustering Coefficient - Stream Aggregated
+
+CALL gds.localClusteringCoefficient.stream(
+ $dependencies_projection + '-cleaned', {
+})
+ YIELD nodeId, localClusteringCoefficient
+  WITH gds.util.asNode(nodeId) AS member
+      ,localClusteringCoefficient
+  WITH coalesce(member.fqn, member.fileName, member.name) AS memberName
+      ,localClusteringCoefficient
+  WITH round(localClusteringCoefficient, 2) AS localClusteringCoefficient
+      ,collect(DISTINCT memberName)[0..9]   AS memberNameExamples
+      ,count(DISTINCT memberName)           AS memberCount
+RETURN localClusteringCoefficient
+      ,memberCount
+      ,memberNameExamples
+ ORDER BY localClusteringCoefficient DESC, memberCount DESC

--- a/cypher/Community_Detection/Community_Detection_10e_LocalClusteringCoefficient_Write.cypher
+++ b/cypher/Community_Detection/Community_Detection_10e_LocalClusteringCoefficient_Write.cypher
@@ -1,0 +1,8 @@
+// Community Detection - Local Clustering Coefficient - Write
+
+CALL gds.localClusteringCoefficient.write(
+ $dependencies_projection + '-cleaned', {
+    writeProperty: $dependencies_projection_write_property
+})
+ YIELD averageClusteringCoefficient, nodeCount, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, writeMillis
+RETURN averageClusteringCoefficient, nodeCount, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, writeMillis

--- a/cypher/Dependencies_Projection/Dependencies_10_Delete_Label.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_10_Delete_Label.cypher
@@ -1,7 +1,7 @@
 // Community Detection Label Propagation Label Delete
 
   CALL db.labels() YIELD label
- WHERE label STARTS WITH $dependencies_projection_node + $dependencies_projection_write_label
+ WHERE label STARTS WITH 'Mark4' + $dependencies_projection_node + $dependencies_projection_write_label
   WITH collect(label) AS selectedLabels
  MATCH (member)
  WHERE $dependencies_projection_node IN labels(member) 

--- a/cypher/Dependencies_Projection/Dependencies_11_Add_Label.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_11_Add_Label.cypher
@@ -5,7 +5,7 @@
    AND $dependencies_projection_node IN LABELS(member) 
   WITH collect(member)            AS members
       ,count(DISTINCT member)     AS memberCount
-      ,$dependencies_projection_node + $dependencies_projection_write_label + toString(member[$dependencies_projection_write_property]) AS labelName
+      ,'Mark4' + $dependencies_projection_node + $dependencies_projection_write_label + toString(member[$dependencies_projection_write_property]) AS labelName
  WHERE memberCount > 1
 UNWIND members AS member
   CALL apoc.create.addLabels(member, [labelName]) YIELD node

--- a/cypher/GitLog/Import_aggregated_git_log_csv_data.cypher
+++ b/cypher/GitLog/Import_aggregated_git_log_csv_data.cypher
@@ -10,7 +10,7 @@ CALL { WITH row
     })
     MERGE (git_file:Git:Log:File {fileName: row.filename})
     MERGE (git_author)-[:AUTHORED]->(git_change_span)
-    MERGE (git_change_span)-[:CONTAINS]->(git_file)
+    MERGE (git_change_span)-[:CONTAINS_CHANGED]->(git_file)
 } IN TRANSACTIONS OF 1000 ROWS
 RETURN count(DISTINCT row.author)   AS numberOfAuthors
       ,count(DISTINCT row.filename) AS numberOfFiles

--- a/cypher/GitLog/Import_git_log_csv_data.cypher
+++ b/cypher/GitLog/Import_git_log_csv_data.cypher
@@ -12,7 +12,7 @@ CALL { WITH row
     })
     MERGE (git_file:Git:Log:File {fileName: row.filename})
     MERGE (git_author)-[:AUTHORED]->(git_commit)
-    MERGE (git_commit)-[:CONTAINS]->(git_file)
+    MERGE (git_commit)-[:CONTAINS_CHANGED]->(git_file)
 } IN TRANSACTIONS OF 1000 ROWS
 RETURN count(DISTINCT row.author)   AS numberOfAuthors
       ,count(DISTINCT row.filename) AS numberOfFiles

--- a/cypher/GitLog/List_ambiguous_git_files.cypher
+++ b/cypher/GitLog/List_ambiguous_git_files.cypher
@@ -1,7 +1,7 @@
 // List ambigiously resolved git files where a single git file is attached to more than one code file for troubleshooting/testing.
 
 MATCH (file:File&!Git)<-[:RESOLVES_TO]-(git_file:File&Git)
-OPTIONAL MATCH (artifact:Artifact:Archive)-[:CONTAINS]->(file)
+OPTIONAL MATCH (artifact:Artifact:Archive)-[:CONTAINS_CHANGED]->(file)
  WITH file.fileName                                           AS fileName
      ,reverse(split(reverse(file.fileName),'.')[0])           AS fileExtension
      ,count(DISTINCT git_file.fileName)                       AS gitFilesCount

--- a/cypher/GitLog/Set_number_of_aggregated_git_commits.cypher
+++ b/cypher/GitLog/Set_number_of_aggregated_git_commits.cypher
@@ -1,7 +1,7 @@
 // Set numberOfGitCommits property on code File nodes when aggregated change spans with grouped commits are present.
 
 MATCH (code_file:File&!Git)<-[:RESOLVES_TO]-(git_file:File&Git)
-MATCH (git_file)<-[:CONTAINS]-(git_changespan:Git:ChangeSpan)
+MATCH (git_file)<-[:CONTAINS_CHANGED]-(git_changespan:Git:ChangeSpan)
  WITH code_file, sum(git_changespan.commits) AS numberOfGitCommits
   SET code_file.numberOfGitCommits = numberOfGitCommits
 RETURN count(DISTINCT coalesce(code_file.absoluteFileName, code_file.fileName)) AS changedCodeFiles

--- a/cypher/GitLog/Set_number_of_git_commits.cypher
+++ b/cypher/GitLog/Set_number_of_git_commits.cypher
@@ -1,7 +1,7 @@
 // Set numberOfGitCommits property on code File nodes when git commits are present
 
 MATCH (code_file:File&!Git)<-[:RESOLVES_TO]-(git_file:File&Git)
-MATCH (git_file)<-[:CONTAINS]-(git_commit:Git:Commit)
+MATCH (git_file)<-[:CONTAINS_CHANGED]-(git_commit:Git:Commit)
  WITH code_file, count(DISTINCT git_commit.hash) AS numberOfGitCommits
   SET code_file.numberOfGitCommits = numberOfGitCommits
 RETURN count(DISTINCT coalesce(code_file.absoluteFileName, code_file.fileName)) AS changedCodeFiles

--- a/cypher/Overview/Node_label_combination_count.cypher
+++ b/cypher/Overview/Node_label_combination_count.cypher
@@ -1,0 +1,22 @@
+// Node count for each label combination. Sums up to the total number of nodes.
+
+ MATCH (allNodes)
+  WITH COUNT(allNodes) AS totalNodeCount
+ MATCH (nodesAndTheirLabels)
+  WITH totalNodeCount
+      ,labels(nodesAndTheirLabels) AS nodeLabels
+      ,nodesAndTheirLabels
+ UNWIND nodeLabels AS nodeLabel
+  WITH totalNodeCount
+      ,nodeLabel
+      ,nodesAndTheirLabels
+ WHERE NOT nodeLabel STARTS WITH 'Mark4'
+  WITH totalNodeCount
+      ,collect(nodeLabel)             AS nodeLabels
+      ,nodesAndTheirLabels
+  WITH totalNodeCount
+      ,nodeLabels
+      ,count(nodesAndTheirLabels)     AS nodesWithThatLabels
+      ,toFloat(count(nodesAndTheirLabels)) / totalNodeCount * 100.0  AS nodesWithThatLabelsPercent
+RETURN nodeLabels, nodesWithThatLabels, nodesWithThatLabelsPercent
+ORDER BY nodesWithThatLabels DESC

--- a/cypher/Overview/Node_label_count.cypher
+++ b/cypher/Overview/Node_label_count.cypher
@@ -1,0 +1,16 @@
+// Node count for each label separate. Doesn_t sum up to the number of total labels since one node can have multiple labels.
+
+ MATCH (allNodes)
+  WITH COUNT(allNodes) AS totalNodeCount
+ MATCH (nodesAndTheirLabels)
+  WITH totalNodeCount
+      ,labels(nodesAndTheirLabels) AS nodeLabels
+      ,nodesAndTheirLabels
+ UNWIND nodeLabels AS nodeLabel
+  WITH totalNodeCount
+      ,nodeLabel
+      ,count(nodesAndTheirLabels)                                    AS nodesWithThatLabel
+      ,toFloat(count(nodesAndTheirLabels)) / totalNodeCount * 100.0  AS nodesWithThatLabelPercent
+ WHERE NOT nodeLabel STARTS WITH 'Mark4'
+RETURN nodeLabel, nodesWithThatLabel, nodesWithThatLabelPercent
+ORDER BY nodesWithThatLabel DESC, nodeLabel ASC

--- a/cypher/Overview/Node_labels_and_their_relationships.cypher
+++ b/cypher/Overview/Node_labels_and_their_relationships.cypher
@@ -1,0 +1,29 @@
+// List node labels and their relationship types, their count and their density.
+
+ MATCH (nodeByLabel)
+  WITH labels(nodeByLabel)  AS nodeLabels
+      ,collect(nodeByLabel) AS nodesWithThatLabels
+      ,count(nodeByLabel)   AS numberOfNodesWithThatLabels
+UNWIND nodesWithThatLabels AS nodeWithThatLabels
+ MATCH (nodeWithThatLabels)-[relation]->(target)
+  WITH nodeLabels                  AS sourceLabels
+      ,numberOfNodesWithThatLabels AS numberOfNodesWithSameLabelsAsSource
+      ,type(relation)              AS relationType
+      ,labels(target)              AS targetLabels
+      ,count(DISTINCT relation)    AS numberOfRelationships
+  WITH sourceLabels
+      ,relationType
+      ,targetLabels
+      ,numberOfRelationships
+      ,numberOfNodesWithSameLabelsAsSource
+      ,count{ MATCH (targetWithLabel) WHERE labels(targetWithLabel) = targetLabels } AS numberOfNodesWithSameLabelsAsTarget
+RETURN sourceLabels
+      ,relationType
+      ,targetLabels
+      ,numberOfRelationships
+      ,numberOfNodesWithSameLabelsAsSource
+      ,numberOfNodesWithSameLabelsAsTarget
+      ,toFloat(numberOfRelationships)
+        / ( numberOfNodesWithSameLabelsAsSource * numberOfNodesWithSameLabelsAsTarget)
+        * 100 AS densityInPercent
+ORDER BY numberOfRelationships DESC

--- a/cypher/Overview/Number_of_elements_per_module_for_Typescript.cypher
+++ b/cypher/Overview/Number_of_elements_per_module_for_Typescript.cypher
@@ -1,0 +1,33 @@
+// Number of elements per module for Typescript
+
+ MATCH (module:TS:Module)-[:EXPORTS]->(element:TS)
+ OPTIONAL MATCH (module)<-[:CONTAINS]-(project:TS:Project)-[:HAS_ROOT]->(projectRoot:Directory)
+  WITH module.name      AS moduleName
+      ,replace(module.globalFqn, 
+               coalesce(projectRoot.absoluteFileName + '/', ''),
+               '')               AS modulePath
+      ,module.globalFqn          AS fullQualifiedModuleName
+      ,count(DISTINCT element)   AS numberOfModuleElements
+      ,collect(DISTINCT element) AS moduleElements
+UNWIND moduleElements AS element
+  WITH moduleName
+      ,modulePath
+      ,fullQualifiedModuleName
+      ,numberOfModuleElements
+      ,element
+      ,labels(element) AS elementLabels
+UNWIND elementLabels AS typeLabel
+  WITH moduleName
+      ,modulePath
+      ,fullQualifiedModuleName
+      ,numberOfModuleElements
+      ,element
+      ,typeLabel
+ WHERE NOT typeLabel IN ['TS', 'ExternalDeclaration']
+RETURN moduleName
+      ,modulePath
+      ,fullQualifiedModuleName
+      ,numberOfModuleElements
+      ,typeLabel       AS languageElement
+      ,count(element)  AS numberOfElements
+ ORDER BY numberOfModuleElements DESC, moduleName ASC

--- a/cypher/Overview/Overview_size_for_Typescript.cypher
+++ b/cypher/Overview/Overview_size_for_Typescript.cypher
@@ -1,0 +1,77 @@
+// Overview size for Typescript
+
+ MATCH (n)
+  WITH COUNT(n) AS nodeCount
+ MATCH ()-[]->()
+  WITH nodeCount
+      ,count(*) AS relationshipCount
+ MATCH (a:TS&Project)
+  WITH nodeCount
+      ,relationshipCount
+      ,count(DISTINCT a) AS projectCount
+ MATCH (p:TS&Module)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,count(DISTINCT p.globalFqn) AS moduleCount
+ MATCH (function:TS&Function)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,count(DISTINCT function) AS functionCount 
+ MATCH (object:TS&Object)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,count(DISTINCT object) AS objectCount
+ MATCH (typeAlias:TS&TypeAlias)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,objectCount
+      ,count(DISTINCT typeAlias) AS typeAliasCount
+ MATCH (interface:TS&Interface)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,objectCount
+      ,typeAliasCount
+      ,count(DISTINCT interface) AS interfaceCount
+ MATCH (method:TS&Method)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,objectCount
+      ,typeAliasCount
+      ,interfaceCount
+      ,count(DISTINCT method) AS methodCount
+ MATCH (class:TS&Class)
+  WITH nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,objectCount
+      ,typeAliasCount
+      ,interfaceCount
+      ,methodCount
+      ,count(DISTINCT class) AS classCount
+RETURN nodeCount
+      ,relationshipCount
+      ,projectCount
+      ,moduleCount
+      ,functionCount
+      ,objectCount
+      ,typeAliasCount
+      ,interfaceCount
+      ,classCount
+      ,methodCount

--- a/cypher/Overview/Relationship_type_count.cypher
+++ b/cypher/Overview/Relationship_type_count.cypher
@@ -1,0 +1,15 @@
+// Relationship count for each type separate. Sums up to the total number of relationships (100%).
+
+ MATCH ()-[allRelationships]-()
+  WITH COUNT(DISTINCT allRelationships) AS totalRelationshipCount
+ MATCH ()-[relationshipsAndTheirTypes]-()
+  WITH totalRelationshipCount
+      ,type(relationshipsAndTheirTypes)                AS relationshipType
+      ,count(DISTINCT relationshipsAndTheirTypes)      AS nodesWithThatRelationshipType
+      ,toFloat(
+          count(DISTINCT relationshipsAndTheirTypes)) 
+        / totalRelationshipCount * 100.0               AS nodesWithThatRelationshipTypePercent
+RETURN relationshipType
+      ,nodesWithThatRelationshipType
+      ,nodesWithThatRelationshipTypePercent
+ORDER BY nodesWithThatRelationshipType DESC, relationshipType ASC

--- a/jupyter/OverviewGeneral.ipynb
+++ b/jupyter/OverviewGeneral.ipynb
@@ -1,0 +1,683 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Overview in General\n",
+    "<br>  \n",
+    "\n",
+    "This file contains a general overview of the data in the graph including node labels and relationships types.\n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4191f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename : str, limit: int = 10_000):\n",
+    "    cypher_query_template = \"{query}\\nLIMIT {row_limit}\"\n",
+    "    cypher_query = get_cypher_query_from_file(filename)\n",
+    "    cypher_query = cypher_query_template.format(query = cypher_query, row_limit = limit)\n",
+    "    records, summary, keys = driver.execute_query(cypher_query)\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da9e8edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9deaabce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2496caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0b83a8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def group_to_others_below_threshold(data_frame : pd.DataFrame, value_column : str, name_column: str, threshold: float) -> pd.DataFrame:    \n",
+    "    \"\"\"Adds a new percentage column for the value column and \n",
+    "    groups all values below the given threshold to \"others\" in the name column.\n",
+    "\n",
+    "    Parameters:\n",
+    "    - data_frame (pd.DataFrame): Input pandas DataFrame\n",
+    "    - value_column (str): Name of the column that contains the numeric value\n",
+    "    - name_column (str): Name of the column that contains the group name that will be replaced by \"others\" for small values\n",
+    "    - threshold (float): Threshold in % that is used to group values below it into the \"others\" group\n",
+    "\n",
+    "    Returns:\n",
+    "    int:Returning value\n",
+    "\n",
+    "    \"\"\"\n",
+    "    result_data_frame = data_frame.copy();\n",
+    "\n",
+    "    percent_column_name = value_column + 'Percent';\n",
+    "\n",
+    "    percent_column_already_exists = percent_column_name in result_data_frame.columns\n",
+    "\n",
+    "    if not percent_column_already_exists:\n",
+    "        # Add column with the name given in \"percent_column_name\" with the percentage of the value column.\n",
+    "        result_data_frame[percent_column_name] = result_data_frame[value_column] / result_data_frame[value_column].sum() * 100.0;\n",
+    "\n",
+    "    # Convert name column to string values if it wasn't of that type before\n",
+    "    result_data_frame[name_column] = result_data_frame[name_column].astype(str)\n",
+    "\n",
+    "    # Change the group name to \"others\" if it is called less than the specified threshold\n",
+    "    result_data_frame.loc[result_data_frame[percent_column_name] < threshold, name_column] = 'others';\n",
+    "\n",
+    "    # Group by name column (foremost the new \"others\" entries) and sum their percentage\n",
+    "    #result_data_frame = result_data_frame.groupby(name_column)[percent_column_name].sum();\n",
+    "    result_data_frame = result_data_frame.groupby(name_column).sum();\n",
+    "    # Sort by values descending\n",
+    "    #return result_data_frame.sort_values(ascending=False).to_frame();\n",
+    "    return result_data_frame.sort_values(by=percent_column_name, ascending=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c68aa20",
+   "metadata": {},
+   "source": [
+    "## Node Labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8333d13e",
+   "metadata": {},
+   "source": [
+    "### Table 1a - Highest node count by label combination\n",
+    "\n",
+    "Lists the 30 label combinations with the highest number of nodes. The labels with the lowest node count are listed in table 1b.\n",
+    "The total list would sum up to the total number of labels (100%).\n",
+    "\n",
+    "The whole table can be found in the CSV report `Node_label_combination_count`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4ddd4d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "node_count_by_label_combination = query_cypher_to_data_frame(\"../cypher/Overview/Node_label_combination_count.cypher\")\n",
+    "total_number_of_nodes = node_count_by_label_combination['nodesWithThatLabels'].sum()\n",
+    "print(\"Total number of nodes:\", total_number_of_nodes)\n",
+    "\n",
+    "node_count_by_label_combination.head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fda95ffc",
+   "metadata": {},
+   "source": [
+    "### Chart 1a - Highest node count by label combination\n",
+    "\n",
+    "Values under 0.5% will be grouped into \"others\" to get a cleaner plot. The group \"others\" is then broken down in Chart 1b."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9709619a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "node_count_by_label_combination_significant = group_to_others_below_threshold(\n",
+    "    data_frame=node_count_by_label_combination,\n",
+    "    value_column='nodesWithThatLabels',\n",
+    "    name_column='nodeLabels',\n",
+    "    threshold= 0.5\n",
+    ");\n",
+    "\n",
+    "if node_count_by_label_combination_significant.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    \n",
+    "    # Explode offsets slices of the pie chart by the given value\n",
+    "    # Each entry in the list corresponds to an x value\n",
+    "    # The comparison with \"others\" produces an array of booleans where nth entry with the \"others\" value is \"true\"\n",
+    "    # Multiplying it leads to 1 for True and 0 for False therefore \"exploding\" the \"others\" entry a bit more than the rest\n",
+    "    explode=(node_count_by_label_combination_significant.index == 'others') * 0.2 + 0.02\n",
+    "    \n",
+    "    def custom_auto_percentage_format(percentage):\n",
+    "        return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_nodes*percentage/100)\n",
+    "\n",
+    "    axis = node_count_by_label_combination_significant.plot(\n",
+    "        kind='pie',\n",
+    "        title='Nodes per label combination (more than 0.5% overall)',\n",
+    "        legend=True,\n",
+    "        labeldistance=None,\n",
+    "        autopct=custom_auto_percentage_format,\n",
+    "        textprops={'fontsize': 6},\n",
+    "        pctdistance=1.15,\n",
+    "        cmap=main_color_map,\n",
+    "        figsize=(9,9),\n",
+    "        x='nodeLabels',\n",
+    "        y='nodesWithThatLabelsPercent',\n",
+    "        ylabel='',\n",
+    "        explode=explode\n",
+    "    )\n",
+    "    axis.legend(bbox_to_anchor=(1.08, 1), loc='upper left', )\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15767f9d",
+   "metadata": {},
+   "source": [
+    "### Table 1b - Lowest node count by label combination\n",
+    "\n",
+    "Lists the 30 label combinations with the lowest number of nodes until they reach 0.5% of the total node count, which are shown above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfa4006b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "node_count_by_label_combination_lowest_first=node_count_by_label_combination.sort_values(by='nodesWithThatLabels', ascending=True)\n",
+    "node_count_by_label_combination_lowest_first=node_count_by_label_combination_lowest_first.query(\"`nodesWithThatLabelsPercent` <= 0.50\")\n",
+    "\n",
+    "node_count_by_label_combination_lowest_first = node_count_by_label_combination_lowest_first.reset_index(drop=True)\n",
+    "node_count_by_label_combination_lowest_first.head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "049223d8",
+   "metadata": {},
+   "source": [
+    "### Chart 1b - Lowest node count by label combination\n",
+    "\n",
+    "Shows the lowest (less than 0.5% overall) node count label combinations. Therefore, this plot breaks down the \"others\" slice of the pie chart above. Values under 0.01% will be grouped into \"others\" to get a cleaner plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "509a9b6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "node_count_by_label_combination_lowest_first_significant = group_to_others_below_threshold(\n",
+    "    data_frame=node_count_by_label_combination_lowest_first,\n",
+    "    value_column='nodesWithThatLabels',\n",
+    "    name_column='nodeLabels',\n",
+    "    threshold= 0.01\n",
+    ");\n",
+    "\n",
+    "if node_count_by_label_combination_lowest_first_significant.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    \n",
+    "    # Explode offsets slices of the pie chart by the given value\n",
+    "    # Each entry in the list corresponds to an x value\n",
+    "    # The comparison with \"others\" produces an array of booleans where nth entry with the \"others\" value is \"true\"\n",
+    "    # Multiplying it leads to 1 for True and 0 for False therefore \"exploding\" the \"others\" entry a bit more than the rest\n",
+    "    explode=(node_count_by_label_combination_lowest_first_significant.index == 'others') * 0.2 + 0.02\n",
+    "\n",
+    "    def custom_auto_percentage_format(percentage):\n",
+    "        return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_nodes*percentage/100)\n",
+    "\n",
+    "    axis = node_count_by_label_combination_lowest_first_significant.plot(\n",
+    "        kind='pie',\n",
+    "        title='Nodes per label combination (less than 0.5% overall)',\n",
+    "        legend=True,\n",
+    "        labeldistance=None,\n",
+    "        autopct=custom_auto_percentage_format,\n",
+    "        textprops={'fontsize': 6},\n",
+    "        pctdistance=1.15,\n",
+    "        cmap=main_color_map,\n",
+    "        figsize=(9,9),\n",
+    "        x='nodeLabels',\n",
+    "        y='nodesWithThatLabelsPercent',\n",
+    "        ylabel='',\n",
+    "        explode=explode\n",
+    "    )\n",
+    "    axis.legend(bbox_to_anchor=(1.08, 1), loc='upper left')\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb063fe",
+   "metadata": {},
+   "source": [
+    "### Table 1c - Highest node count by single label\n",
+    "\n",
+    "Lists the 40 labels with the highest number of nodes.\n",
+    "Doesn't sum up to the total number of nodes or 100% because one node can have multiple labels.\n",
+    "Helps to identify commonly used labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "444d5847",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "node_count_by_every_label = query_cypher_to_data_frame(\"../cypher/Overview/Node_label_count.cypher\")\n",
+    "node_count_by_every_label.head(40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48465382",
+   "metadata": {},
+   "source": [
+    "### Chart 1c - Highest node count by label\n",
+    "\n",
+    "Shows the 40 labels with the highest number of nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8d67442",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if node_count_by_every_label.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    fig, axes = plot.subplots(nrows=2, ncols=2)\n",
+    "    \n",
+    "    fig.suptitle('Node count by label', fontsize=20)\n",
+    "\n",
+    "    node_count_by_every_label.head(10).plot(\n",
+    "        ax=axes[0, 0],\n",
+    "        kind='bar', \n",
+    "        grid=True,\n",
+    "        x='nodeLabel',\n",
+    "        y='nodesWithThatLabel',\n",
+    "        xlabel='node label',\n",
+    "        ylabel='number of nodes',\n",
+    "        figsize=(10,10),\n",
+    "        legend=False,\n",
+    "        fontsize=8\n",
+    "    )\n",
+    "    node_count_by_every_label.head(20).tail(10).plot(\n",
+    "        ax=axes[0, 1],\n",
+    "        kind='bar', \n",
+    "        grid=True,\n",
+    "        x='nodeLabel',\n",
+    "        y='nodesWithThatLabel',\n",
+    "        xlabel='node label',\n",
+    "        ylabel='number of nodes',\n",
+    "        figsize=(10,10),\n",
+    "        legend=False,\n",
+    "        fontsize=8\n",
+    "    )\n",
+    "    node_count_by_every_label.head(30).tail(10).plot(\n",
+    "        ax=axes[1,0],\n",
+    "        kind='bar', \n",
+    "        grid=True,\n",
+    "        x='nodeLabel',\n",
+    "        y='nodesWithThatLabel',\n",
+    "        xlabel='node label',\n",
+    "        ylabel='number of nodes',\n",
+    "        figsize=(10,10),\n",
+    "        legend=False,\n",
+    "        fontsize=8\n",
+    "    )\n",
+    "    node_count_by_every_label.head(40).tail(10).plot(\n",
+    "        ax=axes[1,1],\n",
+    "        kind='bar', \n",
+    "        grid=True,\n",
+    "        x='nodeLabel',\n",
+    "        y='nodesWithThatLabel',\n",
+    "        xlabel='node label',\n",
+    "        ylabel='number of nodes',\n",
+    "        figsize=(10,10),\n",
+    "        legend=False,\n",
+    "        fontsize=8\n",
+    "    )\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a278e5ed",
+   "metadata": {},
+   "source": [
+    "## Relationship Types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec60e9b8",
+   "metadata": {},
+   "source": [
+    "### Table 2a - Highest relationship count by type\n",
+    "\n",
+    "Lists the 30 relationship types with the highest number of occurrences.\n",
+    "The whole table can be found in the CSV report `Relationship_type_count`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1890c1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relationship_count_by_type = query_cypher_to_data_frame(\"../cypher/Overview/Relationship_type_count.cypher\")\n",
+    "total_number_of_relationships = relationship_count_by_type['nodesWithThatRelationshipType'].sum()\n",
+    "print(\"Total number of relationships:\", total_number_of_relationships)\n",
+    "relationship_count_by_type.head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19a46b5a",
+   "metadata": {},
+   "source": [
+    "### Chart 2a - Highest relationship count by type\n",
+    "\n",
+    "Values under 0.5% will be grouped into \"others\" to get a cleaner plot. The group \"others\" is then broken down in the second chart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af481322",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relationship_count_by_type_significant = group_to_others_below_threshold(\n",
+    "    data_frame=relationship_count_by_type,\n",
+    "    value_column='nodesWithThatRelationshipType',\n",
+    "    name_column='relationshipType',\n",
+    "    threshold= 0.5\n",
+    ");\n",
+    "\n",
+    "if relationship_count_by_type_significant.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    \n",
+    "    # Explode offsets slices of the pie chart by the given value\n",
+    "    # Each entry in the list corresponds to an x value\n",
+    "    # The comparison with \"others\" produces an array of booleans where nth entry with the \"others\" value is \"true\"\n",
+    "    # Multiplying it leads to 1 for True and 0 for False therefore \"exploding\" the \"others\" entry a bit more than the rest\n",
+    "    explode=(relationship_count_by_type_significant.index == 'others') * 0.2 + 0.02\n",
+    "    \n",
+    "    def custom_auto_percentage_format(percentage):\n",
+    "        return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_relationships*percentage/100)\n",
+    "\n",
+    "    axis = relationship_count_by_type_significant.plot(\n",
+    "        kind='pie',\n",
+    "        title='Relationship types (more than 0.5% overall)',\n",
+    "        legend=True,\n",
+    "        labeldistance=None,\n",
+    "        autopct=custom_auto_percentage_format,\n",
+    "        textprops={'fontsize': 6},\n",
+    "        pctdistance=1.15,\n",
+    "        cmap=main_color_map,\n",
+    "        figsize=(9,9),\n",
+    "        x='relationshipType',\n",
+    "        y='nodesWithThatRelationshipTypePercent',\n",
+    "        ylabel='',\n",
+    "        explode=explode\n",
+    "    )\n",
+    "    axis.legend(bbox_to_anchor=(1.08, 1), loc='upper left', )\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "874dde4b",
+   "metadata": {},
+   "source": [
+    "### Table 2b - Lowest relationship count by type\n",
+    "\n",
+    "Lists the 30 relationships type with the lowest number of occurrences up to 0.5% of the total node count. This is essentially breaking down the \"others\" slice from the chart above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ee0bdf9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relationship_count_by_type_lowest_first=relationship_count_by_type.sort_values(by='nodesWithThatRelationshipType', ascending=True)\n",
+    "relationship_count_by_type_lowest_first=relationship_count_by_type_lowest_first.query(\"`nodesWithThatRelationshipTypePercent` <= 0.50\")\n",
+    "\n",
+    "relationship_count_by_type_lowest_first = relationship_count_by_type_lowest_first.reset_index(drop=True)\n",
+    "relationship_count_by_type_lowest_first.head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0c6498f",
+   "metadata": {},
+   "source": [
+    "### Chart 2b - Lowest relationship count by type\n",
+    "\n",
+    "Shows the lowest (less than 0.5% overall) relationship types. This plot breaks down the \"others\" slice of the pie chart above. Values under 0.01% will be grouped into \"others\" to get a cleaner plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "794be50f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "relationship_count_by_type_lowest_first_significant = group_to_others_below_threshold(\n",
+    "    data_frame=relationship_count_by_type_lowest_first,\n",
+    "    value_column='nodesWithThatRelationshipType',\n",
+    "    name_column='relationshipType',\n",
+    "    threshold= 0.01\n",
+    ");\n",
+    "\n",
+    "if relationship_count_by_type_lowest_first_significant.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    \n",
+    "    # Explode offsets slices of the pie chart by the given value\n",
+    "    # Each entry in the list corresponds to an x value\n",
+    "    # The comparison with \"others\" produces an array of booleans where nth entry with the \"others\" value is \"true\"\n",
+    "    # Multiplying it leads to 1 for True and 0 for False therefore \"exploding\" the \"others\" entry a bit more than the rest\n",
+    "    explode=(relationship_count_by_type_lowest_first_significant.index == 'others') * 0.2 + 0.02\n",
+    "\n",
+    "    def custom_auto_percentage_format(percentage):\n",
+    "        return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_relationships*percentage/100)\n",
+    "\n",
+    "    axis = relationship_count_by_type_lowest_first_significant.plot(\n",
+    "        kind='pie',\n",
+    "        title='Relationship types (less than 0.5% overall)',\n",
+    "        legend=True,\n",
+    "        labeldistance=None,\n",
+    "        autopct=custom_auto_percentage_format,\n",
+    "        textprops={'fontsize': 6},\n",
+    "        pctdistance=1.15,\n",
+    "        cmap=main_color_map,\n",
+    "        figsize=(9,9),\n",
+    "        x='relationshipType',\n",
+    "        y='nodesWithThatRelationshipTypePercent',\n",
+    "        ylabel='',\n",
+    "        explode=explode\n",
+    "    )\n",
+    "    axis.legend(bbox_to_anchor=(1.08, 1), loc='upper left')\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "926e821e",
+   "metadata": {},
+   "source": [
+    "## Node labels with their relationships"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "681846c7",
+   "metadata": {},
+   "source": [
+    "### Table 3a - Highest relationship count by node labels and relationship type\n",
+    "\n",
+    "Lists the 30 node labels and their relationship types with the highest number of occurrences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01ff80b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_cypher_to_data_frame(\"../cypher/Overview/Node_labels_and_their_relationships.cypher\", limit=30)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7141e72f",
+   "metadata": {},
+   "source": [
+    "## Graph Density"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59e6c6f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"total_number_of_nodes (vertices):\", total_number_of_nodes)\n",
+    "print(\"total_number_of_relationships (edges):\", total_number_of_relationships)\n",
+    "\n",
+    "total_directed_graph_density=total_number_of_relationships / (total_number_of_nodes * (total_number_of_nodes - 1))\n",
+    "print(\"-> total directed graph density:\", total_directed_graph_density)\n",
+    "print(\"-> total directed graph density in percent:\", total_directed_graph_density * 100)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "title": "Graph Metrics"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter/OverviewJava.ipynb
+++ b/jupyter/OverviewJava.ipynb
@@ -6,7 +6,7 @@
    "id": "2f0eabc4",
    "metadata": {},
    "source": [
-    "# Overview\n",
+    "# Overview for Java\n",
     "<br>  \n",
     "\n",
     "### References\n",
@@ -508,9 +508,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   },
-  "title": "Object Oriented Design Quality Metrics for Java with Neo4j"
+  "title": "Overview for Java"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/jupyter/OverviewTypescript.ipynb
+++ b/jupyter/OverviewTypescript.ipynb
@@ -1,0 +1,439 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Overview for Typescript\n",
+    "\n",
+    "<br>  \n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4191f259",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename):\n",
+    "    records, summary, keys = driver.execute_query(get_cypher_query_from_file(filename))\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da9e8edb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9deaabce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2496caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c68aa20",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8333d13e",
+   "metadata": {},
+   "source": [
+    "### Table 1 - Size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4ddd4d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overview_size = query_cypher_to_data_frame(\"../cypher/Overview/Overview_size_for_Typescript.cypher\")\n",
+    "overview_size"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "91d80bf7",
+   "metadata": {},
+   "source": [
+    "## Modules"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "e02f924a",
+   "metadata": {},
+   "source": [
+    "### Table 2a - Largest 30 elements per module\n",
+    "\n",
+    "This table shows the largest (number of elements) modules and their kind of elements (Interface, TypeAlias, Variable).\n",
+    "The whole table can be found in the CSV report `Number_of_elements_per_module_for_Typescript`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc682db6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elements_per_module = query_cypher_to_data_frame(\"../cypher/Overview/Number_of_elements_per_module_for_Typescript.cypher\")\n",
+    "elements_per_module.drop(columns='fullQualifiedModuleName').head(30)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "b44c8a75",
+   "metadata": {},
+   "source": [
+    "### Table 2b - Largest 30 elements per module grouped\n",
+    "\n",
+    "This table shows the largest (number of elements) modules each in one row, their kind of elements in columns and the count of them as values.\n",
+    "\n",
+    "The source data for this aggregated table can be found in the CSV report `Number_of_elements_per_module_for_Typescript`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "390c40f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pivot the DataFrame to \n",
+    "# - group by the first column (moduleName) as new index\n",
+    "# - convert the values in the second column (typeLabel) \n",
+    "# - into columns with the value of the third column (numberOfTypes).\n",
+    "elements_per_module_grouped = elements_per_module.pivot(index=['fullQualifiedModuleName', 'modulePath', 'moduleName'], columns='languageElement', values='numberOfElements')\n",
+    "\n",
+    "# Fill missing values with zero\n",
+    "elements_per_module_grouped.fillna(0, inplace=True)\n",
+    "\n",
+    "# Calculate the sum of values for each row\n",
+    "elements_per_module_grouped['Total'] = elements_per_module_grouped.sum(axis=1)\n",
+    "\n",
+    "# Sort the DataFrame by the sum of values\n",
+    "elements_per_module_grouped.sort_values(by='Total', ascending=False, inplace=True)\n",
+    "\n",
+    "# Remove the 'Total' column\n",
+    "elements_per_module_grouped.drop('Total', axis=1, inplace=True)\n",
+    "\n",
+    "# Sort the order of the columns by their sum\n",
+    "column_sum = elements_per_module_grouped.sum()\n",
+    "elements_per_module_grouped = elements_per_module_grouped[column_sum.sort_values(ascending=False).index[:]]\n",
+    "\n",
+    "# Convert all numeric columns to integers instead of decimal numbers with .0\n",
+    "elements_per_module_grouped = elements_per_module_grouped.astype(int)\n",
+    "\n",
+    "# Reset the index to be able to select the module name representation (name, path, full)\n",
+    "# elements_per_module_grouped.reset_index(inplace=True)\n",
+    "\n",
+    "# Convert to integer\n",
+    "elements_per_module_grouped.reset_index().drop(columns='fullQualifiedModuleName').head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbe350d7",
+   "metadata": {},
+   "source": [
+    "### Table 2b Chart 1 - 30 largest modules and their elements stacked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "982df680",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if elements_per_module_grouped.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    plot.figure();\n",
+    "    elements_per_module_grouped.reset_index().head(30).plot(\n",
+    "        kind='bar', \n",
+    "        title='Top 30 elements per module',\n",
+    "        xlabel='Module',\n",
+    "        ylabel='Elements',\n",
+    "        x='modulePath',\n",
+    "        stacked=True, \n",
+    "        cmap=main_color_map,\n",
+    "        figsize=(9, 6)\n",
+    "    )\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "62268321",
+   "metadata": {},
+   "source": [
+    "### Table 2c - 30 highest element count per module (grouped and normalized in %)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed887815",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Divide every value by the sum of the row to get horizontal normalized values.\n",
+    "# This makes it easier to compare the \"language element\" usage without taking the size of the module into account\n",
+    "elements_per_module_grouped_normalized = elements_per_module_grouped.div(elements_per_module_grouped.sum(axis=1), axis=0).multiply(100)\n",
+    "elements_per_module_grouped_normalized.reset_index().drop(columns='fullQualifiedModuleName').head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47befd1d",
+   "metadata": {},
+   "source": [
+    "### Table 2c Chart 1 - Top 30 modules with the highest relative amount of type aliases in %"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0e1b7bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if elements_per_module_grouped_normalized.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    elements_per_module_sorted_by_type_alias=elements_per_module_grouped_normalized.sort_values(by='TypeAlias', ascending=False)\n",
+    "    \n",
+    "    plot.figure();\n",
+    "    elements_per_module_sorted_by_type_alias.reset_index().head(30).plot(\n",
+    "        x='moduleName',\n",
+    "        kind='bar', \n",
+    "        stacked=True, \n",
+    "        cmap=main_color_map, \n",
+    "        figsize=(9, 5)\n",
+    "    )\n",
+    "    plot.xlabel('Module')\n",
+    "    plot.ylabel('Elements %')\n",
+    "    plot.title('Exported type aliases [%] per module')\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "652b8526",
+   "metadata": {},
+   "source": [
+    "### Table 2c Chart 2 - Top 30 module with the highest relative amount of interfaces in %"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccb4d386",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if elements_per_module_grouped_normalized.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    elements_per_module_sorted_by_interfaces=elements_per_module_grouped_normalized.sort_values(by='Interface', ascending=False)\n",
+    "    \n",
+    "    plot.figure();\n",
+    "    elements_per_module_sorted_by_interfaces.reset_index().head(30).plot(\n",
+    "        x='moduleName',\n",
+    "        kind='bar', \n",
+    "        stacked=True, \n",
+    "        cmap=main_color_map, \n",
+    "        figsize=(8, 5)\n",
+    "    )\n",
+    "    plot.xlabel('Module')\n",
+    "    plot.ylabel('Elements %')\n",
+    "    plot.title('Exported interfaces [%] per module')\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6103211",
+   "metadata": {},
+   "source": [
+    "### Table 2c Chart 3 - Top 30 modules with the highest relative amount of variables in %"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd70980d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if elements_per_module_grouped_normalized.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    elements_per_module_sorted_by_variables=elements_per_module_grouped_normalized.sort_values(by='Variable', ascending=False)\n",
+    "    plot.figure();\n",
+    "    elements_per_module_sorted_by_variables.reset_index().head(30).plot(\n",
+    "        x='moduleName',\n",
+    "        kind='bar', \n",
+    "        stacked=True, \n",
+    "        cmap=main_color_map, \n",
+    "        figsize=(8, 5)\n",
+    "    )\n",
+    "    plot.xlabel('Module')\n",
+    "    plot.ylabel('Elements %')\n",
+    "    plot.title('Exported variables [%] per module')\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17cf05c7",
+   "metadata": {},
+   "source": [
+    "### Table 2c Chart 4 - Top 30 modules with the highest relative amount of functions in %"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1054634e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if elements_per_module_grouped_normalized.empty:\n",
+    "    print(\"No data to plot\")\n",
+    "else:\n",
+    "    elements_per_module_sorted_by_functions=elements_per_module_grouped_normalized.sort_values(by='Function', ascending=False)\n",
+    "    plot.figure();\n",
+    "    elements_per_module_sorted_by_functions.reset_index().head(30).plot(\n",
+    "        x='moduleName',\n",
+    "        kind='bar', \n",
+    "        stacked=True, \n",
+    "        cmap=main_color_map, \n",
+    "        figsize=(8, 5)\n",
+    "    )\n",
+    "    plot.xlabel('Module')\n",
+    "    plot.ylabel('Elements %')\n",
+    "    plot.title('Exported functions [%] per module')\n",
+    "    plot.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "code_graph_analysis_pipeline_data_validation": "ValidateTypescriptModuleDependencies",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "title": "Overview for Typescript"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/reports/OverviewCsv.sh
+++ b/scripts/reports/OverviewCsv.sh
@@ -45,5 +45,13 @@ execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_Method_Line_Count_Distribution.
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_packages_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_packages_per_artifact.csv"
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_types_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_types_per_artifact.csv"
 
+# In general
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Node_label_count.cypher" > "${FULL_REPORT_DIRECTORY}/Node_label_count.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Node_label_combination_count.cypher" > "${FULL_REPORT_DIRECTORY}/Node_label_combination_count.csv"
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Relationship_type_count.cypher" > "${FULL_REPORT_DIRECTORY}/Relationship_type_count.csv"
+
+# TODO Performance needs improvement. Included (limited) in OverviewGeneral Jupyter Notebook.
+# execute_cypher "${OVERVIEW_CYPHER_DIR}/Node_labels_and_their_relationships.cypher" > "${FULL_REPORT_DIRECTORY}/Node_labels_and_their_relationships.csv"
+
 # Clean-up after report generation. Empty reports will be deleted.
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"

--- a/scripts/reports/OverviewCsv.sh
+++ b/scripts/reports/OverviewCsv.sh
@@ -37,6 +37,7 @@ mkdir -p "${FULL_REPORT_DIRECTORY}"
 # Local Constants
 OVERVIEW_CYPHER_DIR="${CYPHER_DIR}/Overview"
 
+# For Java
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Overview_size.cypher" > "${FULL_REPORT_DIRECTORY}/Overview_size.csv"
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Cyclomatic_Method_Complexity_Distribution.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclomatic_Method_Complexity.csv"
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_lines_of_method_code_per_package.cypher" > "${FULL_REPORT_DIRECTORY}/Effective_lines_of_method_code_per_package.csv"
@@ -44,6 +45,9 @@ execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_lines_of_method_code_per_type.c
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Effective_Method_Line_Count_Distribution.cypher" > "${FULL_REPORT_DIRECTORY}/Effective_Method_Line_Count.csv"
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_packages_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_packages_per_artifact.csv"
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_types_per_artifact.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_types_per_artifact.csv"
+
+# For TypeScript
+execute_cypher "${OVERVIEW_CYPHER_DIR}/Number_of_elements_per_module_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/Number_of_elements_per_module_for_Typescript.csv"
 
 # In general
 execute_cypher "${OVERVIEW_CYPHER_DIR}/Node_label_count.cypher" > "${FULL_REPORT_DIRECTORY}/Node_label_count.csv"


### PR DESCRIPTION
### 🚀 Feature

- [Calculate local clustering coefficient for community detection](https://github.com/JohT/code-graph-analysis-pipeline/pull/174/commits/8d70d7ffb17d3da95d8137765572d3cadb78a58a). With this additional algorithm one can now uncover highly interconnected dependencies where the direct dependencies (neighbors) of a code element (node) are also highly dependent (connected) to each other.
- [Add general overview with node and relationship types](https://github.com/JohT/code-graph-analysis-pipeline/pull/174/commits/b5ce9072c1c7a2cc6885547ae523ba6f4702fe3c). This additional Jupyter notebook report shows the distribution of the node labels and relationship types of the Graph in general including its density. It is not dependent on the schema and is therefore useable for any code base (or even other Graphs) to get a first impression of the schema.
- [Add overview report for Typescript](https://github.com/JohT/code-graph-analysis-pipeline/pull/174/commits/55aa58e345de9b405ac5d59f667e76b38ea40b39). Now, there is also an overview report for Typescript comparable to the one for Java.

### ⚙️ Optimization

- [(Breaking) Prefix all algorithm result labels with 'Mark4'](https://github.com/JohT/code-graph-analysis-pipeline/pull/174/commits/86751d6e22cb001dd2a81a43d3f04c1b44aea63f). Now it is more obvious which labels are generated by algorithms mainly to simplify explorative coloring (now prefixed with `Mark4` and which labels belong to the main schema of the original graph data. `Mark4` stands for `Marker for ...` .
- [(Breaking) Change git file relationship to CONTAINS_CHANGED.](https://github.com/JohT/code-graph-analysis-pipeline/pull/174/commits/d3da5f554074901ad7cf79c6f3b9a23f808ee7e3). To clearly separate relationships between code elements and git data, the latter one now uses `CONTAINS_CHANGED` for the relationship between git commits or change spans and the files that were changed with them. `CONTAINS` is now only used for code data like directories and their files.