### PR TITLE
Support Typescript scan for existing sources without clone

### DIFF
--- a/.github/workflows/typescript-code-analysis.yml
+++ b/.github/workflows/typescript-code-analysis.yml
@@ -106,6 +106,10 @@ jobs:
       shell: bash -el {0}
       run: conda info
 
+    - name: Conda environment list updates
+      shell: bash -el {0}
+      run: conda update --all --dry-run | grep -Fe '-->'
+
     - name: Setup temp directory if missing
       run: mkdir -p ./temp
 

--- a/scripts/copyPackageJsonFiles.sh
+++ b/scripts/copyPackageJsonFiles.sh
@@ -38,5 +38,6 @@ fi
         fileName=$(basename "${file}")
         jq 'del(.author)' "${targetDirectory}/${fileName}" > "${targetDirectory}/${fileName}.edited"
         jq 'del(.contributors)' "${targetDirectory}/${fileName}.edited" > "${targetDirectory}/${fileName}"
+        rm -f "${targetDirectory}/${fileName}.edited"
     done
 )

--- a/scripts/copyPackageJsonFiles.sh
+++ b/scripts/copyPackageJsonFiles.sh
@@ -25,7 +25,7 @@ fi
     echo "copyPackageJsonFiles: Existing package.json files will be copied from from ${SOURCE_DIRECTORY} to ../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}"
     echo "copyPackageJsonFiles: Author will be removed as workaround for https://github.com/jqassistant-plugin/jqassistant-npm-plugin/issues/5"
     
-    for file in $( find . -path ./node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
+    for file in $( find . -type d -name node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
         fileDirectory=$(dirname "${file}")
         targetDirectory="../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}/${fileDirectory}"
         # echo "copyPackageJsonFiles: Copying ${file} to ${targetDirectory}"

--- a/scripts/downloader/downloadTypescriptProject.sh
+++ b/scripts/downloader/downloadTypescriptProject.sh
@@ -6,7 +6,7 @@
 # After scanning it with jQAssistant's Typescript Plugin, the resulting JSON will be moved into the "artifacts/typescript" directory.
 
 # Command line options:
-# --url             Git clone URL (required)
+# --url             Git clone URL (optional, default = skip clone)
 # --version         Version of the project
 # --tag             Tag to switch to after "git clone" (optional, default = version)
 # --project         Name of the project/repository (optional, default = clone url file name without .git extension)
@@ -25,9 +25,9 @@ echo "downloadTypescriptProject: SOURCE_DIRECTORY=${SOURCE_DIRECTORY}"
 usage() {
   echo ""
   echo "Usage: $0 \\"
-  echo "          --url <git-clone-url> \\"
   echo "          --version <project version \\"
   echo "          [ --tag <git-tag-for-that-version> (default=version) \\]"
+  echo "          [ --url <git-clone-url> (default=skip clone)] \\"
   echo "          [ --project <name-of-the-project> (default=url file name) \\]"
   echo "          [ --packageManager <npm/pnpm/yarn> (default=npm) ]"
   echo "Example: $0 \\"
@@ -77,28 +77,34 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ -z ${cloneUrl} ]]; then
-  echo "downloadTypescriptProject Error: Please specify an URL for git clone."
-  usage
+if [ -n "${cloneUrl}" ]; then
+  # url specified -> check if valid
+  if ! curl --head --fail "${cloneUrl}" >/dev/null 2>&1; then
+    echo "downloadTypescriptProject Error: Invalid URL: ${cloneUrl}"
+    exit 1
+  fi
+else
+    # url not specified -> check if at least project name specified
+  if [ -z "${projectName}" ]; then
+    echo "downloadTypescriptProject Error: Please specify either an URL or a project name."
+    usage
+  fi
 fi
 
-if ! curl --head --fail "${cloneUrl}" >/dev/null 2>&1; then
-  echo "downloadTypescriptProject Error: Invalid URL: ${cloneUrl}"
-  exit 1
-fi
-
-if [[ -z ${projectName} ]]; then
+if [ -z "${projectName}" ]; then
   # When empty, infer the project name from the file name / last part of the clone url excluding the extension .git
   projectName=$(basename -s .git "${cloneUrl}")
+  echo "downloadTypescriptProject Using ${projectName} as project name from the URL since not specified otherwise."
 fi
 
-if [[ -z ${projectVersion} ]]; then
+if [ -z "${projectVersion}" ]; then
   echo "downloadTypescriptProject Error: Please specify a project version."
   usage
 fi
 
-if [[ -z ${projectTag} ]]; then
+if [ -z "${projectTag}" ]; then
   # When empty, use the value of the option "version" as tag
+  echo "downloadTypescriptProject Using ${projectVersion} as project tag since not specified otherwise."
   projectTag="${projectVersion}"
 fi
 
@@ -152,11 +158,21 @@ mkdir -p ./runtime/logs
 fullProjectName="${projectName}-${projectVersion}"
 fullSourceDirectory="${SOURCE_DIRECTORY}/${fullProjectName}"
 
-if [ ! -d "${fullSourceDirectory}" ] ; then # only clone if source doesn't exist
-  echo "downloadTypescriptProject: Cloning ${cloneUrl} with version ${projectVersion}..."
-  # A full clone is done since not only the source is scanned, but also the git log history.
-  git clone --branch "${projectTag}" "${cloneUrl}" "${fullSourceDirectory}"
+if [ ! -d "${fullSourceDirectory}" ]; then # source doesn't exist
+  if [ -n "${cloneUrl}" ]; then # only clone if url is specified and source doesn't exist 
+    echo "downloadTypescriptProject: Cloning ${cloneUrl} with version ${projectVersion}..."
+    # A full clone is done since not only the source is scanned, but also the git log/history.
+    git clone --branch "${projectTag}" "${cloneUrl}" "${fullSourceDirectory}"
+  else
+    # Source doesn't exist and no clone URL is specified.
+    echo "downloadTypescriptProject: Error: Source directory ${fullSourceDirectory} for project ${projectName} not found."
+    exit 1
+  fi
+else
+  # Source already exists. Cloning not necessary.
+  echo "downloadTypescriptProject: Source already exists. Skip cloning ${cloneUrl}"
 fi
+
 (
   cd "${fullSourceDirectory}" || exit
   usePackageManagerToInstallDependencies


### PR DESCRIPTION
### 🚀 Feature

- [Support Typescript scan without clone if source already exists](https://github.com/JohT/code-graph-analysis-pipeline/pull/191/commits/2b59fbdc1b79b17f4fbf285321949d735514d346). Now, you can also use the script [downloadTypescriptProject.sh](./scripts/downloader/downloadTypescriptProject.sh) to scan already existing sources without the need to clone them first.

### ⚙️ Optimization

- [List available conda package updates](https://github.com/JohT/code-graph-analysis-pipeline/pull/191/commits/6d55930f57916cd04f663da747da42b5cff43032)

### 🛠 Fix

- [Remove temporarily edited files in npm-package-json](https://github.com/JohT/code-graph-analysis-pipeline/pull/191/commits/2dbbf1657432bf24b56bd93e7dc8348096561039).
- [Fix not correctly filtered out node_modules in npm-package-json](https://github.com/JohT/code-graph-analysis-pipeline/pull/191/commits/e6c276f10c7f9a3dd70ca44376c6b8239cec17e5)
