### PR TITLE
Add statistics about resolved external Typescript modules

### DIFF
--- a/cypher/External_Dependencies/List_external_modules_resolved_to_internal_ones_for_Typescript.cypher
+++ b/cypher/External_Dependencies/List_external_modules_resolved_to_internal_ones_for_Typescript.cypher
@@ -1,0 +1,18 @@
+// Statistics about how many ExternalModule nodes were found that match internal Module nodes 
+
+ MATCH (module:TS:Module)<-[resolved:RESOLVES_TO]-(external:TS:ExternalModule)
+OPTIONAL MATCH (project:TS:Project)-[:CONTAINS]->(module)
+  WITH project.name                               AS projectName
+      ,count(DISTINCT module)                     AS resolvedModuleCount
+      ,COUNT { (modules:Module) }                 AS totalModuleCount
+      ,COUNT { (externalModules:ExternalModule) } AS totalExternalModuleCount
+      ,collect(DISTINCT module.fileName + ' -> ' + external.globalFqn)[0..4] AS resolvedExamples
+RETURN projectName
+      ,resolvedModuleCount
+      ,totalModuleCount
+      ,round(100.0 / totalModuleCount 
+                   * resolvedModuleCount, 2) AS resolvedModulePercentage 
+      ,totalExternalModuleCount
+      ,round(100.0 / totalExternalModuleCount 
+                   * resolvedModuleCount, 2) AS resolvedExternalModulePercentage 
+      ,resolvedExamples

--- a/scripts/reports/ExternalDependenciesCsv.sh
+++ b/scripts/reports/ExternalDependenciesCsv.sh
@@ -72,5 +72,7 @@ execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_namespace_usage_per
 execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_module_usage_per_internal_module_aggregated_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/External_module_usage_per_internal_module_aggregated_for_Typescript.csv"
 execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/External_module_usage_per_internal_module_distribution_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/External_module_usage_per_internal_module_distribution_for_Typescript.csv"
 
+execute_cypher "${EXTERNAL_DEPENDENCIES_CYPHER_DIR}/List_external_modules_resolved_to_internal_ones_for_Typescript.cypher" > "${FULL_REPORT_DIRECTORY}/External_modules_resolved_to_internal_ones_for_Typescript.csv"
+
 # Clean-up after report generation. Empty reports will be deleted.
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"


### PR DESCRIPTION
### 🚀 Feature

- [Add statistics about resolved external Typescript modules](https://github.com/JohT/code-graph-analysis-pipeline/pull/215/commits/796ab563b0cc373b8b5fb47abd19b96cdf9e58a0). Now, the external dependencies report file `External_modules_resolved_to_internal_ones_for_Typescript.csv` contains the overall statistics about how many ExternalModule nodes were matched/resolved to Module nodes for every Typescript project.