### PR TITLE
Support npm package.json files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -116,6 +116,18 @@
       "depNameTemplate": "jQAssistant/jqa-commandline-tool",
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^REL-?(?<version>.*?)$"
+    },
+    {
+      "fileMatch": [
+        "^scripts\/profiles\/Neo4jv5\\.sh$",
+        "^scripts\/profiles\/Default\\.sh$",
+        "^scripts\/[^\/]*\\.sh$"
+      ],
+      "matchStrings": [
+        "npx --yes @jqassistant/ts-lce@?(?<currentValue>.*?)"
+      ],
+      "depNameTemplate": "jqassistant-plugin/jqassistant-typescript-plugin",
+      "datasourceTemplate": "github-tags"
     }
   ]
 }

--- a/scripts/configuration/template-neo4jv4-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv4-jqassistant.yaml
@@ -26,7 +26,13 @@ jqassistant:
   #    version:
   #    classifier:
   #    type:
-
+  plugins:
+    - group-id: org.jqassistant.plugin.typescript
+      artifact-id: jqassistant-typescript-plugin
+      version: 1.0.0-RC1
+    - group-id: org.jqassistant.plugin
+      artifact-id: jqassistant-npm-plugin
+      version: 2.0.0
   # The store configuration
   store:
     # URI of the database to connect to. Supported URI schemes are 'file' for embedded databases and 'bolt' for connecting to a running Neo4j instance (3.x+), e.g.

--- a/scripts/configuration/template-neo4jv5-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv5-jqassistant.yaml
@@ -30,7 +30,10 @@ jqassistant:
     - group-id: org.jqassistant.plugin.typescript
       artifact-id: jqassistant-typescript-plugin
       version: 1.0.0-RC1
-
+    - group-id: org.jqassistant.plugin
+      artifact-id: jqassistant-npm-plugin
+      version: 2.0.0
+      
   # The store configuration
   store:
     # URI of the database to connect to. Supported URI schemes are 'file' for embedded databases and 'bolt' for connecting to a running Neo4j instance (3.x+), e.g.

--- a/scripts/copyPackageJsonFiles.sh
+++ b/scripts/copyPackageJsonFiles.sh
@@ -3,6 +3,8 @@
 # Copies all package.json files inside the source directory into the artifacts/npm-package-json directory.
 # It retains the original folder structure where the package.json files were in.
 
+# This script "jq" ( https://stedolan.github.io/jq ).
+
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
@@ -21,6 +23,7 @@ fi
     cd "./${SOURCE_DIRECTORY}"
     
     echo "copyPackageJsonFiles: Existing package.json files will be copied from from ${SOURCE_DIRECTORY} to ../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}"
+    echo "copyPackageJsonFiles: Author will be removed as workaround for https://github.com/jqassistant-plugin/jqassistant-npm-plugin/issues/5"
     
     for file in $( find . -path ./node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
         fileDirectory=$(dirname "${file}")
@@ -29,5 +32,11 @@ fi
 
         mkdir -p "${targetDirectory}"
         cp "${file}" "${targetDirectory}"
+
+        # Workaround until the following issue is resolved:
+        # https://github.com/jqassistant-plugin/jqassistant-npm-plugin/issues/5
+        fileName=$(basename "${file}")
+        jq 'del(.author)' "${targetDirectory}/${fileName}" > "${targetDirectory}/${fileName}.edited"
+        jq 'del(.contributors)' "${targetDirectory}/${fileName}.edited" > "${targetDirectory}/${fileName}"
     done
 )

--- a/scripts/copyPackageJsonFiles.sh
+++ b/scripts/copyPackageJsonFiles.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copies all package.json files inside the source directory into the artifacts/npm-package-json directory.
+# It retains the original folder structure where the package.json files were in.
+
+# Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
+set -o errexit -o pipefail
+
+# Overrideable Defaults
+ARTIFACTS_DIRECTORY=${ARTIFACTS_DIRECTORY:-"artifacts"}
+SOURCE_DIRECTORY=${SOURCE_DIRECTORY:-"source"}
+NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY=${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY:-"npm-package-json"} # Subdirectory of "artifacts" containing the npm package.json files to scan
+
+# Check if the repository is actually a git repository
+if [ ! -d "${SOURCE_DIRECTORY}" ]; then
+  echo "copyPackageJsonFiles: No ${SOURCE_DIRECTORY} directory. Skipping copy of package.json files."
+  return 0
+fi
+
+(
+    cd "./${SOURCE_DIRECTORY}"
+    
+    echo "copyPackageJsonFiles: Existing package.json files will be copied from from ${SOURCE_DIRECTORY} to ../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}"
+    
+    for file in $( find . -path ./node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
+        fileDirectory=$(dirname "${file}")
+        targetDirectory="../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}/${fileDirectory}"
+        # echo "copyPackageJsonFiles: Copying ${file} to ${targetDirectory}"
+
+        mkdir -p "${targetDirectory}"
+        cp "${file}" "${targetDirectory}"
+    done
+)

--- a/scripts/downloader/downloadTypescriptProject.sh
+++ b/scripts/downloader/downloadTypescriptProject.sh
@@ -161,7 +161,7 @@ fi
   cd "${fullSourceDirectory}" || exit
   usePackageManagerToInstallDependencies
   echo "downloadTypescriptProject: Scanning Typescript source using @jqassistant/ts-lce..."
-  npx --yes @jqassistant/ts-lce >"./../../runtime/logs/jqassistant-typescript-scan-${projectName}.log" 2>&1 || exit
+  npx --yes @jqassistant/ts-lce@1.2.0 >"./../../runtime/logs/jqassistant-typescript-scan-${projectName}.log" 2>&1 || exit
 )
 echo "downloadTypescriptProject: Moving scanned results into the artifacts/typescript directory..."
 mkdir -p artifacts/typescript

--- a/scripts/importGit.sh
+++ b/scripts/importGit.sh
@@ -140,6 +140,9 @@ postAggregatedGitLogImport() {
   execute_cypher "${GIT_LOG_CYPHER_DIR}/Set_number_of_aggregated_git_commits.cypher"
 }
 
+# Create import directory in case it doesn't exist.
+mkdir -p "${IMPORT_DIRECTORY}"
+
 # Internal constants
 NEO4J_FULL_IMPORT_DIRECTORY=$(cd "${IMPORT_DIRECTORY}"; pwd)
 

--- a/scripts/resetAndScanChanged.sh
+++ b/scripts/resetAndScanChanged.sh
@@ -4,7 +4,7 @@
 
 # Note: "resetAndScan" expects jQAssistant to be installed in the "tools" directory.
 
-# Requires resetAndScan.sh
+# Requires resetAndScan.sh, copyPackageJsonFiles.sh
 
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
@@ -15,6 +15,9 @@ set -o errexit -o pipefail
 # This way non-standard tools like readlink aren't needed.
 SCRIPTS_DIR=${SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )} # Repository directory containing the shell scripts
 echo "resetAndScanChanged SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Copy 
+source "${SCRIPTS_DIR}/copyPackageJsonFiles.sh"
 
 # Scan and analyze Artifacts when they were changed
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedArtifacts.sh" --readonly)


### PR DESCRIPTION
### 🚀 Feature

- [Support npm package.json file scan](https://github.com/JohT/code-graph-analysis-pipeline/pull/185/commits/6eb4fb25f46a18405d52a9fd5bc979d0267f2f27). Now, the `package.json` file of NPM (and compatible package managers) is also supported and scanned by [jqassistant-npm-plugin](https://github.com/jqassistant-plugin/jqassistant-npm-plugin). This makes it easy to query `package.json` dependencies, dev dependencies, peer dependencies, scripts, ...
- [Add jQAssistant npm plugin to the configuration](https://github.com/JohT/code-graph-analysis-pipeline/pull/185/commits/f4aef0111ef9d1889ab486b0abc9bc00477c7f36)

### ⚙️ Optimization

- [Use pinned version for jQAssistant Typescript npm package](https://github.com/JohT/code-graph-analysis-pipeline/pull/185/commits/5ed9f0c24548f159c1fdff92f5e275c2235a28c9). Typescript project were previously scanned with the latest version of [@jqassistant/ts-lce](https://www.npmjs.com/package/@jqassistant/ts-lce). Now, this is done with a concrete (pinned) version number which is tracked by Renovate. This makes the Typescript scanning part of the pipeline reproducible.

### 🛠 Fix

- [Fix npm package.json scan error by removing the author and contributors](https://github.com/JohT/code-graph-analysis-pipeline/pull/185/commits/27c71d3d10c57927251e63737281ac924c42c574).
- [Create the import directory if it's missing](https://github.com/JohT/code-graph-analysis-pipeline/pull/185/commits/67ac1b4ff419a4f323f59fde385c59c98a982d7d). If no new Neo4j setup is needed and the import directory is missing then it will be created while importing git data so it doesn't fail because of the missing import directory.