### PR TITLE
Auto detect latest git tag if no version is specified

### DIFF
--- a/scripts/copyPackageJsonFiles.sh
+++ b/scripts/copyPackageJsonFiles.sh
@@ -25,7 +25,7 @@ fi
     echo "copyPackageJsonFiles: Existing package.json files will be copied from from ${SOURCE_DIRECTORY} to ../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}"
     echo "copyPackageJsonFiles: Author will be removed as workaround for https://github.com/jqassistant-plugin/jqassistant-npm-plugin/issues/5"
     
-    for file in $( find . -type d -name node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
+    for file in $( find -L . -type d -name node_modules -prune -o -name 'package.json' -print0 | xargs -0 -r -I {}); do
         fileDirectory=$(dirname "${file}")
         targetDirectory="../${ARTIFACTS_DIRECTORY}/${NPM_PACKAGE_JSON_ARTIFACTS_DIRECTORY}/${fileDirectory}"
         # echo "copyPackageJsonFiles: Copying ${file} to ${targetDirectory}"

--- a/scripts/downloader/downloadAntDesign.sh
+++ b/scripts/downloader/downloadAntDesign.sh
@@ -24,7 +24,7 @@ echo "downloadAntDesign: projectVersion=${projectVersion}"
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 DOWNLOADER_SCRIPTS_DIR=${DOWNLOADER_SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
-echo "downloadReactRouter: DOWNLOADER_SCRIPTS_DIR=${DOWNLOADER_SCRIPTS_DIR}"
+echo "downloadAntDesign: DOWNLOADER_SCRIPTS_DIR=${DOWNLOADER_SCRIPTS_DIR}"
 
 source "${DOWNLOADER_SCRIPTS_DIR}/downloadTypescriptProject.sh" \
   --url https://github.com/ant-design/ant-design.git \

--- a/scripts/examples/analyzeAntDesign.sh
+++ b/scripts/examples/analyzeAntDesign.sh
@@ -5,16 +5,19 @@
 
 # Note: The first (and only) parameter is the version of "ant-design" to analyze.
 # Note: This script is meant to be started in the root directory of this repository.
+# Note: This script requires "cURL" ( https://curl.se ) to be installed.
 
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
-# Read the first input argument containing the version of the artifacts
-if [ "$#" -ne 1 ]; then
-  echo "analyzerAntDesign Error: Usage: $0 <version>" >&2
-  exit 1
-fi
+# Read the first input argument containing the version of the project
 projectVersion=$1
+if [ -z "${projectVersion}" ]; then
+  echo "analyzerAntDesign: Optional parameter <version> is not specified. Detecting latest version..." >&2
+  echo "analyzerAntDesign: Usage example: $0 <version>" >&2
+  projectVersion=$( ./../../scripts/examples/detectLatestGitTag.sh --url "https://github.com/ant-design/ant-design.git" )
+  echo "analyzerAntDesign: Using latest version: ${projectVersion}" >&2
+fi
 
 # Check if environment variable is set
 if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then

--- a/scripts/examples/analyzeAxonFramework.sh
+++ b/scripts/examples/analyzeAxonFramework.sh
@@ -9,16 +9,17 @@
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
-# Read the first input argument containing the version of the artifacts
-if [ "$#" -ne 1 ]; then
-  echo "analyzeAxonFramework Error: Usage: $0 <version>" >&2
-  exit 1
-fi
 artifactsVersion=$1
+if [ -z "${artifactsVersion}" ]; then
+  echo "analyzeAxonFramework: Optional parameter <version> is not specified. Detecting latest version..." >&2
+  echo "analyzeAxonFramework: Usage example: $0 <version>" >&2
+  artifactsVersion=$( ./../../scripts/examples/detectLatestGitTag.sh --url "https://github.com/AxonFramework/AxonFramework.git" --prefix "axon-")
+  echo "analyzeAxonFramework: Using latest version: ${artifactsVersion}" >&2
+fi
 
 # Check if environment variable is set
 if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then
-    echo "analyzeAxonFramework: Error: Requires environment variable NEO4J_INITIAL_PASSWORD to be set first. Use 'export NEO4J_INITIAL_PASSWORD=<your-own-password>'."
+    echo "analyzeAxonFramework: Error: Requires environment variable NEO4J_INITIAL_PASSWORD to be set first. Use 'export NEO4J_INITIAL_PASSWORD=<your-own-password>'." >&2
     exit 1
 fi
 

--- a/scripts/examples/analyzeReactRouter.sh
+++ b/scripts/examples/analyzeReactRouter.sh
@@ -9,12 +9,14 @@
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
-# Read the first input argument containing the version of the artifacts
-if [ "$#" -ne 1 ]; then
-  echo "analyzerReactRouter Error: Usage: $0 <version>" >&2
-  exit 1
-fi
+# Read the first input argument containing the version of the project
 projectVersion=$1
+if [ -z "${projectVersion}" ]; then
+  echo "analyzerReactRouter: Optional parameter <version> is not specified. Detecting latest version..." >&2
+  echo "analyzerReactRouter: Usage example: $0 <version>" >&2
+  projectVersion=$( ./../../scripts/examples/detectLatestGitTag.sh --url "https://github.com/remix-run/react-router.git" )
+  echo "analyzerReactRouter: Using latest version: ${projectVersion}" >&2
+fi
 
 # Check if environment variable is set
 if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then

--- a/scripts/examples/detectLatestGitTag.sh
+++ b/scripts/examples/detectLatestGitTag.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Returns the latest tag of a remote repository given by its url.
+
+# Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
+set -o errexit -o pipefail
+
+# Display how this command is intended to be used including an example when wrong input parameters were detected
+usage() {
+  echo "" >&2
+  echo "Usage:   $0 --url <git-clone-url> [--prefix <tag prefix to ignore>]" >&2
+  echo "Example: $0 --url https://github.com/ant-design/ant-design.git" >&2
+  exit 1
+}
+
+# Default command line option values
+url=""
+prefix=""
+
+# Parse command line options
+while [[ $# -gt 0 ]]; do
+  key="${1}"
+  value="${2}"
+
+  case "${key}" in
+    --url)
+      url="${value}"
+      shift
+      ;;
+    --prefix)
+      prefix="${value}"
+      shift
+      ;;
+    *)
+      echo "detectLatestVersion Error: Unknown option: ${key}" >&2
+      usage
+      ;;
+  esac
+  shift
+done
+
+if [ -n "${url}" ]; then
+  # url specified -> check if it is a valid URL
+  if ! curl --head --fail --max-time 20 "${url}" >/dev/null 2>&1; then
+    echo "detectLatestVersion Error: Invalid URL: ${url}" >&2
+    exit 1
+  fi
+else
+  echo "detectLatestVersion: Error: Please specify an url." >&2
+fi
+
+if [ -n "${prefix}" ]; then
+  echo "detectLatestVersion: Ignoring tag prefix '${prefix}'." >&2
+fi
+
+
+# Check if the command succeeded
+if ! projectVersion=$( git ls-remote --sort "-version:refname" --tags "${url}" \
+                     | grep -E "refs/tags/${prefix:-.*}[0-9]+.*\w$" \
+                     | sed -n '1p' \
+                     | sed "s/.*\/${prefix}//" \
+                     )
+then
+  redColor='\033[0;31m'
+  noColor='\033[0m'
+  echo -e "${redColor}detectLatestVersion: Error: Failed to detect latest git tag for ${url}($?):${noColor}" >&2
+  echo -e "${redColor}${projectVersion}${noColor}" >&2
+  exit 1
+fi
+# echo "detectLatestVersion: Detected latest version ${projectVersion} for ${url}." >&2
+
+# # Retrieve latest release from GitHub API 
+# # Extract the owner and repo of the url 
+# url_without_github_domain="${url#https://github.com/}"
+# owner_and_repo="${url_without_github_domain%.*}"
+# github_latest_release_endpoint_url="https://api.github.com/repos/${owner_and_repo}/releases/latest"
+#
+# if ! projectVersion=$( curl --silent --fail-with-body "${github_latest_release_endpoint_url}" \
+#                      | grep '"tag_name":' \
+#                      | sed -E 's/.*"([^"]+)".*/\1/'\
+#                      )
+# then
+#   redColor='\033[0;31m'
+#   noColor='\033[0m'
+#   echo -e "${redColor}detectLatestVersion: Error: Failed to detect latest version for ${github_latest_release_endpoint_url}($?):${noColor}" >&2
+#   echo -e "${redColor}${projectVersion}${noColor}" >&2
+#   exit 1
+# fi
+#
+# echo "detectLatestVersion: Detected latest GitHub release ${projectVersion} for ${github_latest_release_endpoint_url}." >&2
+
+# Print the latest version as result
+echo "${projectVersion}"


### PR DESCRIPTION
### 🚀 Feature

- [Follow symbolic links when collecting package.json files](https://github.com/JohT/code-graph-analysis-pipeline/pull/208/commits/6e47610f80e579d3d3662e17ff813a3ba6ded09f). If you use symbolic links in the "source" directory to avoid copying git repositories you might already have downloaded, the package.json files will now be detected correctly.
- [Auto detect latest tag if no version is specified](https://github.com/JohT/code-graph-analysis-pipeline/pull/208/commits/dfdab2c4ddb96143c92486314128f0204afdc3fd). If you are using the example analysis scripts like 
[analyzeAxonFramework.sh](https://github.com/JohT/code-graph-analysis-pipeline/blob/6f61826826d57e7999eeed92f3a81f7f02e5228f/scripts/examples/analyzeAxonFramework.sh), [analyzeAntDesign.sh](https://github.com/JohT/code-graph-analysis-pipeline/blob/6f61826826d57e7999eeed92f3a81f7f02e5228f/scripts/examples/analyzeAntDesign.sh), [analyzeReactRouter.sh](https://github.com/JohT/code-graph-analysis-pipeline/blob/6f61826826d57e7999eeed92f3a81f7f02e5228f/scripts/examples/analyzeReactRouter.sh), then you don't have to specify the version number. In case it isn't given, the latest git tag will be automatically detected and used for that.

### 🛠 Fix

- [Fix typo in info log entry](https://github.com/JohT/code-graph-analysis-pipeline/pull/208/commits/b344a951a65579f8ffd63d54a2c931de39654800).
