### PR TITLE
Use Renovate to update jQAssistant plugins

### DIFF
--- a/.github/workflows/check-renovate-config.yml
+++ b/.github/workflows/check-renovate-config.yml
@@ -1,0 +1,24 @@
+name: Check Renovate Configuration
+
+on:
+  pull_request:
+    branches:
+      - main
+    # Only watch root level Renovate configuration changes
+    paths:
+      - 'renovate.json*'
+
+jobs:
+  reports:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout GIT Repository
+      uses: actions/checkout@v4
+
+    - name: Setup node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Run renovate-config-validator
+      run: npx --yes --package renovate -- renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,9 @@
     "schedule:earlyMondays"
   ],
   "ignoreUnstable": false,
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "^(workflow-templates|\\.github\/workflows)\\/[^/]+\\.ya?ml$",
         "(^|\\/)action\\.ya?ml$]"
@@ -21,6 +22,7 @@
       "extractVersionTemplate": "^axon-?(?<version>.*?)$"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^(workflow-templates|\\.github\/workflows)\\/[^/]+\\.ya?ml$",
         "(^|\\/)action\\.ya?ml$]"
@@ -33,6 +35,7 @@
       "extractVersionTemplate": "^react-router@?(?<version>.*?)$"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "README.md"
       ],
@@ -44,6 +47,7 @@
       "extractVersionTemplate": "^axon-?(?<version>.*?)$"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^(workflow-templates|\\.github\/workflows)\\/[^/]+\\.ya?ml$",
         "(^|\\/)action\\.ya?ml$]"
@@ -55,6 +59,7 @@
       "datasourceTemplate": "github-releases"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/profiles\/Neo4jv5\\.sh$",
         "^scripts\/profiles\/Default\\.sh$",
@@ -67,6 +72,7 @@
       "datasourceTemplate": "github-tags"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/profiles\/Neo4jv5\\.sh$",
         "^scripts\/profiles\/Default\\.sh$",
@@ -79,6 +85,7 @@
       "datasourceTemplate": "github-releases"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/profiles\/Neo4jv5\\.sh$",
         "^scripts\/profiles\/Default\\.sh$",
@@ -91,6 +98,7 @@
       "datasourceTemplate": "github-releases"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/profiles\/Neo4jv5\\.sh$",
         "^scripts\/profiles\/Default\\.sh$",
@@ -105,6 +113,7 @@
       "versioningTemplate": "loose"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/profiles\/Neo4jv5\\.sh$",
         "^scripts\/profiles\/Default\\.sh$",
@@ -118,6 +127,7 @@
       "extractVersionTemplate": "^REL-?(?<version>.*?)$"
     },
     {
+      "customType": "regex",
       "fileMatch": [
         "^scripts\/[^\/]*\\.sh$"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,22 @@
   "extends": [
     "config:base",
     ":combinePatchMinorReleases",
-    ":ignoreUnstable",
     "schedule:earlyMondays"
   ],
   "ignoreUnstable": false,
+  "packageRules": [
+    {
+      "description": "Neo4j update settings",
+      "matchDepNames": [
+        "neo4j/neo4j"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "minimumReleaseAge": "1 month"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,16 @@
       ],
       "depNameTemplate": "jqassistant-plugin/jqassistant-typescript-plugin",
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "fileMatch": [
+        "^scripts\/configuration\/*\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s*\\-\\s+group-id:\\s*(?<group>.*?)\\s*[\r\n]\\s*artifact-id:\\s*(?<artifact>.*?)\\s*[\r\n]\\s*version:\\s*(?<currentValue>.*?)\\s*[\r\n]"
+      ],
+      "depNameTemplate": "{{{group}}}:{{{artifact}}}",
+      "datasourceTemplate": "maven"
     }
   ]
 }


### PR DESCRIPTION
### ⚙️ Optimization

- [Migrate to Renovate custom managers](https://github.com/JohT/code-graph-analysis-pipeline/pull/198/commits/ddfc0e9c12eb602205e437c3feca3b520cabc7fa)
- [Use Renovate to update jQAssistant plugins in config](https://github.com/JohT/code-graph-analysis-pipeline/pull/198/commits/7d7f6cd9bd574691dc8a63eb6bbb3b5c0a234397)
- [Delay Neo4j updates for 1 month.](https://github.com/JohT/code-graph-analysis-pipeline/pull/198/commits/13734392211c94214d825630579b3f7b2517fcde). The intention is to wait until corresponding graph-data-science updates are available.
- [Add Renovate configuration check to pipeline](https://github.com/JohT/code-graph-analysis-pipeline/pull/198/commits/15f3e0bd20786760a79378d44ac046ca78bec2f9)