### PR TITLE
Add visibility reports for Typescript

### DIFF
--- a/cypher/Visibility/Global_relative_visibility_statistics_for_elements_for_Typescript.cypher
+++ b/cypher/Visibility/Global_relative_visibility_statistics_for_elements_for_Typescript.cypher
@@ -1,0 +1,39 @@
+// Global relative visibility statistics for elements for Typescript
+
+         MATCH (project:Directory)<-[:HAS_ROOT]-(:Project)-[:CONTAINS]->(module:TS:Module)
+         MATCH (module)-[:DECLARES]->(anyElement:TS)
+OPTIONAL MATCH (module)-[:EXPORTS]->(exportedElement:TS)
+ WITH project.absoluteFileName AS projectPath
+     ,module
+     ,COUNT(DISTINCT exportedElement) AS exportedElements
+     ,COUNT(DISTINCT anyElement)      AS allElements
+ WITH projectPath
+     ,module
+     ,exportedElements
+     ,allElements
+     ,toFloat(exportedElements) / allElements AS relativeVisibility
+ WITH projectPath
+     ,SUM(exportedElements)   AS exported
+     ,SUM(allElements)        AS all
+     ,AVG(relativeVisibility) AS average
+     ,MIN(relativeVisibility) AS min
+     ,MAX(relativeVisibility) AS max
+     ,percentileCont(relativeVisibility, 0.25) AS percentile25
+     ,percentileCont(relativeVisibility, 0.5)  AS percentile50
+     ,percentileCont(relativeVisibility, 0.75) AS percentile75
+     ,percentileCont(relativeVisibility, 0.90) AS percentile90
+     ,percentileCont(relativeVisibility, 0.95) AS percentile95
+     ,percentileCont(relativeVisibility, 0.99) AS percentile99
+RETURN projectPath
+      ,all
+      ,exported
+      ,min
+      ,max
+      ,average
+      ,percentile25
+      ,percentile50
+      ,percentile75
+      ,percentile90
+      ,percentile95
+      ,percentile99
+ORDER BY projectPath

--- a/cypher/Visibility/Relative_visibility_exported_elements_to_all_elements_per_module_for_Typescript.cypher
+++ b/cypher/Visibility/Relative_visibility_exported_elements_to_all_elements_per_module_for_Typescript.cypher
@@ -1,0 +1,23 @@
+// Relative visibility: exported elements to all elements per module
+
+         MATCH (project:Directory)<-[:HAS_ROOT]-(:Project)-[:CONTAINS]->(module:TS:Module)
+         MATCH (module)-[:DECLARES]->(moduleElement:TS)
+// Check if element is not only declared but also exported. 
+// Only EXPORTS refers to re-exported elements. 
+OPTIONAL MATCH (module)-[export:EXPORTS]->(moduleElement) 
+ WITH project.absoluteFileName        AS projectPath
+     ,module
+     ,count(DISTINCT export)          AS exportedElements 
+     ,count(DISTINCT moduleElement)   AS allElements
+ WITH projectPath 
+     ,module
+     ,exportedElements
+     ,allElements
+     ,toFloat(exportedElements) / allElements AS relativeVisibility
+RETURN projectPath
+      ,replace(module.fileName, './', '')  AS modulePath
+      ,module.name      AS moduleName
+      ,exportedElements
+      ,allElements
+      ,relativeVisibility
+ORDER BY relativeVisibility DESC, allElements DESC, projectPath ASC, moduleName ASC

--- a/jupyter/VisibilityMetricsTypescript.ipynb
+++ b/jupyter/VisibilityMetricsTypescript.ipynb
@@ -6,7 +6,7 @@
    "id": "2f0eabc4",
    "metadata": {},
    "source": [
-    "# Visibility Metrics for Java\n",
+    "# Visibility Metrics for Typescript\n",
     "<br>  \n",
     "\n",
     "### References\n",
@@ -145,21 +145,21 @@
    "id": "d7cfd862",
    "metadata": {},
    "source": [
-    "## Relative Visibility Of Types\n",
+    "## Relative Visibility Of Elements\n",
     "\n",
-    "A Java class or interface may be declared with the modifier public, in which case it is visible to all classes everywhere. If a class or interface has no modifier (the default, also known as package-private), it is visible only within its own package.\n",
+    "A Typescript element (variable, function, class, ...) may be exported in which case it is visible and can be imported everywhere (if there are no other rules defined). If there is no \"export\" keyword and the element (variable, function, class, ...) is only declared, then it is only visible within the file or module.\n",
     "\n",
-    "The relative visibility is the number of inner components that are visible outside (public) divided by the number of all types:\n",
+    "The relative visibility is the number of inner components that are visible outside (exported) divided by the number of all components:\n",
     "\n",
-    "$$ relative visibility = \\frac{public\\:types}{all\\:types} $$\n",
+    "$$ relative visibility = \\frac{exported\\:elements}{all\\:declared\\:elements} $$\n",
     "\n",
-    "Using package protected types is one of many ways to improve encapsulation and implementation detail hiding.\n",
+    "Using directories with an index file as a module and exporting only the elements (variables, function, classes, ...) that the caller of the module should use is a good way to improve encapsulation and implementation detail hiding.\n",
     "\n",
     "### How to apply the results\n",
     "\n",
-    "The relative visibility is between zero (all types are package protected) and one (all types are public). A value lower than one means that there are types that are declared package protected. The lower the value is, the better implementation details are hidden. \n",
+    "The relative visibility is between zero (no element is exported) and one (all elements are exported). A value lower than one means that there are elements that are not exported. The lower the value is, the better the encapsulation and the better the implementation details are hidden. \n",
     "\n",
-    "Non public classes can't be accessed from another package so they can be changed without affecting code in other packages. They clearly indicate functionality that only belongs to one package. This also motivates to use more classes and to split up code into smaller pieces with a single responsibility and reason to change."
+    "Non exported elements can't be accessed from another modules so they can be changed without affecting code in other modules. They clearly indicate functionality that only belongs to one modules. This also motivates to split up code into smaller pieces with a dedicated reason to change (single responsibility)."
    ]
   },
   {
@@ -167,12 +167,12 @@
    "id": "c9536fd9",
    "metadata": {},
    "source": [
-    "### Table 1a - Top 40 artifacts with lowest median of package protection encapsulation\n",
+    "### Table 1a - Top 40 projects with lowest median of module encapsulation\n",
     "\n",
-    "This table shows the relative visibility statistics aggregated for all packages per artifact and focusses on artifacts with many packages and hardly any package protected types (lowest median, high visibility). Package protected types would help to  improve encapsulation.\n",
+    "This table shows the relative visibility statistics aggregated for all modules per project and focusses on projects with many modules and hardly any non-exported elements (lowest median, high visibility). Module directories with an index file and intentional exporting helps to improve encapsulation.\n",
     "\n",
     "Only the top 40 entries are shown. The whole table can be found in the following CSV report:  \n",
-    "`Global_relative_visibility_statistics_for_types`"
+    "`Global_relative_visibility_statistics_for_elements_for_Typescript`"
    ]
   },
   {
@@ -182,9 +182,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Query the visibility statistics per artifact (all packages aggregated)\n",
-    "# The results Will be used in multiple tables below.\n",
-    "relative_visibility_per_artifact_aggregated=query_cypher_to_data_frame(\"../cypher/Visibility/Global_relative_visibility_statistics_for_types.cypher\")"
+    "# Query the visibility statistics per project (all modules aggregated)\n",
+    "# The results will be used in multiple tables below.\n",
+    "relative_visibility_per_project_aggregated=query_cypher_to_data_frame(\"../cypher/Visibility/Global_relative_visibility_statistics_for_elements_for_Typescript.cypher\")"
    ]
   },
   {
@@ -196,8 +196,8 @@
    },
    "outputs": [],
    "source": [
-    "# Sort by the \"percentile50\" (median) and \"all\" (number of packages in the artifact) descending\n",
-    "relative_visibility_statistics_highest_median=relative_visibility_per_artifact_aggregated.sort_values(by=['percentile50', 'all'], ascending=[False, False])\n",
+    "# Sort by the \"percentile50\" (median) and \"all\" (number of modules in the project) descending\n",
+    "relative_visibility_statistics_highest_median=relative_visibility_per_project_aggregated.sort_values(by=['percentile50', 'all'], ascending=[False, False])\n",
     "\n",
     "# Reset the index (row numbering starting at 0 and increasing by 1)\n",
     "relative_visibility_statistics_highest_median=relative_visibility_statistics_highest_median.reset_index(drop=True)\n",
@@ -210,12 +210,12 @@
    "id": "1b84fd51",
    "metadata": {},
    "source": [
-    "### Table 1b - Top 40 artifacts with highest median of package protection encapsulation\n",
+    "### Table 1b - Top 40 projects with highest median of module encapsulation\n",
     "\n",
-    "This table shows the relative visibility statistics aggregated for all packages per artifact and focusses on artifacts with many packages and the highest median of package protected types (low visibility). Package protected types help to improve encapsulation.\n",
+    "This table shows the relative visibility statistics aggregated for all modules per project and focusses on project with many modules and the highest median of non-exported elements (variables, functions, classes, ...) (low visibility). Module directories with an index file and intentional exporting helps to improve encapsulation.\n",
     "\n",
     "Only the top 40 entries are shown. The whole table can be found in the following CSV report:  \n",
-    "`Global_relative_visibility_statistics_for_types`"
+    "`Global_relative_visibility_statistics_for_elements_for_Typescript`"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "outputs": [],
    "source": [
     "# Sort by the \"percentile50\" (median) ascending and \"all\" (number of packages in the artifact) descending\n",
-    "relative_visibility_statistics_lowest_median=relative_visibility_per_artifact_aggregated.sort_values(by=['percentile50', 'all'], ascending=[True, False])\n",
+    "relative_visibility_statistics_lowest_median=relative_visibility_per_project_aggregated.sort_values(by=['percentile50', 'all'], ascending=[True, False])\n",
     "\n",
     "# Reset the index (row numbering starting at 0 and increasing by 1)\n",
     "relative_visibility_statistics_lowest_median=relative_visibility_statistics_lowest_median.reset_index(drop=True)\n",
@@ -239,7 +239,7 @@
    "id": "5196ecc2",
    "metadata": {},
    "source": [
-    "### Table 1 Chart 1 - Relative visibility in artifacts"
+    "### Table 1 Chart 1 - Relative visibility in projects"
    ]
   },
   {
@@ -252,37 +252,37 @@
     "plot.figure();\n",
     "fig, axes = plot.subplots(nrows=3, ncols=1, sharex=True)\n",
     "\n",
-    "number_of_packages_grid_ticks=[1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000]\n",
+    "number_of_modules_grid_ticks=[1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000]\n",
     "\n",
-    "relative_visibility_per_artifact_aggregated.plot(\n",
+    "relative_visibility_per_project_aggregated.plot(\n",
     "    ax=axes[0],\n",
     "    kind='scatter',\n",
-    "    title='Relative visibility in artifacts (75% percentile)', \n",
+    "    title='Relative visibility in projects (75% percentile)', \n",
     "    x='percentile75',\n",
     "    y='all',\n",
     "    grid=True,\n",
     "    logy=True,\n",
-    "    yticks=number_of_packages_grid_ticks,\n",
+    "    yticks=number_of_modules_grid_ticks,\n",
     "    xlabel='relative visibility',\n",
-    "    ylabel='number of packages',\n",
+    "    ylabel='number of modules',\n",
     "    cmap=main_color_map,\n",
     "    figsize=(10,4),\n",
     ")\n",
-    "relative_visibility_per_artifact_aggregated.plot(\n",
+    "relative_visibility_per_project_aggregated.plot(\n",
     "    ax=axes[1],\n",
     "    kind='scatter',\n",
-    "    title='Relative visibility in artifacts (50% percentile)', \n",
+    "    title='Relative visibility in projects (50% percentile)', \n",
     "    x='percentile50',\n",
     "    y='all',\n",
     "    grid=True,\n",
     "    logy=True,\n",
-    "    yticks=number_of_packages_grid_ticks,\n",
+    "    yticks=number_of_modules_grid_ticks,\n",
     "    xlabel='relative visibility',\n",
-    "    ylabel='number of packages',\n",
+    "    ylabel='number of modules',\n",
     "    cmap=main_color_map,\n",
     "    figsize=(10,4),\n",
     ")\n",
-    "relative_visibility_per_artifact_aggregated.plot(\n",
+    "relative_visibility_per_project_aggregated.plot(\n",
     "    ax=axes[2],\n",
     "    kind='scatter',\n",
     "    title='Relative visibility in artifacts (25% percentile)', \n",
@@ -290,7 +290,7 @@
     "    y='all',\n",
     "    grid=True,\n",
     "    logy=True,\n",
-    "    yticks=number_of_packages_grid_ticks,\n",
+    "    yticks=number_of_modules_grid_ticks,\n",
     "    xlabel='relative visibility',\n",
     "    ylabel='number of packages',\n",
     "    cmap=main_color_map,\n",
@@ -308,12 +308,12 @@
    "id": "3f59da8d",
    "metadata": {},
    "source": [
-    "### Table 2a - Top 40 packages with the highest visibility and lowest encapsulation\n",
+    "### Table 2a - Top 40 modules with the highest visibility and lowest encapsulation\n",
     "\n",
-    "This table shows the relative visibility statistics per packages and artifact and focusses on packages with many types, hardly any package protected ones and therefore the highest relative visibility (lowest encapsulation). Package protected types would help to improve encapsulation.\n",
+    "This table shows the relative visibility statistics per module and project and focusses on modules with many elements (variables, functions, classes, ...), hardly any non-exported ones and therefore the highest relative visibility (lowest encapsulation). Module directories with an index file and intentional exporting helps to improve encapsulation.\n",
     "\n",
     "Only the top 40 entries are shown. The whole table can be found in the following CSV report:  \n",
-    "`Relative_visibility_public_types_to_all_types_per_package`"
+    "`Relative_visibility_exported_elements_to_all_elements_per_module_for_Typescript`"
    ]
   },
   {
@@ -325,9 +325,9 @@
    },
    "outputs": [],
    "source": [
-    "# Query the visibility statistics per package and artifact (all types aggregated)\n",
-    "# The results Will be used in multiple tables below.\n",
-    "relative_visibility_per_package=query_cypher_to_data_frame(\"../cypher/Visibility/Relative_visibility_public_types_to_all_types_per_package.cypher\")"
+    "# Query the visibility statistics per module and project (all elements aggregated)\n",
+    "# The results will be used in multiple tables below.\n",
+    "relative_visibility_per_module=query_cypher_to_data_frame(\"../cypher/Visibility/Relative_visibility_exported_elements_to_all_elements_per_module_for_Typescript.cypher\")"
    ]
   },
   {
@@ -337,13 +337,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sort by the \"relativeVisibility\" and \"allTypes\" (number of types in the package) descending\n",
-    "highest_relative_visibility_packages=relative_visibility_per_package.sort_values(by=['relativeVisibility', 'allTypes'], ascending=[False, False])\n",
+    "# Sort by the \"relativeVisibility\" and \"allElements\" (number of elements in the module) descending\n",
+    "highest_relative_visibility_module=relative_visibility_per_module.sort_values(by=['relativeVisibility', 'allElements'], ascending=[False, False])\n",
     "\n",
     "# Reset the index (row numbering starting at 0 and increasing by 1)\n",
-    "highest_relative_visibility_packages=highest_relative_visibility_packages.reset_index(drop=True)\n",
+    "highest_relative_visibility_module=highest_relative_visibility_module.reset_index(drop=True)\n",
     "\n",
-    "highest_relative_visibility_packages.head(40)"
+    "highest_relative_visibility_module.head(40)"
    ]
   },
   {
@@ -351,9 +351,9 @@
    "id": "c6786ef1",
    "metadata": {},
    "source": [
-    "### Table 2b - Top 40 packages with the lowest visibility and highest encapsulation\n",
+    "### Table 2b - Top 40 modules with the lowest visibility and highest encapsulation\n",
     "\n",
-    "This table shows the relative visibility statistics per packages and artifact and focusses on packages with many types, many package protected ones and therefore the lowest relative visibility (highest encapsulation). Package protected types help to improve encapsulation. Zero percent visibility and therefore packages with no public visible type are suspicious to be dead code.\n",
+    "This table shows the relative visibility statistics per modules and project and focusses on modules with many elements (variables, functions, classes, ...), many non-exported ones and therefore the lowest relative visibility (highest encapsulation). Non-exported elements help to improve encapsulation. Zero percent visibility and therefore modules with no exported elements are suspicious to contain dead code.\n",
     "\n",
     "Only the top 40 entries are shown. The whole table can be found in the following CSV report:  \n",
     "`Relative_visibility_public_types_to_all_types_per_package`"
@@ -367,12 +367,12 @@
    "outputs": [],
    "source": [
     "# Sort by the \"relativeVisibility\" ascending and \"allTypes\" (number of types in the package) descending\n",
-    "lowest_relative_visibility_packages=relative_visibility_per_package.sort_values(by=['relativeVisibility', 'allTypes'], ascending=[True, False])\n",
+    "lowest_relative_visibility_modules=relative_visibility_per_module.sort_values(by=['relativeVisibility', 'allElements'], ascending=[True, False])\n",
     "\n",
     "# Reset the index (row numbering starting at 0 and increasing by 1)\n",
-    "lowest_relative_visibility_packages=lowest_relative_visibility_packages.reset_index(drop=True)\n",
+    "lowest_relative_visibility_modules=lowest_relative_visibility_modules.reset_index(drop=True)\n",
     "\n",
-    "lowest_relative_visibility_packages.head(40)"
+    "lowest_relative_visibility_modules.head(40)"
    ]
   },
   {
@@ -380,7 +380,7 @@
    "id": "8ff237fd",
    "metadata": {},
    "source": [
-    "### Table 2 Chart 1 - Relative visibility of packages"
+    "### Table 2 Chart 1 - Relative visibility of modules"
    ]
   },
   {
@@ -394,16 +394,16 @@
     "\n",
     "number_of_types_grid_ticks=[1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000]\n",
     "\n",
-    "relative_visibility_per_package.plot(\n",
+    "relative_visibility_per_module.plot(\n",
     "    kind='scatter',\n",
-    "    title='Relative visibility of packages', \n",
+    "    title='Relative visibility of modules', \n",
     "    x='relativeVisibility',\n",
-    "    y='allTypes',\n",
+    "    y='allElements',\n",
     "    grid=True,\n",
     "    logy=True,\n",
     "    yticks=number_of_types_grid_ticks,\n",
     "    xlabel='relative visibility',\n",
-    "    ylabel='number of types',\n",
+    "    ylabel='number of elements',\n",
     "    cmap=main_color_map,\n",
     "    figsize=(10,4),\n",
     ")\n",
@@ -418,7 +418,7 @@
     "name": "JohT"
    }
   ],
-  "code_graph_analysis_pipeline_data_validation": "ValidateJavaTypes",
+  "code_graph_analysis_pipeline_data_validation": "ValidateTypescriptModuleDependencies",
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -434,9 +434,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   },
-  "title": "Visibility Metrics for Java"
+  "title": "Visibility Metrics for Typescript"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/scripts/reports/VisibilityMetricsCsv.sh
+++ b/scripts/reports/VisibilityMetricsCsv.sh
@@ -38,8 +38,13 @@ mkdir -p "${FULL_REPORT_DIRECTORY}"
 # Local Constants
 VISIBILITY_CYPHER_DIR="${CYPHER_DIR}/Visibility"
 
+# For Java
 execute_cypher "${VISIBILITY_CYPHER_DIR}/Global_relative_visibility_statistics_for_types.cypher" > "${FULL_REPORT_DIRECTORY}/RelativeVisibilityPerArtifact.csv"
 execute_cypher "${VISIBILITY_CYPHER_DIR}/Relative_visibility_public_types_to_all_types_per_package.cypher" > "${FULL_REPORT_DIRECTORY}/RelativeVisibilityPerPackage.csv"
+
+# For TypeScript
+execute_cypher "${VISIBILITY_CYPHER_DIR}/Global_relative_visibility_statistics_for_elements_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/RelativeVisibilityPerTypescriptProject.csv"
+execute_cypher "${VISIBILITY_CYPHER_DIR}/Relative_visibility_exported_elements_to_all_elements_per_module_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/RelativeVisibilityPerTypescriptModule.csv"
 
 # Clean-up after report generation. Empty reports will be deleted.
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"


### PR DESCRIPTION
### 🚀 Feature

- [Add visibility reports for Typescript](https://github.com/JohT/code-graph-analysis-pipeline/pull/175/commits/6ccee6c7f4a9cfc717722838dc77d445a5713efb). Now, there is also a visibility report for Typescript that shows how many elements (variables, functions, classes, ...) of a module are exported ignoring re-exported ones.