### PR TITLE
Add file distance to DEPENDS_ON relationships

### DIFF
--- a/cypher/Internal_Dependencies/Get_file_distance_as_shortest_contains_path_for_dependencies.cypher
+++ b/cypher/Internal_Dependencies/Get_file_distance_as_shortest_contains_path_for_dependencies.cypher
@@ -1,0 +1,10 @@
+// Get file distance distribution for dependencies (intuitively the fewest number of change directory commands needed)
+
+  MATCH (source:File)-[dependency:DEPENDS_ON]->(target:File)
+  WHERE dependency.fileDistanceAsFewestChangeDirectoryCommands IS NOT NULL
+ RETURN dependency.fileDistanceAsFewestChangeDirectoryCommands
+       ,count(*)               AS numberOfDependencies
+       ,count(DISTINCT source) AS numberOfDependencyUsers
+       ,count(DISTINCT target) AS numberOfDependencyProviders
+       ,collect(source.fileName + ' uses ' + target.fileName)[0..4] AS examples
+ ORDER BY dependency.fileDistanceAsFewestChangeDirectoryCommands

--- a/cypher/Internal_Dependencies/Set_file_distance_as_shortest_contains_path_for_dependencies.cypher
+++ b/cypher/Internal_Dependencies/Set_file_distance_as_shortest_contains_path_for_dependencies.cypher
@@ -1,0 +1,18 @@
+// Set file distance for dependencies as the shortest path of CONTAINS relationships (intuitively the fewest number of change directory commands needed)
+
+   MATCH (source:File)-[dependency:DEPENDS_ON]->(target:File)
+   MATCH changeDirectoryPath = shortestPath((source)-[:CONTAINS*1..15]-(target))
+   WHERE ALL ( file IN nodes(changeDirectoryPath) WHERE "File" IN labels(file) )
+OPTIONAL MATCH (source)<-[:CONTAINS]-(commonDirectory:Directory)-[:CONTAINS]->(target)
+    WITH *, CASE commonDirectory
+              WHEN IS NOT NULL THEN 0
+              ELSE length(changeDirectoryPath)
+            END AS fileDistanceAsFewestChangeDirectoryCommands
+    SET dependency.fileDistanceAsFewestChangeDirectoryCommands
+                  =fileDistanceAsFewestChangeDirectoryCommands
+ RETURN fileDistanceAsFewestChangeDirectoryCommands
+       ,count(*)               AS numberOfDependencies
+       ,count(DISTINCT source) AS numberOfDependencyUsers
+       ,count(DISTINCT target) AS numberOfDependencyProviders
+       ,collect(source.fileName + ' uses ' + target.fileName)[0..4] AS examples
+ ORDER BY fileDistanceAsFewestChangeDirectoryCommands

--- a/jupyter/InternalDependenciesJava.ipynb
+++ b/jupyter/InternalDependenciesJava.ipynb
@@ -73,6 +73,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c09da482",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_first_non_empty_cypher_to_data_frame(*filenames : str, limit: int = 10_000):\n",
+    "    \"\"\"\n",
+    "    Executes the Cypher queries of the given files and returns the first result that is not empty.\n",
+    "    If all given file names result in empty results, the last (empty) result will be returned.\n",
+    "    By additionally specifying \"limit=\" the \"LIMIT\" keyword will appended to query so that only the first results get returned.\n",
+    "    \"\"\"    \n",
+    "    result=pd.DataFrame()\n",
+    "    for filename in filenames:\n",
+    "        result=query_cypher_to_data_frame(filename, limit)\n",
+    "        if not result.empty:\n",
+    "            return result\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a56670c9",
    "metadata": {},
    "outputs": [],
@@ -561,6 +582,27 @@
    "source": [
     "annotated_elements=query_cypher_to_data_frame(\"../cypher/Java/Annotated_code_elements.cypher\", limit=30)\n",
     "annotated_elements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf903e2",
+   "metadata": {},
+   "source": [
+    "### Table 10 - Distance distribution between dependent files\n",
+    "\n",
+    "This table shows the file directory distance distribution between dependent files. Intuitively, the distance is given by the fewest number of change directory commands needed to navigate between a file and a dependency it uses. Those are aggregate to see how many dependent files are in the same directory, how many are just one change directory command apart, and so on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b86a804",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_first_non_empty_cypher_to_data_frame(\"../cypher/Internal_Dependencies/Get_file_distance_as_shortest_contains_path_for_dependencies.cypher\",\n",
+    "                                           \"../cypher/Internal_Dependencies/Set_file_distance_as_shortest_contains_path_for_dependencies.cypher\", limit=20)"
    ]
   }
  ],

--- a/jupyter/InternalDependenciesTypescript.ipynb
+++ b/jupyter/InternalDependenciesTypescript.ipynb
@@ -73,6 +73,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bb3646d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_first_non_empty_cypher_to_data_frame(*filenames : str, limit: int = 10_000):\n",
+    "    \"\"\"\n",
+    "    Executes the Cypher queries of the given files and returns the first result that is not empty.\n",
+    "    If all given file names result in empty results, the last (empty) result will be returned.\n",
+    "    By additionally specifying \"limit=\" the \"LIMIT\" keyword will appended to query so that only the first results get returned.\n",
+    "    \"\"\"    \n",
+    "    result=pd.DataFrame()\n",
+    "    for filename in filenames:\n",
+    "        result=query_cypher_to_data_frame(filename, limit)\n",
+    "        if not result.empty:\n",
+    "            return result\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a56670c9",
    "metadata": {},
    "outputs": [],
@@ -403,6 +424,27 @@
    "source": [
     "used_packages_of_dependent_artifact=query_cypher_to_data_frame(\"../cypher/Internal_Dependencies/How_many_elements_compared_to_all_existing_are_used_by_dependent_modules_for_Typescript.cypher\",limit=30)\n",
     "used_packages_of_dependent_artifact"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d06d91b7",
+   "metadata": {},
+   "source": [
+    "### Table 3c - Distance distribution between dependent files\n",
+    "\n",
+    "This table shows the file directory distance distribution between dependent files. Intuitively, the distance is given by the fewest number of change directory commands needed to navigate between a file and a dependency it uses. Those are aggregate to see how many dependent files are in the same directory, how many are just one change directory command apart, and so on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80166282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_first_non_empty_cypher_to_data_frame(\"../cypher/Internal_Dependencies/Get_file_distance_as_shortest_contains_path_for_dependencies.cypher\",\n",
+    "                                           \"../cypher/Internal_Dependencies/Set_file_distance_as_shortest_contains_path_for_dependencies.cypher\", limit=20)"
    ]
   }
  ],

--- a/scripts/reports/InternalDependenciesCsv.sh
+++ b/scripts/reports/InternalDependenciesCsv.sh
@@ -21,11 +21,11 @@ echo "InternalDependenciesCsv: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
 
 # Get the "scripts" directory by taking the path of this script and going one directory up.
 SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."} # Repository directory containing the shell scripts
-echo "InternalDependenciesCsv SCRIPTS_DIR=${SCRIPTS_DIR}"
+echo "InternalDependenciesCsv: SCRIPTS_DIR=${SCRIPTS_DIR}"
 
 # Get the "cypher" directory by taking the path of this script and going two directory up and then to "cypher".
 CYPHER_DIR=${CYPHER_DIR:-"${REPORTS_SCRIPT_DIR}/../../cypher"}
-echo "InternalDependenciesCsv CYPHER_DIR=${CYPHER_DIR}"
+echo "InternalDependenciesCsv: CYPHER_DIR=${CYPHER_DIR}"
 
 # Define functions to execute cypher queries from within a given file
 source "${SCRIPTS_DIR}/executeQueryFunctions.sh"
@@ -39,7 +39,15 @@ mkdir -p "${FULL_REPORT_DIRECTORY}"
 CYCLIC_DEPENDENCIES_CYPHER_DIR="${CYPHER_DIR}/Cyclic_Dependencies"
 INTERNAL_DEPENDENCIES_CYPHER_DIR="${CYPHER_DIR}/Internal_Dependencies"
 
-# Cyclic Dependencies Java
+# Calculate the fewest number of change directory commands needed between dependent files as a distance metric
+echo "InternalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Calculating distance between dependent files..."
+execute_cypher_queries_until_results "${INTERNAL_DEPENDENCIES_CYPHER_DIR}/Get_file_distance_as_shortest_contains_path_for_dependencies.cypher" \
+                                     "${INTERNAL_DEPENDENCIES_CYPHER_DIR}/Set_file_distance_as_shortest_contains_path_for_dependencies.cypher" \
+                                     > "${FULL_REPORT_DIRECTORY}/Distance_distribution_between_dependent_files.csv"
+
+# Internal Dependencies for Java
+echo "InternalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing internal dependencies for Java..."
+
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies.csv"
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies_Breakdown.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies_Breakdown.csv"
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies_Breakdown_Backward_Only.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies_Breakdown_Backward_Only.csv"
@@ -53,6 +61,8 @@ execute_cypher "${INTERNAL_DEPENDENCIES_CYPHER_DIR}/How_many_packages_compared_t
 execute_cypher "${INTERNAL_DEPENDENCIES_CYPHER_DIR}/How_many_classes_compared_to_all_existing_in_the_same_package_are_used_by_dependent_packages_across_different_artifacts.cypher" > "${FULL_REPORT_DIRECTORY}/ClassesPerPackageUsageAcrossArtifacts.csv"
 
 # Internal Dependencies for TypeScript
+echo "InternalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing internal dependencies for TypeScript..."
+
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies_for_Typescript.csv"
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies_Breakdown_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies_Breakdown_for_Typescript.csv"
 execute_cypher "${CYCLIC_DEPENDENCIES_CYPHER_DIR}/Cyclic_Dependencies_Breakdown_Backward_Only_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/Cyclic_Dependencies_Breakdown_Backward_Only_for_Typescript.csv"
@@ -63,3 +73,5 @@ execute_cypher "${INTERNAL_DEPENDENCIES_CYPHER_DIR}/How_many_elements_compared_t
 
 # Clean-up after report generation. Empty reports will be deleted.
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"
+
+echo "InternalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Successfully finished."


### PR DESCRIPTION
### 🚀 Feature

- [Add file distance to DEPENDS_ON relationships](https://github.com/JohT/code-graph-analysis-pipeline/pull/184/commits/4203f104097240477c9523260e198c1701ed424a). Now, internal dependencies reports also include a table that shows how dependencies between files are distributed regarding their folder structure distance measured in the fewest number of change directory commands needed.