### PR TITLE
Introduce path finding algorithm reports

### DIFF
--- a/cypher/Artifact_Dependencies/Artifacts_with_dependencies_to_other_artifacts.cypher
+++ b/cypher/Artifact_Dependencies/Artifacts_with_dependencies_to_other_artifacts.cypher
@@ -1,4 +1,4 @@
-// Artifacts with dependencies to other artifacts
+// Artifacts with dependencies to other artifacts. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]->(packageInArtifact:Package)
 MATCH (packageInArtifact)-[:CONTAINS]->(typeInPackage:Type)
@@ -6,7 +6,7 @@ MATCH (typeInPackage)-[:DEPENDS_ON]->(dependencyType:Type)
 MATCH (dependencyPackage:Package)-[:CONTAINS]->(dependencyType)
 MATCH (dependencyArtifact:Artifact)-[:CONTAINS]->(dependencyPackage)
 WHERE artifact.fileName <> dependencyArtifact.fileName
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,artifact.numberOfPackages               AS packagesInArtifactCount
      ,artifact.numberOfTypes                  AS typesInArtifactCount
      ,collect(DISTINCT packageInArtifact.fqn) AS packages
@@ -19,7 +19,7 @@ WHERE artifact.fileName <> dependencyArtifact.fileName
      ,round(100.0 / artifact.numberOfTypes 
                   * count(DISTINCT typeInPackage.fqn)
            , 2)                               AS typesSpread 
-     ,replace(last(split(dependencyArtifact.fileName, '/')), '.jar', '') AS dependencyArtifactName
+     ,dependencyArtifact.name AS dependencyArtifactName
 // additionally group by if the dependency is an interface or not
      ,dependencyType:Interface                AS dependencyTypeIsInterface 
      ,collect(DISTINCT dependencyPackage.fqn) AS dependencyPackages

--- a/cypher/Artifact_Dependencies/Artifacts_with_duplicate_packages.cypher
+++ b/cypher/Artifact_Dependencies/Artifacts_with_duplicate_packages.cypher
@@ -1,9 +1,9 @@
-// Artifacts with the same full qualified package name (duplicate packages). These can lead to confusion and provide access to package protected classes to another artifact that might not be intended.
+// Artifacts with the same full qualified package name (duplicate packages). These can lead to confusion and provide access to package protected classes to another artifact that might not be intended. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  WHERE EXISTS ((package)-[:CONTAINS]->(:Type))
   WITH package.fqn AS packageName
-      ,replace(last(split(artifact.fileName, '/')), '.jar', '') as artifactName
+      ,artifact.name as artifactName
   WITH packageName
       ,collect(DISTINCT artifactName) AS artifactNames
       ,count(*) AS duplicates 

--- a/cypher/Artifact_Dependencies/Most_used_internal_dependencies_acreoss_artifacts.cypher
+++ b/cypher/Artifact_Dependencies/Most_used_internal_dependencies_acreoss_artifacts.cypher
@@ -1,13 +1,13 @@
-// Most used internal dependencies across artifacts
+// Most used internal dependencies across artifacts. Requires "Add_file_name and_extension.cypher".
 
 MATCH (type:Type)-[:DEPENDS_ON]->(dependencyType:Type)
 MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)-[:CONTAINS]->(type:Type)
 MATCH (dependencyArtifact:Artifact)-[:CONTAINS]->(dependencyPackage:Package)-[:CONTAINS]->(dependencyType)
 WHERE artifact.fileName <> dependencyArtifact.fileName
- WITH replace(last(split(dependencyArtifact.fileName, '/')), '.jar', '')    AS dependencyArtifactName
+ WITH dependencyArtifact.name    AS dependencyArtifactName
      ,COLLECT(DISTINCT dependencyPackage.fqn)                               AS dependencyPackageNames
      ,COLLECT(DISTINCT dependencyType.name)                                 AS dependencyTypeNames
-     ,COLLECT(DISTINCT replace(last(split(artifact.fileName, '/')), '.jar', '')) AS artifactNames
+     ,COLLECT(DISTINCT artifact.name) AS artifactNames
      ,COUNT(DISTINCT package.fqn)                                           AS numberOfPackages
      ,COUNT(DISTINCT type.fqn)                                              AS numberOfTypes
      ,COUNT(DISTINCT dependencyType)                                        AS numberOfDependencyTypes

--- a/cypher/Artifact_Dependencies/Usage_and_spread_of_internal_artifact_dependencies.cypher
+++ b/cypher/Artifact_Dependencies/Usage_and_spread_of_internal_artifact_dependencies.cypher
@@ -1,4 +1,4 @@
-// Usage and spread of internal artifact dependencies
+// Usage and spread of internal artifact dependencies. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]->(packageInArtifact:Package)
 MATCH (packageInArtifact)-[:CONTAINS]->(typeInPackage:Type)
@@ -6,7 +6,7 @@ MATCH (typeInPackage)-[:DEPENDS_ON]->(dependencyType:Type)
 MATCH (dependencyPackage:Package)-[:CONTAINS]->(dependencyType)
 MATCH (dependencyArtifact:Artifact)-[:CONTAINS]->(dependencyPackage)
 WHERE artifact.fileName <> dependencyArtifact.fileName
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,artifact.numberOfPackages                AS packagesInArtifactCount
      ,artifact.numberOfTypes                   AS typesInArtifactCount
      ,collect(DISTINCT packageInArtifact.fqn)  AS packages
@@ -19,7 +19,7 @@ WHERE artifact.fileName <> dependencyArtifact.fileName
      ,(100.0 
        / artifact.numberOfTypes 
        * count(DISTINCT typeInPackage.fqn))     AS typesSpread 
-     ,replace(last(split(dependencyArtifact.fileName, '/')), '.jar', '') AS dependencyArtifactName
+     ,dependencyArtifact.name AS dependencyArtifactName
 // additionally group by if the dependency is an interface or not
      ,dependencyType:Interface                 AS dependencyTypeIsInterface 
      ,collect(DISTINCT dependencyPackage.fqn)  AS dependencyPackages

--- a/cypher/Artifact_Dependencies/Usage_and_spread_of_internal_artifact_dependents.cypher
+++ b/cypher/Artifact_Dependencies/Usage_and_spread_of_internal_artifact_dependents.cypher
@@ -1,4 +1,4 @@
-// Usage and spread of internal artifact dependents
+// Usage and spread of internal artifact dependents. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]->(packageInArtifact:Package)
 MATCH (packageInArtifact)-[:CONTAINS]->(typeInPackage:Type)
@@ -6,7 +6,7 @@ MATCH (typeInPackage)-[:DEPENDS_ON]->(dependencyType:Type)
 MATCH (dependencyPackage:Package)-[:CONTAINS]->(dependencyType)
 MATCH (dependencyArtifact:Artifact)-[:CONTAINS]->(dependencyPackage)
 WHERE artifact.fileName <> dependencyArtifact.fileName
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,artifact.numberOfPackages                AS packagesInArtifactCount
      ,artifact.numberOfTypes                   AS typesInArtifactCount
      ,collect(DISTINCT packageInArtifact.fqn)  AS packages
@@ -19,7 +19,7 @@ WHERE artifact.fileName <> dependencyArtifact.fileName
      ,(100.0 
        / artifact.numberOfTypes 
        * count(DISTINCT typeInPackage.fqn))     AS typesSpread 
-     ,replace(last(split(dependencyArtifact.fileName, '/')), '.jar', '') AS dependencyArtifactName
+     ,dependencyArtifact.name AS dependencyArtifactName
 // additionally group by if the dependency is an interface or not
      ,dependencyType:Interface                 AS dependencyTypeIsInterface 
      ,collect(DISTINCT dependencyPackage.fqn)  AS dependencyPackages

--- a/cypher/Centrality/Centrality_10_Summary.cypher
+++ b/cypher/Centrality/Centrality_10_Summary.cypher
@@ -1,10 +1,10 @@
-// Centrality Summary
+// Centrality Summary. Requires "Add_file_name and_extension.cypher".
 
 MATCH (codeUnit)
 WHERE (codeUnit.incomingDependencies > 0 OR codeUnit.outgoingDependencies > 0)
   AND $dependencies_projection_node IN LABELS(codeUnit) 
 RETURN coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name)      AS name
-      ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortName
+      ,codeUnit.name AS shortName
       ,codeUnit.centralityPageRank                  AS pageRank
       ,codeUnit.centralityArticleRank               AS articleRank
       ,codeUnit.centralityBetweenness               AS betweenness

--- a/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
+++ b/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
@@ -1,4 +1,4 @@
-// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream Mutated
+// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream Mutated. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -11,7 +11,7 @@ YIELD nodeId, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,collect(propertyValue)  AS values
 RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))      AS shortCodeUnitName
+     ,codeUnit.name      AS shortCodeUnitName
      ,values[0] AS centralityHyperlinkInducedTopicSearchAuthority
      ,values[1] AS centralityHyperlinkInducedTopicSearchHub
      ,codeUnit.incomingDependencies AS incomingDependencies

--- a/cypher/Community_Detection/Community_Detection_7d_Modularity_Members.cypher
+++ b/cypher/Community_Detection/Community_Detection_7d_Modularity_Members.cypher
@@ -1,4 +1,4 @@
-// Community Detection Modularity Members
+// Community Detection Modularity Members. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.modularity.stream(
  $dependencies_projection + '-cleaned', {
@@ -13,7 +13,7 @@ CALL gds.modularity.stream(
   WITH modularities 
       ,member[$dependencies_projection_write_property]                               AS communityId
       ,coalesce(member.fqn, member.fileName, member.name)                            AS memberName
-      ,coalesce(member.name, replace(last(split(member.fileName, '/')), '.jar', '')) AS shortMemberName
+      ,member.name AS shortMemberName
   WITH modularities
       ,communityId
       ,count(DISTINCT memberName)        AS memberCount

--- a/cypher/Community_Detection/Community_Detection_8d_Conductance_Members.cypher
+++ b/cypher/Community_Detection/Community_Detection_8d_Conductance_Members.cypher
@@ -1,4 +1,4 @@
-// Community Detection Conductance Members
+// Community Detection Conductance Members. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.conductance.stream(
  $dependencies_projection + '-cleaned', {
@@ -13,7 +13,7 @@ CALL gds.conductance.stream(
   WITH communityMetrics 
       ,member[$dependencies_projection_write_property]                               AS communityId
       ,coalesce(member.fqn, member.fileName, member.name)                            AS memberName
-      ,coalesce(member.name, replace(last(split(member.fileName, '/')), '.jar', '')) AS shortMemberName
+      ,member.name AS shortMemberName
   WITH communityMetrics
       ,communityId
       ,count(DISTINCT memberName)        AS memberCount

--- a/cypher/Community_Detection/Community_Detection_9_Community_Metrics.cypher
+++ b/cypher/Community_Detection/Community_Detection_9_Community_Metrics.cypher
@@ -1,4 +1,4 @@
-// Community Metrics
+// Community Metrics. Requires "Add_file_name and_extension.cypher".
 
   CALL gds.conductance.stream(
  $dependencies_projection + '-cleaned', {
@@ -22,7 +22,7 @@
       ,modularities
       ,member[$dependencies_projection_write_property]                               AS communityId
       ,coalesce(member.fqn, member.fileName, member.name)                            AS memberName
-      ,coalesce(member.name, replace(last(split(member.fileName, '/')), '.jar', '')) AS shortMemberName
+      ,member.name AS shortMemberName
   WITH conductances
       ,modularities
       ,communityId

--- a/cypher/Community_Detection/Community_Detection_Summary.cypher
+++ b/cypher/Community_Detection/Community_Detection_Summary.cypher
@@ -1,10 +1,10 @@
-// Community Detection Summary. Variables: dependencies_projection_node ("Artifact", "Package", "Type")
+// Community Detection Summary. Variables: dependencies_projection_node ("Artifact", "Package", "Type"). Requires "Add_file_name and_extension.cypher".
 
 MATCH (codeUnit)
 WHERE (codeUnit.incomingDependencies > 0 OR codeUnit.outgoingDependencies > 0)
   AND $dependencies_projection_node IN LABELS(codeUnit) 
 RETURN coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name)      AS name
-      ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortName
+      ,codeUnit.name AS shortName
       ,codeUnit.communityLouvainId                  AS louvainId
       ,codeUnit.communityLouvainIntermediateIds     AS louvainIntermediateIds
       ,codeUnit.communityLeidenId                   AS leidenId

--- a/cypher/Community_Detection/Compare_Louvain_vs_Leiden_Results.cypher
+++ b/cypher/Community_Detection/Compare_Louvain_vs_Leiden_Results.cypher
@@ -1,4 +1,4 @@
-// Compare Louvain vs. Leiden Community Detection Results. Variables: dependencies_projection_node (e.g. "Artifact", "Package", "Type")
+// Compare Louvain vs. Leiden Community Detection Results. Variables: dependencies_projection_node (e.g. "Artifact", "Package", "Type"). Requires "Add_file_name and_extension.cypher".
 
  MATCH (member)
  WHERE $dependencies_projection_node IN LABELS(member)
@@ -7,7 +7,7 @@
  WITH member.communityLouvainId    AS louvainCommunityId
      ,member.communityLeidenId     AS leidenCommunityId
      ,coalesce(member.fqn, member.fileName, member.signature, member.name)          AS memberName
-     ,coalesce(member.name, replace(last(split(member.fileName, '/')), '.jar', '')) AS shortMemberName
+     ,member.name AS shortMemberName
  WITH louvainCommunityId
      ,leidenCommunityId
      ,collect(DISTINCT shortMemberName) AS shortMemberNames

--- a/cypher/Community_Detection/Type_communities_that_span_the_most_packages.cypher
+++ b/cypher/Community_Detection/Type_communities_that_span_the_most_packages.cypher
@@ -1,7 +1,7 @@
-// Communities that span the most packages
+// Communities that span the most packages. Requires "Add_file_name and_extension.cypher".
 
  MATCH (a:Artifact)-[:CONTAINS]->(p:Package)-[:CONTAINS]->(t:Type)
-  WITH replace(last(split(a.fileName, '/')), '.jar', '') AS artifactName
+  WITH a.name AS artifactName
       ,t.communityLeidenId                               AS communityId  
       ,collect(DISTINCT p.fqn)                           AS packageNames
       ,count(DISTINCT p.fqn)                             AS packageCount

--- a/cypher/Community_Detection/Type_communities_that_span_the_most_packages_with_type_statistics.cypher
+++ b/cypher/Community_Detection/Type_communities_that_span_the_most_packages_with_type_statistics.cypher
@@ -1,7 +1,7 @@
 // Communities that span the most packages with type statistics
 
  MATCH (a:Artifact)-[:CONTAINS]->(p:Package)-[:CONTAINS]->(t:Type)
-  WITH replace(last(split(a.fileName, '/')), '.jar', '') AS artifactName
+  WITH a.name AS artifactName
       ,t.communityLeidenId                               AS communityId
       ,p.fqn                                             AS packageName
       ,collect(DISTINCT p.fqn)                           AS packageNames

--- a/cypher/Community_Detection/Type_communities_with_few_members_in_foreign_packages.cypher
+++ b/cypher/Community_Detection/Type_communities_with_few_members_in_foreign_packages.cypher
@@ -1,4 +1,4 @@
-// Type communities with few members in foreign packages
+// Type communities with few members in foreign packages. Requires "Add_file_name and_extension.cypher".
 
  MATCH (t:Type)
   WITH t.communityLeidenId   AS communityId
@@ -8,7 +8,7 @@
  MATCH (p)-[:CONTAINS]->(packageType:Type)
  WHERE communityType.communityLeidenId = communityId
    AND packageType.communityLeidenId IS NOT NULL
-  WITH replace(last(split(a.fileName, '/')), '.jar', '') AS artifactName
+  WITH a.name AS artifactName
       ,p.fqn                           AS packageName
       ,numberOfTypesInCommunity
       ,count(DISTINCT packageType.fqn) AS numberOfTypesInPackage

--- a/cypher/Community_Detection/Which_package_community_spans_multiple_artifacts.cypher
+++ b/cypher/Community_Detection/Which_package_community_spans_multiple_artifacts.cypher
@@ -1,8 +1,8 @@
-// Which package community spans multiple artifacts?
+// Which package community spans multiple artifacts? Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
   WITH package.communityLeidenId AS communityId
-      ,collect(DISTINCT replace(last(split(artifact.fileName, '/')), '.jar', '')) AS artifactNames
+      ,collect(DISTINCT artifact.name) AS artifactNames
       ,size(collect(DISTINCT artifact)) AS artifactCount
  WHERE communityId IS NOT NULL
 RETURN communityId, artifactNames, artifactCount

--- a/cypher/Community_Detection/Which_package_community_spans_several_artifacts_and_how_are_the_packages_distributed.cypher
+++ b/cypher/Community_Detection/Which_package_community_spans_several_artifacts_and_how_are_the_packages_distributed.cypher
@@ -1,4 +1,4 @@
-// Which package community spans several artifacts and how are the packages distributed?
+// Which package community spans several artifacts and how are the packages distributed? Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (externalArtifact:Artifact)-[:CONTAINS]->(externalPackage:Package)
@@ -6,7 +6,7 @@
    AND package.communityLeidenId 
      = externalPackage.communityLeidenId
   WITH package.communityLeidenId AS communityId
-      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,artifact.name AS artifactName
       ,collect(DISTINCT package.name)  AS packageNames
       ,size(collect(DISTINCT package)) AS packageCount
  WHERE communityId IS NOT NULL

--- a/cypher/Community_Detection/Which_type_community_spans_several_artifacts_and_how_are_the_types_distributed.cypher
+++ b/cypher/Community_Detection/Which_type_community_spans_several_artifacts_and_how_are_the_types_distributed.cypher
@@ -1,4 +1,4 @@
-// Which type community spans several artifacts and how are the types distributed?
+// Which type community spans several artifacts and how are the types distributed? Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)-[:CONTAINS]->(type:Type)
  MATCH (externalArtifact:Artifact)-[:CONTAINS]->(externalPackage:Package)-[:CONTAINS]->(externalType:Type)
@@ -7,7 +7,7 @@
    AND type.communityLeidenId = externalType.communityLeidenId
   WITH type.communityLeidenId AS communityId
       ,size(collect(DISTINCT artifact)) AS artifactCount
-      ,collect(DISTINCT replace(last(split(artifact.fileName, '/')), '.jar', '')) AS artifactNames
+      ,collect(DISTINCT artifact.name) AS artifactNames
       ,size(collect(DISTINCT package)) AS packageCount
       ,collect(DISTINCT package.name) AS packageNames
       ,size(collect(DISTINCT type)) AS typeCount

--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies.cypher
@@ -1,13 +1,13 @@
-//Cyclic Dependencies as List
+//Cyclic Dependencies as List. Requires "Add_file_name and_extension.cypher".
 
 MATCH (package:Package)-[:CONTAINS]->(forwardSource:Type)-[:DEPENDS_ON]->(forwardTarget:Type)<-[:CONTAINS]-(dependentPackage:Package)
 MATCH (dependentPackage)-[:CONTAINS]->(backwardSource:Type)-[:DEPENDS_ON]->(backwardTarget:Type)<-[:CONTAINS]-(package)
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
 MATCH (dependentArtifact:Artifact)-[:CONTAINS]->(dependentPackage)
 WHERE package.fqn <> dependentPackage.fqn
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '')            AS artifactName
+ WITH artifact.name                                                       AS artifactName
      ,package.fqn                                                         AS packageName
-     ,replace(last(split(dependentArtifact .fileName, '/')), '.jar', '')  AS dependentArtifactName
+     ,dependentArtifact.name                                              AS dependentArtifactName
      ,dependentPackage.fqn                                                AS dependentPackageName
      ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
      ,collect(DISTINCT backwardSource.name + '->' + backwardTarget.name)  AS backwardDependencies

--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown.cypher
@@ -1,13 +1,13 @@
-//Cyclic Dependencies Breakdown
+//Cyclic Dependencies Breakdown. Requires "Add_file_name and_extension.cypher".
 
 MATCH (package:Package)-[:CONTAINS]->(forwardSource:Type)-[:DEPENDS_ON]->(forwardTarget:Type)<-[:CONTAINS]-(dependentPackage:Package)
 MATCH (dependentPackage)-[:CONTAINS]->(backwardSource:Type)-[:DEPENDS_ON]->(backwardTarget:Type)<-[:CONTAINS]-(package)
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
 MATCH (dependentArtifact:Artifact)-[:CONTAINS]->(dependentPackage)
 WHERE package.fqn <> dependentPackage.fqn
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '')            AS artifactName
+ WITH artifact.name            AS artifactName
      ,package.fqn                                                         AS packageName
-     ,replace(last(split(dependentArtifact .fileName, '/')), '.jar', '')  AS dependentArtifactName
+     ,dependentArtifact.name                                              AS dependentArtifactName
      ,dependentPackage.fqn                                                AS dependentPackageName
      ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
      ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name)  AS backwardDependencies

--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_Backward_Only.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_Backward_Only.cypher
@@ -1,13 +1,13 @@
-//Cyclic Dependencies Breakdown Backward Only
+//Cyclic Dependencies Breakdown Backward Only. Requires "Add_file_name and_extension.cypher".
 
 MATCH (package:Package)-[:CONTAINS]->(forwardSource:Type)-[:DEPENDS_ON]->(forwardTarget:Type)<-[:CONTAINS]-(dependentPackage:Package)
 MATCH (dependentPackage)-[:CONTAINS]->(backwardSource:Type)-[:DEPENDS_ON]->(backwardTarget:Type)<-[:CONTAINS]-(package)
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
 MATCH (dependentArtifact:Artifact)-[:CONTAINS]->(dependentPackage)
 WHERE package.fqn <> dependentPackage.fqn
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '')            AS artifactName
+ WITH artifact.name                                                       AS artifactName
      ,package.fqn                                                         AS packageName
-     ,replace(last(split(dependentArtifact .fileName, '/')), '.jar', '')  AS dependentArtifactName
+     ,dependentArtifact.name                                             AS dependentArtifactName
      ,dependentPackage.fqn                                                AS dependentPackageName
      ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
      ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name)  AS backwardDependencies

--- a/cypher/Dependencies_Projection/Dependencies_12_Get_Projection_Statistics.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_12_Get_Projection_Statistics.cypher
@@ -1,0 +1,17 @@
+// Get dependency projection statistics
+
+ CALL gds.graph.list($dependencies_projection + '-cleaned')
+YIELD nodeCount, relationshipCount, density, sizeInBytes, degreeDistribution
+RETURN nodeCount
+      ,relationshipCount
+      ,density
+      ,sizeInBytes
+      ,degreeDistribution.min
+      ,degreeDistribution.mean
+      ,degreeDistribution.max
+      ,degreeDistribution.p50
+      ,degreeDistribution.p75
+      ,degreeDistribution.p90
+      ,degreeDistribution.p95
+      ,degreeDistribution.p99
+      ,degreeDistribution.p999

--- a/cypher/Dependencies_Projection/Dependencies_6_Check_Projection_Nodes.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_6_Check_Projection_Nodes.cypher
@@ -1,19 +1,14 @@
 // Check Projection Node Properties
 
-CALL gds.graph.nodeProperties.stream(
-   $dependencies_projection + '-cleaned'
-  ,['incomingDependencies', 'outgoingDependencies']
-)
-YIELD nodeId, targetNodeId, propertyValue, relationshipType
-  WITH nodeId                        AS sourceNodeId
-      ,gds.util.asNode(nodeId)       AS sourceNode
-      ,nodeProperty                  
-      ,propertyValue
-      ,nodeLabels
-RETURN sourceNodeId
+ CALL gds.graph.nodeProperties.stream(
+    $dependencies_projection + '-cleaned'
+   ,['incomingDependencies', 'outgoingDependencies']
+ )
+ YIELD nodeId, propertyValue
+  WITH * ,gds.util.asNode(nodeId) AS source               
+RETURN nodeId
       ,coalesce(source.fqn, source.fileName, source.name) AS sourceName
-      ,nodeProperty
       ,propertyValue
-      ,nodeLabels
+      ,labels(source)[0..4] AS first5NodeLabels
  ORDER BY sourceName ASC
  LIMIT 50

--- a/cypher/Dependencies_Projection/Dependencies_7_Check_Projection_Relationships.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_7_Check_Projection_Relationships.cypher
@@ -1,7 +1,7 @@
 // Check Projection Relationships
 
 CALL gds.graph.relationshipProperty.stream(
-   $dependencies_projection + '-cleaned',
+   $dependencies_projection + '-cleaned'
   ,$dependencies_projection_weight_property
   ,['DEPENDS_ON']
 )

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property
+// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -9,6 +9,6 @@ YIELD nodeId, nodeProperty, propertyValue
      ,nodeProperty            AS propertyName
      ,propertyValue
 RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))      AS shortCodeUnitName
+     ,codeUnit.name      AS shortCodeUnitName
      ,propertyName
      ,propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection into the Graph. Variables: dependencies_projection, dependencies_projection_write_property
+// Read a property from the projection into the Graph. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -10,9 +10,9 @@ YIELD nodeId, nodeProperty, propertyValue
      ,propertyValue
 OPTIONAL MATCH (artifact:Artifact)-[:CONTAINS]->(codeUnit)
 RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.name) AS codeUnitName
-     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortCodeUnitName
+     ,codeUnit.name AS shortCodeUnitName
      ,propertyName
      ,propertyValue
      ,coalesce(codeUnit.communityLeidenId, 0) AS communityId // optional, might be null
      ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality // optional, might be null
-     ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS owningArtifactName
+     ,artifact.name AS owningArtifactName

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property
+// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -11,7 +11,7 @@ YIELD nodeId, nodeProperty, propertyValue
  WITH propertyName
      ,propertyValue
      ,coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.name)                          AS codeUnitName
-     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortCodeUnitName
+     ,codeUnit.name AS shortCodeUnitName
  WITH propertyName
      ,propertyValue
      ,collect(DISTINCT codeUnitName)      AS codeUnitNames

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection and order it by its value descending. Variables: dependencies_projection, dependencies_projection_write_property
+// Read a property from the projection and order it by its value descending. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -9,7 +9,7 @@ YIELD nodeId, nodeProperty, propertyValue
      ,nodeProperty            AS propertyName
      ,propertyValue
 RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-     ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))      AS shortCodeUnitName
+     ,codeUnit.name      AS shortCodeUnitName
      ,propertyName
      ,propertyValue
 ORDER BY propertyValue DESCENDING, codeUnitName ASCENDING

--- a/cypher/External_Dependencies/External_package_usage_per_artifact.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact.cypher
@@ -1,7 +1,7 @@
-// External package usage per artifact
+// External package usage per artifact. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact:Archive)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,count(type)   AS numberOfTypesInArtifact
       ,collect(type) AS typeList
 UNWIND typeList AS type

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_and_external_package.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_and_external_package.cypher
@@ -1,10 +1,10 @@
-// External package usage per artifact and external package
+// External package usage per artifact and external package. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  OPTIONAL MATCH (packageUsingExternal:Package)-[:CONTAINS]->(type)-[:DEPENDS_ON]->(external:ExternalType)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')       AS artifactName
+  WITH artifact.name       AS artifactName
       ,count(DISTINCT package.fqn)                                    AS artifactPackages
       ,count(DISTINCT type.fqn)                                       AS artifactTypes
       ,count(DISTINCT replace(external.fqn, '.' + external.name, '')) AS artifactExternalPackages

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_and_package.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_and_package.cypher
@@ -1,8 +1,8 @@
-// External package usage per artifact and package
+// External package usage per artifact and package. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,package.fqn   AS fullPackageName
       ,package.name  AS packageName
       ,count(type)   AS numberOfTypesInPackage

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_and_package_with_annotations.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_and_package_with_annotations.cypher
@@ -1,8 +1,8 @@
-// External package usage per artifact and package with external annotations
+// External package usage per artifact and package with external annotations. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,package.fqn   AS fullPackageName
       ,package.name  AS packageName
       ,count(type)   AS numberOfTypesInPackage

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_distribution.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_distribution.cypher
@@ -1,8 +1,8 @@
-// External package usage per artifact distribution
+// External package usage per artifact distribution. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,count(DISTINCT package.fqn)                               AS artifactPackages
       ,count(DISTINCT type.fqn)                                  AS artifactTypes
       ,collect(type)                                             AS typeList

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_package_aggregated.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_package_aggregated.cypher
@@ -1,10 +1,10 @@
-// External package usage per artifact package aggregated
+// External package usage per artifact package aggregated. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  WHERE NOT type:ExternalType
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,artifact.communityLeidenId                                AS leidenCommunityId
       ,count(DISTINCT package.fqn)                               AS artifactPackages
       ,count(DISTINCT type.fqn)                                  AS artifactTypes

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_sorted.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_sorted.cypher
@@ -1,8 +1,8 @@
-// External package usage per artifact sorted by external usage descending
+// External package usage per artifact sorted by external usage descending. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact:Archive)-[:CONTAINS]->(type:Type)
  OPTIONAL MATCH (type)-[:DEPENDS_ON]->(externalType:ExternalType)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,count(DISTINCT type.fqn)         AS numberOfTypesInArtifact
       ,count(DISTINCT externalType.fqn) AS numberOfExternalTypesInArtifact
       ,count(DISTINCT replace(externalType.fqn, '.' + externalType.name, '')) AS numberOfExternalPackagesInArtifact

--- a/cypher/External_Dependencies/External_package_usage_per_artifact_sorted_top.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_artifact_sorted_top.cypher
@@ -1,8 +1,8 @@
-// External package usage per artifact top externals
+// External package usage per artifact top externals. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact:Archive)-[:CONTAINS]->(type:Type)
  OPTIONAL MATCH (type)-[:DEPENDS_ON]->(externalType:ExternalType)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,count(DISTINCT type.fqn)         AS numberOfTypesInArtifact
       ,count(DISTINCT externalType.fqn) AS numberOfExternalTypesInArtifact
       ,count(DISTINCT replace(externalType.fqn, '.' + externalType.name, '')) AS numberOfExternalPackagesInArtifact

--- a/cypher/External_Dependencies/External_package_usage_per_internal_package_count.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_internal_package_count.cypher
@@ -1,10 +1,10 @@
-// External package usage per internal package count
+// External package usage per internal package count. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  WHERE NOT type:ExternalType
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,count(DISTINCT package.fqn)                               AS artifactPackages
       ,count(DISTINCT type.fqn)                                  AS artifactTypes
       ,collect(type)                                             AS typeList

--- a/cypher/External_Dependencies/External_package_usage_per_type.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_type.cypher
@@ -1,10 +1,10 @@
-// External package usage per type
+// External package usage per type. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  MATCH (type)-[externalDependency:DEPENDS_ON]->(externalType:ExternalType)
   WITH externalDependency
-      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+      ,artifact.name AS artifactName
       ,package.fqn  AS fullPackageName
       ,package.name AS packageName
       ,type.fqn     AS fullTypeName

--- a/cypher/External_Dependencies/External_package_usage_per_type_distribution_with_annotations.cypher
+++ b/cypher/External_Dependencies/External_package_usage_per_type_distribution_with_annotations.cypher
@@ -1,7 +1,7 @@
-// External package usage per type distribution with external annotations
+// External package usage per type distribution with external annotations. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,count(type)                                               AS artifactTypes
       ,collect(type)                                             AS typeList
 UNWIND typeList AS type

--- a/cypher/External_Dependencies/External_package_usage_spread.cypher
+++ b/cypher/External_Dependencies/External_package_usage_spread.cypher
@@ -1,10 +1,10 @@
-// External package usage spread
+// External package usage spread. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  WHERE NOT type:ExternalType
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,count(DISTINCT package.fqn)                               AS artifactPackages
       ,count(DISTINCT type.fqn)                                  AS artifactTypes
       ,collect(type)                                             AS typeList

--- a/cypher/External_Dependencies/External_second_level_package_usage_per_artifact_and_external_package.cypher
+++ b/cypher/External_Dependencies/External_second_level_package_usage_per_artifact_and_external_package.cypher
@@ -1,10 +1,10 @@
-// External second level package usage per artifact and external package
+// External second level package usage per artifact and external package. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  OPTIONAL MATCH (packageUsingExternal:Package)-[:CONTAINS]->(type)-[:DEPENDS_ON]->(external:ExternalType)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')       AS artifactName
+  WITH artifact.name       AS artifactName
       ,count(DISTINCT package.fqn)                                    AS artifactPackages
       ,count(DISTINCT type.fqn)                                       AS artifactTypes
       ,count(DISTINCT split(external.fqn,'.')[0..2])                  AS artifactExternalPackagesFirst2Levels

--- a/cypher/External_Dependencies/External_second_level_package_usage_spread.cypher
+++ b/cypher/External_Dependencies/External_second_level_package_usage_spread.cypher
@@ -1,10 +1,10 @@
-// External second level package usage spread
+// External second level package usage spread. Requires "Add_file_name and_extension.cypher".
 
 // Get the overall artifact statistics first
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  WHERE NOT type:ExternalType
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '')  AS artifactName
+  WITH artifact.name  AS artifactName
       ,count(DISTINCT package.fqn)                               AS artifactPackages
       ,count(DISTINCT type.fqn)                                  AS artifactTypes
       ,collect(type)                                             AS typeList

--- a/cypher/External_Dependencies/External_types_per_artifact_using_requires.cypher
+++ b/cypher/External_Dependencies/External_types_per_artifact_using_requires.cypher
@@ -1,9 +1,9 @@
-// External types per artifact using requires
+// External types per artifact using requires. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:REQUIRES]->(externalType:ExternalType)
 MATCH (artifact)-[:CONTAINS]->(caller:Type)
 OPTIONAL MATCH (caller)-[callerDependency:DEPENDS_ON]->(externalType)
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,replace(externalType.fqn, '.' + externalType.name, '') AS externalTypePackage
      ,COLLECT(DISTINCT externalType.name)   AS externalTypeNames
      ,COUNT(callerDependency)               AS numberOfCaller

--- a/cypher/General_Enrichment/Add_file_name and_extension.cypher
+++ b/cypher/General_Enrichment/Add_file_name and_extension.cypher
@@ -1,0 +1,27 @@
+ // Add "name", "extension" and "extensionExtended" properties to File nodes
+
+ MATCH (file:File)
+ WHERE file.fileName IS NOT NULL
+  WITH *
+      ,file.fileName AS fileName
+  WITH *
+      ,last(split(fileName, '/')) AS fileNameWithoutPath
+  WITH *
+      ,coalesce(nullif(last(split(fileNameWithoutPath, '.')), fileNameWithoutPath), '') AS fileExtension
+  WITH *
+      //,rtrim(fileNameWithoutPath, '.' + fileExtension) AS fileNameWithoutPathAndExtensionOld //rtrim seems to have an issue
+      ,substring(fileNameWithoutPath, 0, size(fileNameWithoutPath) - size(fileExtension) - 1) AS fileNameWithoutPathAndExtension
+  WITH *
+      ,CASE WHEN file:Directory OR file:ServiceLoader THEN fileNameWithoutPath ELSE fileNameWithoutPathAndExtension END AS name
+      ,CASE WHEN file:Directory OR file:ServiceLoader THEN '' ELSE fileExtension  END AS fileExtension
+   SET file.name              = name
+      ,file.extension         = fileExtension
+RETURN count(*) AS updatedArtifacts
+// Debugging
+//RETURN labels(file)[0..3]                    AS fileLabels
+//      ,count(*)                              AS nodeCount
+//      ,collect(DISTINCT fileName 
+//              + ': name='        + name 
+//              + ', withoutPath=' + fileNameWithoutPath 
+//              + ', extension='   + fileExtension 
+//              )[0..4] AS exampleFiles

--- a/cypher/Internal_Dependencies/How_many_classes_compared_to_all_existing_in_the_same_package_are_used_by_dependent_packages_across_different_artifacts.cypher
+++ b/cypher/Internal_Dependencies/How_many_classes_compared_to_all_existing_in_the_same_package_are_used_by_dependent_packages_across_different_artifacts.cypher
@@ -1,11 +1,11 @@
-// How many classes compared to all existing in the same package are used by dependent packages across different artifacts?
+// How many classes compared to all existing in the same package are used by dependent packages across different artifacts. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)-[:CONTAINS]->(type:Type)-[:DEPENDS_ON]->(dependentType:Type)<-[:CONTAINS]-(dependentPackage:Package)<-[:CONTAINS]-(dependentArtifact:Artifact)
 MATCH (dependentPackage)-[:CONTAINS]->(dependentPackageType:Type)
 WHERE type <> dependentType
   AND artifact <> dependentArtifact
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
-      ,replace(last(split(dependentArtifact.fileName, '/')), '.jar', '') AS dependentArtifactName
+  WITH artifact.name AS artifactName
+      ,dependentArtifact.name AS dependentArtifactName
       ,package
       ,dependentPackage
       ,COUNT(DISTINCT dependentType)        AS dependentTypes

--- a/cypher/Internal_Dependencies/How_many_packages_compared_to_all_existing_are_used_by_dependent_artifacts.cypher
+++ b/cypher/Internal_Dependencies/How_many_packages_compared_to_all_existing_are_used_by_dependent_artifacts.cypher
@@ -1,9 +1,9 @@
-// How many packages compared to all existing are used by dependent artifacts?
+// How many packages compared to all existing are used by dependent artifacts? Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]-(package:Package)-[:DEPENDS_ON]->(dependentPackage:Package)<-[:CONTAINS]-(dependentArtifact:Artifact)
 MATCH (dependentArtifact)-[:CONTAINS]->(dependentArtifactPackage:Package)-[:CONTAINS]->(dependentArtifactType:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
-      ,replace(last(split(dependentArtifact.fileName, '/')), '.jar', '') AS dependentArtifactName
+  WITH artifact.name AS artifactName
+      ,dependentArtifact.name AS dependentArtifactName
       ,dependentArtifact
       ,COUNT(DISTINCT dependentPackage.fqn)     AS dependentPackages
       ,COUNT(DISTINCT dependentArtifactPackage) AS dependentArtifactPackages

--- a/cypher/Java/Annotated_code_elements_per_artifact.cypher
+++ b/cypher/Java/Annotated_code_elements_per_artifact.cypher
@@ -1,4 +1,4 @@
-// Annotated code elements per artifact and element type with some examples
+// Annotated code elements per artifact and element type with some examples. Requires "Add_file_name and_extension.cypher".
 
 MATCH (annotatedElement:Annotation|Parameter|Field|Method|Type&!ExternalType&!JavaType)-[:ANNOTATED_BY]->()-[]->(annotation:Type)
 OPTIONAL MATCH (annotatedElementArtifact:Artifact)-[:CONTAINS]->(annotatedElement)
@@ -12,7 +12,7 @@ OPTIONAL MATCH (parameterArtifact:Artifact)-[:CONTAINS]->(parameterOwnerType:Typ
               ,parameterOwnerType.fqn + '.' + parameterOwnerMethod.name + '(' +  annotatedElement.index + ')'
               ,annotatedElement.name
               ) AS nameOfAnnotatedElement
-     ,replace(last(split(coalesce(parameterArtifact, memberArtifact, annotatedElementArtifact).fileName, '/')), '.jar', '') AS artifactName
+     ,coalesce(parameterArtifact, memberArtifact, annotatedElementArtifact).name AS artifactName
  WITH annotation.fqn  AS annotationName
   ,CASE WHEN 'Annotation'  IN labels(annotatedElement) THEN 'Annotation'
         WHEN 'Parameter'   IN labels(annotatedElement) THEN 'Parameter'

--- a/cypher/Java/JakartaEE_REST_Annotations.cypher
+++ b/cypher/Java/JakartaEE_REST_Annotations.cypher
@@ -1,4 +1,4 @@
-// Jakarta Enterprise Edition JAX-RS REST Annotations
+// Jakarta Enterprise Edition JAX-RS REST Annotations. Requires "Add_file_name and_extension.cypher".
 //
 // --- Method Http Annotation ---
 MATCH (method:Method)-[:ANNOTATED_BY]->(httpMethodLink:Annotation)-[:OF_TYPE]->(httpMethodAnnotation:Type)
@@ -37,7 +37,7 @@ RETURN replace(
          coalesce(pathMethodValue.value, '')
        , '//', '/')                                             AS path
       ,httpMethodAnnotation.name                                AS httpMethod
-      ,replace(last(split(artifact.fileName, '/')), '.jar', '') AS resourceArtifact
+      ,artifact.name AS resourceArtifact
       ,coalesce(subPathType.fqn, pathType.fqn)                  AS resourceType
       ,method.name                                              AS resourceMethod
       ,collect(methodParamAnnotation.name + ': ' + 

--- a/cypher/Java/Java_Reflection_usage.cypher
+++ b/cypher/Java/Java_Reflection_usage.cypher
@@ -1,7 +1,7 @@
-// Query Java Reflection usage combined with invokations of "Class.forName"
+// Query Java Reflection usage combined with invocations of "Class.forName". Requires "Add_file_name and_extension.cypher".
 
    MATCH (dependentArtifact:Artifact)-[:CONTAINS]-(dependentType:Type)
-    WITH replace(last(split(dependentArtifact.fileName, '/')), '.jar', '') AS dependentArtifactName
+    WITH dependentArtifact.name AS dependentArtifactName
         ,dependentType
 OPTIONAL MATCH (dependentType)-[:DEPENDS_ON]->(reflectionType:Type)
    WHERE reflectionType.fqn STARTS WITH 'java.lang.reflect.'

--- a/cypher/Java/Java_Reflection_usage_detailed.cypher
+++ b/cypher/Java/Java_Reflection_usage_detailed.cypher
@@ -1,7 +1,7 @@
-// Query all types that use Java Reflection or "Class.forName"
+// Query all types that use Java Reflection or "Class.forName". Requires "Add_file_name and_extension.cypher".
 
    MATCH (dependentArtifact:Artifact)-[:CONTAINS]-(dependentType:Type)
-    WITH replace(last(split(dependentArtifact.fileName, '/')), '.jar', '') AS dependentArtifactName
+    WITH dependentArtifact.name AS dependentArtifactName
         ,dependentType
 OPTIONAL MATCH (dependentType)-[:DEPENDS_ON]->(reflectionType:Type)
    WHERE reflectionType.fqn STARTS WITH 'java.lang.reflect.'

--- a/cypher/Java/Java_deprecated_element_usage.cypher
+++ b/cypher/Java/Java_deprecated_element_usage.cypher
@@ -1,4 +1,4 @@
-// Query deprecated type and member usage by non deprecated elements
+// Query deprecated type and member usage by non deprecated elements. Requires "Add_file_name and_extension.cypher".
 
          MATCH (annotated)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
 OPTIONAL MATCH (artifactReadsDeprecated:Artifact)-[:CONTAINS]->(typeReadsDeprecated:Type)-[:DECLARES]->(readsDeprecated:Method)-[:READS]->(annotated:Field)
@@ -28,7 +28,7 @@ OPTIONAL MATCH (artifactDependsOnDeprecated:Artifact)-[:CONTAINS]->(typeDependsO
   WHERE artifact IS NOT NULL
     AND NOT (type)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
     AND NOT (method)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,deprecatedElement
       ,count(DISTINCT elementUsingDeprecatedElement)            AS numberOfElementsUsingDeprecatedElements
       ,collect(DISTINCT elementUsingDeprecatedElement)[0..19]   AS someElementsUsingDeprecatedElements

--- a/cypher/Java/Java_deprecated_element_usage_detailed.cypher
+++ b/cypher/Java/Java_deprecated_element_usage_detailed.cypher
@@ -1,4 +1,4 @@
-// List all non deprecated elements (types, members) that call deprecated elements
+// List all non deprecated elements (types, members) that call deprecated elements. Requires "Add_file_name and_extension.cypher".
 
          MATCH (annotated)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
 OPTIONAL MATCH (artifactReadsDeprecated:Artifact)-[:CONTAINS]->(typeReadsDeprecated:Type)-[:DECLARES]->(readsDeprecated:Method)-[:READS]->(annotated:Field)
@@ -29,7 +29,7 @@ OPTIONAL MATCH (artifactDependsOnDeprecated:Artifact)-[:CONTAINS]->(typeDependsO
   WHERE artifact IS NOT NULL
     AND NOT (type)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
     AND NOT (method)-[:ANNOTATED_BY]->(:Annotation)-[:OF_TYPE]->(:Type{fqn:'java.lang.Deprecated'})
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,deprecatedElementType
       ,elementUsingDeprecatedElement
       ,deprecatedElement

--- a/cypher/Java/Spring_Web_Request_Annotations.cypher
+++ b/cypher/Java/Spring_Web_Request_Annotations.cypher
@@ -1,4 +1,4 @@
-// Spring Web Request Annotations
+// Spring Web Request Annotations. Requires "Add_file_name and_extension.cypher".
 //
 // --- Method HTTP Annotation ---
 MATCH (method:Method)-[:ANNOTATED_BY]->(httpMethodLink:Annotation)-[:OF_TYPE]->(httpMethodAnnotation:Type)
@@ -42,7 +42,7 @@ RETURN replace(
           replace(replace(httpMethodAnnotation.name, 'Mapping', ''), 'Request', 'All')
           )
        )                                                            AS httpMethod
-      ,replace(last(split(artifact.fileName, '/')), '.jar', '')     AS resourceArtifact
+      ,artifact.name     AS resourceArtifact
       ,coalesce(subResourceType.fqn, resourceType.fqn)              AS resourceType
       ,method.name                                                  AS resourceMethod
       ,collect(

--- a/cypher/Metrics/Calculate_and_set_Abstractness_for_Java.cypher
+++ b/cypher/Metrics/Calculate_and_set_Abstractness_for_Java.cypher
@@ -1,8 +1,8 @@
-//Calculate and set Abstractness for Java Packages including Counts 
+//Calculate and set Abstractness for Java Packages including Counts. Requires "Add_file_name and_extension.cypher".
 
 MATCH (package:Java:Package)
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,package
      ,count{(package)-[:CONTAINS]->(:Type)}                    AS numberTypes
      ,count{(package)-[:CONTAINS]->(:Class{abstract:true})}    AS numberAbstractClasses

--- a/cypher/Metrics/Calculate_and_set_Abstractness_for_Java_including_Subpackages.cypher
+++ b/cypher/Metrics/Calculate_and_set_Abstractness_for_Java_including_Subpackages.cypher
@@ -1,4 +1,4 @@
-//Calculate and set Abstractness for Java Packages including sub-packages 
+//Calculate and set Abstractness for Java Packages including sub-packages. Requires "Add_file_name and_extension.cypher".
 
 MATCH path = (package:Java:Package)-[:CONTAINS*0..]->(subpackage:Java:Package)
  WITH *
@@ -9,7 +9,7 @@ MATCH path = (package:Java:Package)-[:CONTAINS*0..]->(subpackage:Java:Package)
      ,EXISTS{ (package)-[:CONTAINS]->(:Type) } AS containsTypes
 WHERE hasSiblingPackages OR containsTypes
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
- WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+ WITH artifact.name AS artifactName
      ,package
      ,sum(subpackage.numberOfTypes)            AS numberTypes
      ,sum(subpackage.numberOfAbstractTypes)    AS numberAbstractTypes

--- a/cypher/Metrics/Calculate_and_set_Instability_for_Java.cypher
+++ b/cypher/Metrics/Calculate_and_set_Instability_for_Java.cypher
@@ -1,4 +1,4 @@
-// Calculate and set Instability for Java
+// Calculate and set Instability for Java. Requires "Add_file_name and_extension.cypher".
 // Instability = outgoing / (outgoing + incoming) Dependencies
 
  MATCH (p:Java:Package)
@@ -22,7 +22,7 @@ WHERE p.incomingDependencies > 0
       ,instabilityPackages
       ,instabilityArtifacts
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                   AS fullQualifiedPackageName
       ,p.name                  AS packageName
       ,instability

--- a/cypher/Metrics/Calculate_and_set_Instability_for_Java_Including_Subpackages.cypher
+++ b/cypher/Metrics/Calculate_and_set_Instability_for_Java_Including_Subpackages.cypher
@@ -1,4 +1,4 @@
-// Calculate and set Instability = outgoing / (outgoing + incoming) Dependencies
+// Calculate and set Instability = outgoing / (outgoing + incoming) Dependencies. Requires "Add_file_name and_extension.cypher".
 
  MATCH (p:Java:Package)
  WHERE p.incomingDependenciesIncludingSubpackages > 0 
@@ -21,7 +21,7 @@
       ,instabilityPackages
       ,instabilityArtifacts
  MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                   AS fullQualifiedPackageName
       ,p.name                  AS packageName
       ,instability

--- a/cypher/Metrics/Calculate_distance_between_abstractness_and_instability_for_Java.cypher
+++ b/cypher/Metrics/Calculate_distance_between_abstractness_and_instability_for_Java.cypher
@@ -1,7 +1,7 @@
-// Calculate distance between abstractness and instability
+// Calculate distance between abstractness and instability. Requires "Add_file_name and_extension.cypher".
 
 MATCH (artifact:Artifact)-[:CONTAINS]->(package:Java:Package)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,package.fqn           AS fullQualifiedName
       ,package.name          AS name
       ,abs(package.abstractness + package.instability - 1) AS distance     

--- a/cypher/Metrics/Calculate_distance_between_abstractness_and_instability_for_Java_including_subpackages.cypher
+++ b/cypher/Metrics/Calculate_distance_between_abstractness_and_instability_for_Java_including_subpackages.cypher
@@ -1,10 +1,10 @@
-// Calculate distance between abstractness and instability including subpackages
+// Calculate distance between abstractness and instability including subpackages. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Java:Package)
  WHERE package.abstractnessIncludingSubpackages  IS NOT NULL
    AND package.instabilityIncludingSubpackages   IS NOT NULL
    AND package.numberOfTypesIncludingSubpackages IS NOT NULL
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,package.fqn           AS fullQualifiedName
       ,package.name          AS name
       ,abs(package.abstractnessIncludingSubpackages + package.instabilityIncludingSubpackages - 1) AS distance     

--- a/cypher/Metrics/Get_Abstractness_for_Java.cypher
+++ b/cypher/Metrics/Get_Abstractness_for_Java.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages with the lowest abstractness first (if set before)
+// Get Java Packages with the lowest abstractness first (if set before). Requires "Add_file_name and_extension.cypher".
 
 MATCH (package:Java:Package)
 WHERE package.abstractness IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(package)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
      ,package.fqn                   AS fullQualifiedPackageName
      ,package.name                  AS packageName
      ,package.abstractness          AS abstractness

--- a/cypher/Metrics/Get_Abstractness_for_Java_including_Subpackages.cypher
+++ b/cypher/Metrics/Get_Abstractness_for_Java_including_Subpackages.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages including their sub packages with the lowest abstractness first (if set before)
+// Get Java Packages including their sub packages with the lowest abstractness first (if set before). Requires "Add_file_name and_extension.cypher".
 
  MATCH path = (package:Java:Package)-[:CONTAINS*0..]->(subpackage:Java:Package)
  WHERE package.abstractnessIncludingSubpackages IS NOT NULL
  MATCH (artifact:Artifact)-[:CONTAINS]->(package)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,package.fqn   AS fullQualifiedPackageName
       ,package.name  AS packageName
       ,package.abstractnessIncludingSubpackages          AS abstractness

--- a/cypher/Metrics/Get_Incoming_Java_Package_Dependencies.cypher
+++ b/cypher/Metrics/Get_Incoming_Java_Package_Dependencies.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages with the most incoming dependencies first (if set before)
+// Get Java Packages with the most incoming dependencies first (if set before). Requires "Add_file_name and_extension.cypher".
 
 MATCH (p:Java:Package)
 WHERE  p.incomingDependencies IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                         AS fullQualifiedPackageName
       ,p.name                        AS packageName
       ,p.incomingDependencies        AS incomingDependencies

--- a/cypher/Metrics/Get_Incoming_Java_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Get_Incoming_Java_Package_Dependencies_Including_Subpackages.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages including their sub-packages with the most incoming dependencies first (if set before)
+// Get Java Packages including their sub-packages with the most incoming dependencies first (if set before). Requires "Add_file_name and_extension.cypher".
 
 MATCH (p:Java:Package)
 WHERE p.incomingDependenciesIncludingSubpackages IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                                             AS fullQualifiedPackageName
       ,p.name                                            AS packageName
       ,p.incomingDependenciesIncludingSubpackages        AS incomingDependencies

--- a/cypher/Metrics/Get_Instability_for_Java.cypher
+++ b/cypher/Metrics/Get_Instability_for_Java.cypher
@@ -1,10 +1,10 @@
-// Get Java Packages with the lowest Instability (outgoing / all dependencies) first (if set before)
+// Get Java Packages with the lowest Instability (outgoing / all dependencies) first (if set before). Requires "Add_file_name and_extension.cypher".
 // Instability = outgoing / (outgoing + incoming) Dependencies
 
  MATCH (p:Java:Package)
  WHERE p.instability IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-  RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  RETURN artifact.name AS artifactName
       ,p.fqn                   AS fullQualifiedPackageName
       ,p.name                  AS packageName
       ,p.instability           AS instability

--- a/cypher/Metrics/Get_Instability_for_Java_Including_Subpackages.cypher
+++ b/cypher/Metrics/Get_Instability_for_Java_Including_Subpackages.cypher
@@ -1,10 +1,10 @@
-// Get Java Packages including their sub packages with the lowest Instability
+// Get Java Packages including their sub packages with the lowest Instability. Requires "Add_file_name and_extension.cypher".
 // Instability = outgoing / (outgoing + incoming) Dependencies
 
  MATCH (p:Java:Package)
  WHERE p.instabilityIncludingSubpackages IS NOT NULL
  MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                   AS fullQualifiedPackageName
       ,p.name                  AS packageName
       ,p.instabilityIncludingSubpackages           AS instability

--- a/cypher/Metrics/Get_Outgoing_Java_Package_Dependencies.cypher
+++ b/cypher/Metrics/Get_Outgoing_Java_Package_Dependencies.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages with the most outgoing dependencies first (if set before)
+// Get Java Packages with the most outgoing dependencies first (if set before). Requires "Add_file_name and_extension.cypher".
 
 MATCH (p:Java:Package)
 WHERE p.outgoingDependencies IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName 
+RETURN artifact.name AS artifactName 
       ,p.fqn                         AS fullQualifiedPackageName
       ,p.name                        AS packageName
       ,p.outgoingDependencies        AS outgoingDependencies

--- a/cypher/Metrics/Get_Outgoing_Java_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Get_Outgoing_Java_Package_Dependencies_Including_Subpackages.cypher
@@ -1,9 +1,9 @@
-// Get Java Packages including their sub packages with the most outgoing dependencies first (if set before)
+// Get Java Packages including their sub packages with the most outgoing dependencies first (if set before). Requires "Add_file_name and_extension.cypher".
 
 MATCH (p:Java:Package)
 WHERE p.outgoingDependenciesIncludingSubpackages IS NOT NULL
 MATCH (artifact:Artifact)-[:CONTAINS]->(p)
-RETURN replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+RETURN artifact.name AS artifactName
       ,p.fqn                                             AS fullQualifiedPackageName
       ,p.name                                            AS packageName
       ,p.outgoingDependenciesIncludingSubpackages        AS outgoingDependencies

--- a/cypher/Metrics/Incoming_Package_Dependencies.cypher
+++ b/cypher/Metrics/Incoming_Package_Dependencies.cypher
@@ -1,11 +1,11 @@
-// Incoming Package Dependencies
+// Incoming Package Dependencies. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
 OPTIONAL MATCH (p)-[:CONTAINS]->(it:Java:Type)<-[r:DEPENDS_ON]-(et:Java:Type)<-[:CONTAINS]-(ep:Package)<-[:CONTAINS]-(ea:Artifact)
    WHERE ep.fqn <> p.fqn
 OPTIONAL MATCH (it)<-[:DEPENDS_ON]-(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS incomingDependencies
         ,SUM(r.weight)          AS incomingDependenciesWeight

--- a/cypher/Metrics/Incoming_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Incoming_Package_Dependencies_Including_Subpackages.cypher
@@ -1,4 +1,4 @@
-// Incoming Package Dependencies including sub-packages
+// Incoming Package Dependencies including sub-packages. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
@@ -6,7 +6,7 @@ OPTIONAL MATCH (p:Package)-[:CONTAINS*0..]->(sp:Package)-[:CONTAINS]->(st:Java:T
    WHERE NOT ep.fqn starts with p.fqn + '.'
      AND ep.fqn <> p.fqn
 OPTIONAL MATCH (st)<-[:DEPENDS_ON]-(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS incomingDependencies
         ,SUM(r.weight)          AS incomingDependenciesWeight

--- a/cypher/Metrics/Outgoing_Package_Dependencies.cypher
+++ b/cypher/Metrics/Outgoing_Package_Dependencies.cypher
@@ -1,11 +1,11 @@
-// Outgoing Package Dependencies
+// Outgoing Package Dependencies. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
 MATCH (p)-[:CONTAINS]->(it:Java:Type)-[r:DEPENDS_ON]->(et:Java:Type)<-[:CONTAINS]-(ep:Package)<-[:CONTAINS]-(ea:Artifact)
    WHERE ep.fqn <> p.fqn
 OPTIONAL MATCH (it)-[:DEPENDS_ON]->(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS outgoingDependencies
         ,SUM(r.weight)          AS outgoingDependenciesWeight

--- a/cypher/Metrics/Outgoing_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Outgoing_Package_Dependencies_Including_Subpackages.cypher
@@ -1,4 +1,4 @@
-// Outgoing Package Dependencies including sub-packages
+// Outgoing Package Dependencies including sub-packages. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
@@ -6,7 +6,7 @@ OPTIONAL MATCH (p:Package)-[:CONTAINS*0..]->(sp:Package)-[:CONTAINS]->(st:Java:T
    WHERE NOT ep.fqn starts with p.fqn + '.'
      AND ep.fqn <> p.fqn
 OPTIONAL MATCH (st)<-[:DEPENDS_ON]-(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS outgoingDependencies
         ,SUM(r.weight)          AS outgoingDependenciesWeight

--- a/cypher/Metrics/Set_Incoming_Java_Package_Dependencies.cypher
+++ b/cypher/Metrics/Set_Incoming_Java_Package_Dependencies.cypher
@@ -1,4 +1,4 @@
-// Set Incoming Package Dependencies
+// Set Incoming Package Dependencies. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Java:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
@@ -7,7 +7,7 @@ OPTIONAL MATCH (it)<-[:DEPENDS_ON]-(eti:Java:Type:Interface)
    WHERE p <> ep
      AND p.fqn <> ep.fqn
      // AND p.incomingDependencies IS NULL // comment out to recalculate
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)               AS incomingDependencies
         ,SUM(r.weight)           AS incomingDependenciesWeight

--- a/cypher/Metrics/Set_Incoming_Java_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Set_Incoming_Java_Package_Dependencies_Including_Subpackages.cypher
@@ -1,4 +1,4 @@
-// Set Incoming Package Dependencies including sub-packages
+// Set Incoming Package Dependencies including sub-packages. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Java:Package)
     WITH *
@@ -14,7 +14,7 @@ OPTIONAL MATCH (p)-[:CONTAINS*0..]->(sp:Package)-[:CONTAINS]->(st:Java:Type)<-[r
      AND ep.fqn <> p.fqn
      // AND p.incomingDependenciesIncludingSubpackages IS NULL // comment out to recalculate
 OPTIONAL MATCH (st)<-[:DEPENDS_ON]-(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS incomingDependencies
         ,SUM(r.weight)          AS incomingDependenciesWeight

--- a/cypher/Metrics/Set_Outgoing_Java_Package_Dependencies.cypher
+++ b/cypher/Metrics/Set_Outgoing_Java_Package_Dependencies.cypher
@@ -1,4 +1,4 @@
-//Set Outgoing Package Dependencies
+//Set Outgoing Package Dependencies. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Java:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
@@ -7,7 +7,7 @@ OPTIONAL MATCH (it)-[:DEPENDS_ON]->(eti:Java:Type:Interface)
    WHERE p <> ep
      AND p.fqn <> ep.fqn
      // AND p.incomingDependencies IS NULL // comment out to recalculate
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName 
+    WITH artifact.name AS artifactName 
         ,p
         ,COUNT(et)              AS outgoingDependencies
         ,SUM(r.weight)          AS outgoingDependenciesWeight

--- a/cypher/Metrics/Set_Outgoing_Java_Package_Dependencies_Including_Subpackages.cypher
+++ b/cypher/Metrics/Set_Outgoing_Java_Package_Dependencies_Including_Subpackages.cypher
@@ -1,4 +1,4 @@
-// Set Outgoing Package Dependencies including sub-packages
+// Set Outgoing Package Dependencies including sub-packages. Requires "Add_file_name and_extension.cypher".
 
    MATCH (p:Java:Package)
     WITH *
@@ -14,7 +14,7 @@ OPTIONAL MATCH (p)-[:CONTAINS*0..]->(sp:Package)-[:CONTAINS]->(st:Java:Type)-[r:
      AND ep.fqn <> p.fqn
      // AND p.outgoingDependenciesIncludingSubpackages IS NULL // comment out to recalculate
 OPTIONAL MATCH (st)<-[:DEPENDS_ON]-(ei:Java:Type:Interface)
-    WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+    WITH artifact.name AS artifactName
         ,p
         ,COUNT(et)              AS outgoingDependencies
         ,SUM(r.weight)          AS outgoingDependenciesWeight

--- a/cypher/Miscellaneous/Set_artifactName_property_on_every_Package_node.cypher
+++ b/cypher/Miscellaneous/Set_artifactName_property_on_every_Package_node.cypher
@@ -1,7 +1,7 @@
-// Set artifactName property on every Package node
+// Set artifactName property on every Package node. Requires "Add_file_name and_extension.cypher".
 
 MATCH (a:Artifact:File)-[:CONTAINS]->(p:Package)
 WHERE a.fileName IS NOT NULL
- WITH p, replace(last(split(a.fileName, '/')), '.jar', '') AS artifactName
+ WITH p, a.name AS artifactName
   SET p.artifactName = artifactName
 RETURN p, artifactName

--- a/cypher/Node_Embeddings/Node_Embeddings_0a_Query_Calculated.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_0a_Query_Calculated.cypher
@@ -1,16 +1,16 @@
-// Query already calculated and written node embeddings on nodes with label in parameter $dependencies_projection_node including a communityId and centrality. Variables: dependencies_projection_node, dependencies_projection_write_property
+// Query already calculated and written node embeddings on nodes with label in parameter $dependencies_projection_node including a communityId and centrality. Variables: dependencies_projection_node, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
 
  MATCH (codeUnit)
  WHERE $dependencies_projection_node IN LABELS(codeUnit)
    AND codeUnit[$dependencies_projection_write_property] IS NOT NULL
    // AND codeUnit.notExistingToForceRecalculation IS NOT NULL // uncomment this line to force recalculation
 OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+   WITH *, artifact.name AS artifactName
 OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-       ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', ''))                AS shortCodeUnitName
+       ,codeUnit.name                AS shortCodeUnitName
        ,coalesce(artifactName, projectName)                                                              AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)           AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01)       AS centrality

--- a/cypher/Node_Embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
@@ -1,4 +1,4 @@
-// Node Embeddings 1d using Fast Random Projection: Stream
+// Node Embeddings 1d using Fast Random Projection: Stream. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.fastRP.stream(
  $dependencies_projection + '-cleaned', {
@@ -11,12 +11,12 @@ YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
 OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+   WITH *, artifact.name AS artifactName
 OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-       ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortCodeUnitName
+       ,codeUnit.name AS shortCodeUnitName
        ,coalesce(artifactName, projectName) AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality

--- a/cypher/Node_Embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
@@ -1,4 +1,4 @@
-// Node Embeddings 2c using Hash GNN (Graph Neural Networks): Stream
+// Node Embeddings 2c using Hash GNN (Graph Neural Networks): Stream. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.beta.hashgnn.stream(
  $dependencies_projection + '-cleaned', {
@@ -17,12 +17,12 @@ YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
 OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+   WITH *, artifact.name AS artifactName
 OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-       ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortCodeUnitName
+       ,codeUnit.name AS shortCodeUnitName
        ,coalesce(artifactName, projectName) AS projectName
      ,coalesce(codeUnit.communityLeidenId, 0) AS communityId
      ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality

--- a/cypher/Node_Embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
+++ b/cypher/Node_Embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
@@ -1,4 +1,4 @@
-// Node Embeddings 3c using Node2Vec: Stream
+// Node Embeddings 3c using Node2Vec: Stream. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.node2vec.stream(
  $dependencies_projection + '-cleaned', {
@@ -12,12 +12,12 @@ YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
 OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+   WITH *, artifact.name AS artifactName
 OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-       ,coalesce(codeUnit.name, replace(last(split(codeUnit.fileName, '/')), '.jar', '')) AS shortCodeUnitName
+       ,codeUnit.name AS shortCodeUnitName
        ,coalesce(artifactName, projectName) AS projectName
      ,coalesce(codeUnit.communityLeidenId, 0) AS communityId
      ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality

--- a/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
+++ b/cypher/Overview/Effective_lines_of_method_code_per_package.cypher
@@ -1,10 +1,10 @@
-// Effective lines of method code per package
+// Effective lines of method code per package. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  MATCH (type)-[:DECLARES]->(method:Method)
  WHERE method.effectiveLineCount > 0
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,package.fqn                                              AS fullPackageName
       ,package.name                                             AS packageName
       ,sum(method.effectiveLineCount)                           AS sumEffectiveLinesOfMethodCode

--- a/cypher/Overview/Effective_lines_of_method_code_per_type.cypher
+++ b/cypher/Overview/Effective_lines_of_method_code_per_type.cypher
@@ -1,10 +1,10 @@
-// Effective lines of method code per type
+// Effective lines of method code per type. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
  MATCH (package)-[:CONTAINS]->(type:Type)
  MATCH (type)-[:DECLARES]->(method:Method)
  WHERE method.effectiveLineCount > 0
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,package.fqn                                              AS packageName
       ,type.name                                                AS typeName
       ,sum(method.effectiveLineCount)                           AS sumEffectiveLinesOfMethodCode

--- a/cypher/Overview/Number_of_packages_per_artifact.cypher
+++ b/cypher/Overview/Number_of_packages_per_artifact.cypher
@@ -1,6 +1,6 @@
-// Number of packages per artifact
+// Number of packages per artifact. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)-[:CONTAINS]->(type:Type)
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,count(DISTINCT package.fqn) as numberOfPackages
  RETURN artifactName, numberOfPackages

--- a/cypher/Overview/Number_of_types_per_artifact.cypher
+++ b/cypher/Overview/Number_of_types_per_artifact.cypher
@@ -1,7 +1,7 @@
-// Number of types per artifact
+// Number of types per artifact. Requires "Add_file_name and_extension.cypher".
 
  MATCH (artifact:Artifact)-[:CONTAINS]->(type:Type) 
-  WITH replace(last(split(artifact.fileName, '/')), '.jar', '') AS artifactName
+  WITH artifact.name AS artifactName
       ,count(DISTINCT type.fqn) AS numberOfArtifactTypes
       ,collect(DISTINCT type)   AS types
 UNWIND types AS type

--- a/cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_overall.cypher
+++ b/cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_overall.cypher
@@ -1,0 +1,17 @@
+// Path Finding - All pairs shortest path algorithm - Stream - Overall
+
+  CALL gds.allShortestPaths.stream($dependencies_projection + '-cleaned')
+ YIELD sourceNodeId, targetNodeId, distance
+ WHERE gds.util.isFinite(distance) = true
+  WITH gds.util.asNode(sourceNodeId) AS source
+      ,gds.util.asNode(targetNodeId) AS target
+      ,toInteger(distance)           AS distance
+      ,sourceNodeId
+      ,targetNodeId
+ WHERE sourceNodeId <> targetNodeId
+RETURN distance
+      ,count(*)                     AS pairCount
+      ,count(DISTINCT sourceNodeId) AS sourceNodeCount
+      ,count(DISTINCT targetNodeId) AS targetNodeCount
+      ,collect(DISTINCT source.fileName + ' ->' + target.fileName)[0..2] AS examples
+ORDER BY distance

--- a/cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher
+++ b/cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher
@@ -1,0 +1,41 @@
+// Path Finding - All pairs shortest path algorithm - Stream - Per project
+
+  CALL gds.allShortestPaths.stream($dependencies_projection + '-cleaned')
+ YIELD sourceNodeId, targetNodeId, distance
+// Filter out all pairs that have no connection (infinite distance)
+ WHERE gds.util.isFinite(distance) = true
+  WITH toInteger(distance) AS distance
+      ,sourceNodeId
+      ,targetNodeId
+ WHERE sourceNodeId  <> targetNodeId // Filter out cyclic dependencies
+// Group by distance to get the overall distribution
+  WITH distance
+      ,count(*)                     AS distanceTotalPairCount
+      ,count(DISTINCT sourceNodeId) AS distanceTotalSourceCount
+      ,count(DISTINCT targetNodeId) AS distanceTotalTargetCount
+      ,collect({sourceNodeId: sourceNodeId, targetNodeId: targetNodeId}) AS sourcesAndTargets
+// Unwind group to get every corresponding distance, source and target again
+UNWIND sourcesAndTargets AS sourceAndTarget
+  WITH *
+      ,sourceAndTarget.sourceNodeId AS sourceNodeId
+      ,sourceAndTarget.targetNodeId AS targetNodeId
+// Resolve node ids to actual nodes
+  WITH *
+      ,gds.util.asNode(sourceNodeId) AS source
+      ,gds.util.asNode(targetNodeId) AS target
+// Optionally get the project (e.g. Java Artifact, Typescript Project) the source and target belong to
+OPTIONAL MATCH (sourceProject:Artifact|Project)-[:CONTAINS]->(source)
+OPTIONAL MATCH (targetProject:Artifact|Project)-[:CONTAINS]->(target)
+// Group by project name, if the target project is the same and the distance. Return those as result.
+RETURN sourceProject.name               AS sourceProject
+      ,(targetProject <> sourceProject) AS isDifferentTargetProject
+      ,distance
+      ,distanceTotalPairCount
+      ,distanceTotalSourceCount
+      ,distanceTotalTargetCount
+      ,count(*)                         AS pairCount
+      ,count(DISTINCT sourceNodeId)     AS sourceNodeCount
+      ,count(DISTINCT targetNodeId)     AS targetNodeCount
+      ,collect(DISTINCT source.fileName + ' ->' + target.fileName)[0..4] AS examples
+// Sort by source project name, if the target project is the same and the distance, all ascending
+ORDER BY sourceProject, isDifferentTargetProject, distance

--- a/cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_overall.cypher
+++ b/cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_overall.cypher
@@ -1,0 +1,7 @@
+// Longest paths distribution
+
+  CALL gds.dag.longestPath.stream($dependencies_projection + '-cleaned')
+ YIELD index, sourceNode, targetNode, totalCost, nodeIds, costs, path
+RETURN toInteger(totalCost) AS totalCost
+      ,count(*)             AS nodeCount
+ORDER BY totalCost

--- a/cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_per_project.cypher
+++ b/cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_per_project.cypher
@@ -1,0 +1,46 @@
+// Longest paths distribution
+
+  CALL gds.dag.longestPath.stream($dependencies_projection + '-cleaned')
+ YIELD index, sourceNode, targetNode, totalCost//, nodeIds, costs, path
+  WITH toInteger(totalCost) AS distance
+      ,sourceNode           AS sourceNodeId
+      ,targetNode           AS targetNodeId
+ WHERE sourceNodeId  <> targetNodeId // Filter out cyclic dependencies
+// Group by distance to get the overall distribution
+  WITH distance
+      ,count(*)                     AS distanceTotalPairCount
+      ,count(DISTINCT sourceNodeId) AS distanceTotalSourceCount
+      ,count(DISTINCT targetNodeId) AS distanceTotalTargetCount
+      ,collect({sourceNodeId: sourceNodeId, targetNodeId: targetNodeId}) AS sourcesAndTargets
+// Unwind group to get every corresponding distance, source and target again
+UNWIND sourcesAndTargets AS sourceAndTarget
+  WITH *
+      ,sourceAndTarget.sourceNodeId AS sourceNodeId
+      ,sourceAndTarget.targetNodeId AS targetNodeId
+// Resolve node ids to actual nodes
+  WITH *
+      ,gds.util.asNode(sourceNodeId) AS source
+      ,gds.util.asNode(targetNodeId) AS target
+// Optionally get the project (e.g. Java Artifact, Typescript Project) the source and target belong to
+OPTIONAL MATCH (sourceProject:Artifact|Project)-[:CONTAINS]->(source)
+OPTIONAL MATCH (targetProject:Artifact|Project)-[:CONTAINS]->(target)
+// Group by project name, if the target project is the same and the distance. Return those as result.
+RETURN sourceProject.name               AS sourceProject
+      ,(targetProject <> sourceProject) AS isDifferentTargetProject
+      ,distance
+      ,distanceTotalPairCount
+      ,distanceTotalSourceCount
+      ,distanceTotalTargetCount
+      ,count(*)                         AS pairCount
+      ,count(DISTINCT sourceNodeId)     AS sourceNodeCount
+      ,count(DISTINCT targetNodeId)     AS targetNodeCount
+      ,collect(DISTINCT source.fileName + ' ->' + target.fileName)[0..4] AS examples
+// Sort by source project name, if the target project is the same and the distance, all ascending
+ORDER BY sourceProject, isDifferentTargetProject, distance
+
+
+
+
+//RETURN toInteger(totalCost) AS totalCost
+//      ,count(*)             AS nodeCount
+//ORDER BY totalCost

--- a/cypher/Path_Finding/Set_Parameters.cypher
+++ b/cypher/Path_Finding/Set_Parameters.cypher
@@ -1,0 +1,7 @@
+// Example on how to set the parameters for centrality in this case for Packages and PageRank
+
+:params {
+    "dependencies_projection": "package-path-finding",     
+    "dependencies_projection_node": "Package",
+    "dependencies_projection_weight_property": "weight25PercentInterfaces",
+}

--- a/cypher/Similarity/Similarity_1d_Stream_Mutated.cypher
+++ b/cypher/Similarity/Similarity_1d_Stream_Mutated.cypher
@@ -1,4 +1,4 @@
-// Read the similarity relationship from the projection. Variables: dependencies_projection
+// Read the similarity relationship from the projection. Variables: dependencies_projection. Requires "Add_file_name and_extension.cypher".
 
 CALL gds.graph.relationshipProperty.stream(
      $dependencies_projection + '-cleaned'
@@ -16,8 +16,8 @@ OPTIONAL MATCH (sourceArtifact:Artifact)-[:CONTAINS]->(sourceNode)
 OPTIONAL MATCH (targetArtifact:Artifact)-[:CONTAINS]->(targetNode)
  WITH sourceNode
      ,targetNode
-     ,replace(last(split(sourceArtifact.fileName, '/')), '.jar', '')  AS sourceArtifactName
-     ,replace(last(split(targetArtifact.fileName, '/')), '.jar', '')  AS targetArtifactName
+     ,sourceArtifact.name AS sourceArtifactName
+     ,targetArtifact.name AS targetArtifactName
      ,similarity
  WHERE (sourceNode.incomingDependencies > 0
    OR   sourceNode.outgoingDependencies > 0)

--- a/cypher/Similarity/Similarity_1e_Stream.cypher
+++ b/cypher/Similarity/Similarity_1e_Stream.cypher
@@ -1,4 +1,4 @@
-// Similarity Stream
+// Similarity Stream. Requires "Add_file_name and_extension.cypher".
 
  CALL gds.nodeSimilarity.stream(
   $dependencies_projection + '-cleaned', {
@@ -14,8 +14,8 @@ OPTIONAL MATCH (artifact1:Artifact)-[:CONTAINS]->(node1)
 OPTIONAL MATCH (artifact2:Artifact)-[:CONTAINS]->(node2)
  WITH node1
      ,node2
-     ,replace(last(split(artifact1.fileName, '/')), '.jar', '') AS artifactName1
-     ,replace(last(split(artifact2.fileName, '/')), '.jar', '') AS artifactName2
+     ,artifact1.name AS artifactName1
+     ,artifact2.name AS artifactName2
      ,similarity
 RETURN similarity
       ,artifactName1

--- a/cypher/Topological_Sort/Topological_Sort_List.cypher
+++ b/cypher/Topological_Sort/Topological_Sort_List.cypher
@@ -19,4 +19,4 @@ FOREACH (i IN range(0, SIZE(sortedNodeIds)-1) |
  UNWIND topologicalSortedCodeUnits       AS sorted
  RETURN coalesce(sorted.codeUnit.fqn, sorted.codeUnit.fileName, sorted.codeUnit.name) AS codeUnitName
        ,sorted.codeUnit.maxDistanceFromSource                                         AS maxDistanceFromSource
-       ,overallMaxDistance                                                            AS overalNumberOfBuildLevels
+       ,overallMaxDistance                                                            AS overallNumberOfBuildLevels

--- a/cypher/Topological_Sort/Topological_Sort_Query.cypher
+++ b/cypher/Topological_Sort/Topological_Sort_Query.cypher
@@ -1,4 +1,4 @@
-// Topological Sort to query the properties topologicalSortIndex (e.g. build order) and maxDistanceFromSource (build level) for each code unit node in topologicalSortIndex order.
+// Topological Sort to query the properties topologicalSortIndex (e.g. build order) and maxDistanceFromSource (build level) for each code unit node in topologicalSortIndex order. Requires "Add_file_name and_extension.cypher".
 // Needs graph-data-science plugin version >= 2.5.0
 
 MATCH (codeUnit)
@@ -9,7 +9,7 @@ MATCH (codeUnit)
       ,max(codeUnit.maxDistanceFromSource) AS overallMaxDistanceFromSource
 UNWIND codeUnits AS codeUnit
 RETURN coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.name)                          AS codeUnitName
-      ,coalesce(replace(last(split(codeUnit.fileName, '/')), '.jar', ''), codeUnit.name) AS shortName
+      ,codeUnit.name                                                                     AS shortName
       ,codeUnit.topologicalSortIndex                                                     AS topologicalSortIndex
       ,codeUnit.maxDistanceFromSource                                                    AS maxDistanceFromSource
       ,overallMaxDistanceFromSource

--- a/cypher/Visibility/Global_relative_visibility_statistics_for_types.cypher
+++ b/cypher/Visibility/Global_relative_visibility_statistics_for_types.cypher
@@ -1,9 +1,9 @@
-// Global relative visibility statistics for types
+// Global relative visibility statistics for types. Requires "Add_file_name and_extension.cypher".
 
          MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
          MATCH (package)-[:CONTAINS]->(anyType:Type)
 OPTIONAL MATCH (package)-[:CONTAINS]->(publicType:Type{visibility:"public"})
- WITH replace(last(split(artifact.fileName, '/')),'.jar','') AS artifact
+ WITH artifact.name              AS artifact
      ,package
      ,COUNT(DISTINCT publicType) AS publicTypes
      ,COUNT(DISTINCT anyType)    AS allTypes

--- a/cypher/Visibility/Relative_visibility_public_types_to_all_types_per_package.cypher
+++ b/cypher/Visibility/Relative_visibility_public_types_to_all_types_per_package.cypher
@@ -1,9 +1,9 @@
-// Relative visibility: public types to all types per package
+// Relative visibility: public types to all types per package. Requires "Add_file_name and_extension.cypher".
 
          MATCH (artifact:Artifact)-[:CONTAINS]->(package:Package)
          MATCH (package)-[:CONTAINS]->(anyType:Type)
 OPTIONAL MATCH (package)-[:CONTAINS]->(publicType:Type{visibility:"public"})
- WITH replace(last(split(artifact.fileName, '/')),'.jar','') AS artifactName
+ WITH artifact.name              AS artifactName
      ,package
      ,COUNT(DISTINCT publicType) AS publicTypes
      ,COUNT(DISTINCT anyType)    AS allTypes

--- a/jupyter/DependenciesGraphJava.ipynb
+++ b/jupyter/DependenciesGraphJava.ipynb
@@ -159,15 +159,6 @@
     "      }\n",
     "    }\n",
     "  }\n",
-    "  configuration.labels.Artifact = {\n",
-    "      [NeoVis.NEOVIS_ADVANCED_CONFIG]: {\n",
-    "          function: {\n",
-    "              // Use \"fileName\" as label. Remove leading slash, trailing \".jar\" and version number.\n",
-    "              // TODO Enrich the Graph so that there is a distinct property for the \"cleaned up\" artifact name\n",
-    "              label: (node) => node.properties.fileName.replace('/', '').replace('.jar', '').replace(/-[\\d\\\\.]+/, '')\n",
-    "          }\n",
-    "      }\n",
-    "  }\n",
     "  console.debug(configuration)\n",
     "  const neoViz = new NeoVis.default(configuration);\n",
     "  neoViz.render();\n",
@@ -244,7 +235,7 @@
     "        \"initialCypher\": query,\n",
     "        \"labels\": {\n",
     "            \"Artifact\": {\n",
-    "                \"label\": \"fileName\"\n",
+    "                \"label\": \"name\"\n",
     "            },\n",
     "        },\n",
     "        \"relationships\": {\n",
@@ -312,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   },
   "title": "Neo4j Java Code-Structure Graph"
  },

--- a/jupyter/DependenciesGraphTypescript.ipynb
+++ b/jupyter/DependenciesGraphTypescript.ipynb
@@ -159,15 +159,6 @@
     "      }\n",
     "    }\n",
     "  }\n",
-    "  configuration.labels.Artifact = {\n",
-    "      [NeoVis.NEOVIS_ADVANCED_CONFIG]: {\n",
-    "          function: {\n",
-    "              // Use \"fileName\" as label. Remove leading slash, trailing \".jar\" and version number.\n",
-    "              // TODO Enrich the Graph so that there is a distinct property for the \"cleaned up\" artifact name\n",
-    "              label: (node) => node.properties.fileName.replace('/', '').replace('.jar', '').replace(/-[\\d\\\\.]+/, '')\n",
-    "          }\n",
-    "      }\n",
-    "  }\n",
     "  console.debug(configuration)\n",
     "  const neoViz = new NeoVis.default(configuration);\n",
     "  neoViz.render();\n",
@@ -314,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   },
   "title": "Neo4j Java Code-Structure Graph"
  },

--- a/jupyter/PathFindingJava.ipynb
+++ b/jupyter/PathFindingJava.ipynb
@@ -1,0 +1,1530 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Path Finding for Java\n",
+    "\n",
+    "This notebook demonstrates different ways on how path finding algorithms can be utilized for code analysis. \n",
+    "\n",
+    "Path algorithms in Graphs are famous for e.g. finding the fastest way from one place to another. How can these be applied to static code analysis and how can the results be interpreted?\n",
+    "\n",
+    "One promising algorithm is [All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path). It shows dependencies from a different perspective and provides an overview on how directly or indirectly dependencies are connected to each other. The longest shortest path has an additional meaning: It is also known as the [**Graph Diameter**](https://mathworld.wolfram.com/GraphDiameter.html) and is very useful as a metric for the complexity of the Graph (or Subgraphs). The same applies to the longest path (for directed acyclic graphs) that can uncover long dependency chains.\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)\n",
+    "- [All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path)\n",
+    "- [Longest Path for DAG (neo4j)](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path)\n",
+    "- [Graph Diameter](https://mathworld.wolfram.com/GraphDiameter.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec6baa64",
+   "metadata": {},
+   "source": [
+    "## What GPT-4 has to say about it\n",
+    "\n",
+    "### All pairs shortest path\n",
+    "\n",
+    "Interpreting the results of the \"all pairs shortest path\" algorithm on a graph of statically analyzed code modules and their dependencies involves understanding the structure and implications of the paths between nodes (modules) in the graph. Here are some specific steps and insights to consider:\n",
+    "\n",
+    "1. **Graph Structure**: Each node represents a code module, and edges indicate dependencies. A directed edge from module A to module B implies that A depends on B.\n",
+    "\n",
+    "2. **Shortest Paths**: The results will give you the shortest path lengths between all pairs of modules. This helps identify:\n",
+    "  - **Direct Dependencies**: A length of 1 indicates a direct dependency.\n",
+    "  - **Transitive Dependencies**: A length greater than 1 shows indirect dependencies. For example, if the path from A to C is 2, it could mean A → B → C, indicating A indirectly depends on C via B.\n",
+    "\n",
+    "3. **Module Isolation**: If a module has very long paths to others, it might be more isolated. This could signal potential issues in the code structure, suggesting that module might be overly complex or decoupled from the rest of the system.\n",
+    "\n",
+    "4. **Critical Paths**: Identify the shortest paths that connect key modules (e.g., core functionalities). These paths can highlight the most crucial dependencies that, if modified, might have extensive impacts on the system.\n",
+    "\n",
+    "5. **Cycle Detection**: If any pairs have paths that loop back to themselves with a length not equal to 0, it indicates a cycle. Cycles can complicate dependency management, potentially leading to recursive dependencies, which can be problematic in terms of maintainability.\n",
+    "\n",
+    "6. **Refactoring Opportunities**: By examining the lengths of paths, you might identify modules that could benefit from refactoring to decrease dependency complexity. For example, a module that has dependencies on many others (with longer path lengths) might be a candidate for breaking into smaller, more manageable components.\n",
+    "\n",
+    "7. **Performance Considerations**: In large systems, long paths could impact performance. If certain modules are far from frequently accessed modules, consider whether they can be optimized for speed.\n",
+    "\n",
+    "8. **Visual Representation**: Creating a visual representation of the graph with the shortest paths highlighted can be immensely helpful. Tools like Graphviz or D3.js can illustrate these relationships clearly, aiding in your analysis.\n",
+    "\n",
+    "By focusing on these aspects, you can glean actionable insights from the results of the all pairs shortest path algorithm in the context of your statically analyzed code modules and their dependencies.\n",
+    "\n",
+    "### Graph diameter (shortest longest path)\n",
+    "\n",
+    "The longest shortest path in a dependency graph (often referred to in graph theory as the \"diameter\" of the graph) represents the maximum distance (in terms of the number of edges or dependencies) between any two nodes (modules) in the graph. Here’s how you can interpret this metric in the context of statically analyzed code modules and their dependencies:\n",
+    "\n",
+    "1. **Network Complexity**: The longest shortest path indicates the overall complexity of the network of dependencies. A longer path suggests a more complicated interrelationship among modules. For example, a longest shortest path of 6 could indicate that there is at least one pair of modules in your system that rely on a chain of 6 other modules to communicate or function together.\n",
+    "\n",
+    "2. **Potential Bottlenecks**: If the longest shortest path is significant, it may suggest potential bottlenecks in your architecture. For instance, if a core module at the beginning of a long path is slow or error-prone, it could affect numerous other modules dependent on it, resulting in systemic performance issues.\n",
+    "\n",
+    "3. **Critical Communication Points**: The endpoints of the longest shortest path can be seen as critical communication points within your codebase. Understanding these connections can help identify which modules should be prioritized for testing and monitoring, especially during changes.\n",
+    "\n",
+    "4. **Isolation and Coupling**: A long longest shortest path might indicate that some modules are isolated and far removed from others, which can suggest low cohesion. This can be a sign that the architecture might benefit from refactoring to reduce unnecessary dependencies or to improve modularity.\n",
+    "\n",
+    "5. **Refactoring Opportunities**: If the longest shortest path is disproportionately long, it may highlight areas in the codebase where modules are too tightly coupled. This situation presents an opportunity for refactoring to create more independent modules or components that can interact with fewer dependencies.\n",
+    "\n",
+    "6. **Impact of Changes**: Modules that lie along or are endpoints of the longest shortest paths are likely to have a significant impact on the overall system. Changes to them should be approached with caution and accompanied by rigorous testing.\n",
+    "\n",
+    "7. **Cycle Detection**: In some cases, a long shortest path can indicate the presence of cycles in the graph. If there are paths that seem to loop back on themselves, it suggests potential design flaws that could lead to recursion or infinite loops, complicating maintenance.\n",
+    "\n",
+    "8. **Architectural Decisions**: The longest shortest path can inform architectural decisions by providing insights into which dependencies might need to be revised or eliminated. For instance, if certain modules are consistently part of the longest path, it could justify investing resources in redesigning their interactions.\n",
+    "\n",
+    "In summary, interpreting the longest shortest path provides a comprehensive view of the interdependencies among modules in your system, focusing on complexity, potential bottlenecks, and opportunities for improvement in architecture and design.\n",
+    "\n",
+    "### Longest path\n",
+    "\n",
+    "1. **Complex Dependencies**: Longest paths indicate modules that have extensive dependencies before reaching another module. For instance, if you find a path like A → B → C → D with a length of 4, it highlights a complex chain of dependencies. This can suggest that changes in module A might have far-reaching implications across the system.\n",
+    "\n",
+    "2. **Potential Bottlenecks**: Modules located at the beginning of long paths could be performance bottlenecks. If a frequently used module is several layers deep in dependencies (e.g., A → B → C), it may slow down the entire system. Optimizing or refactoring these modules could improve performance.\n",
+    "\n",
+    "3. **Maintenance Challenges**: Long paths may indicate parts of the code that are difficult to maintain or understand. For example, if module A requires multiple intermediary modules (B, C, D) for its functionality, developers may struggle to trace how changes propagate, leading to potential bugs.\n",
+    "\n",
+    "4. **Risk of Change**: A module with a long dependency path can be more risky to modify. If A has dependencies on several modules down the line (e.g., A → B → C → D → E), any changes to A could inadvertently affect E, which might be critical or sensitive. This insight can help prioritize testing and reviews around such modules.\n",
+    "\n",
+    "5. **Decoupling Opportunities**: Identifying the longest paths can highlight areas where you might want to break up dependencies. If there’s a long chain that could be simplified (e.g., by creating intermediary modules or interfaces), it may lead to a more modular and maintainable architecture.\n",
+    "\n",
+    "6. **Redundancy**: Long paths may also reveal redundancy in dependencies. For instance, if multiple modules depend on a series of others (A → B → C → D and A → B → E), it could indicate unnecessary coupling that can be streamlined.\n",
+    "\n",
+    "7. **System Understanding**: Long paths can help map out the architecture of your codebase. Understanding which modules are pivotal in long chains can provide insights into the overall design and help inform architectural decisions.\n",
+    "\n",
+    "8. **Documentation & Knowledge Transfer**: If certain modules consistently appear in the longest paths, they may require better documentation. Ensuring that their roles and the reasons for their lengthy dependencies are well understood can facilitate knowledge transfer among team members.\n",
+    "\n",
+    "By focusing on the longest paths in your dependency graph, you can uncover areas requiring attention for optimization, maintenance, and improved system architecture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 309,
+   "id": "d19447e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from IPython.display import display\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "import typing as typ\n",
+    "import numpy as np\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 310,
+   "id": "807bba03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb92ef74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 312,
+   "id": "648e2a5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 313,
+   "id": "e49ca888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pandas DataFrame Display Configuration\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 314,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 315,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 316,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename, parameters_: typ.Optional[typ.Dict[str, typ.Any]] = None):\n",
+    "    records, summary, keys = driver.execute_query(get_cypher_query_from_file(filename),parameters_=parameters_)\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 317,
+   "id": "7d2e62d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_directed_unweighted_projection(parameters: dict) -> bool: \n",
+    "    \"\"\"\n",
+    "    Creates an directed homogenous unweighted in-memory Graph projection for/with Neo4j Graph Data Science Plugin.\n",
+    "    It returns True if there is data available for the given parameter and False otherwise.\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    dependencies_projection : str\n",
+    "        The name prefix for the in-memory projection for dependencies. Example: \"java-package-path-finding-notebook\"\n",
+    "    dependencies_projection_node : str\n",
+    "        The label of the nodes that will be used for the projection. Example: \"Package\"\n",
+    "    dependencies_projection_weight_property : str\n",
+    "        The name of the node property that contains the dependency weight. Example: \"weight25PercentInterfaces\"\n",
+    "    dependencies_projection_embedding_dimension : str\n",
+    "        The number of the dimensions and therefore size of the resulting array of floating point numbers\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    is_data_missing=query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_0_Check_Projectable.cypher\", parameters).empty\n",
+    "    if is_data_missing: return False\n",
+    "\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_1_Delete_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_2_Delete_Subgraph.cypher\", parameters)\n",
+    "    # To exclude the direction of the relationships use the following line to create the projection:\n",
+    "    # query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_4_Create_Undirected_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_3_Create_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_5_Create_Subgraph.cypher\", parameters)\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 318,
+   "id": "3f2e905c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def empty_projection_result() -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Creates an empty result and is meant to be used in case there is no data for the projection.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    print(\"No projected data for path finding available\")\n",
+    "    return pd.DataFrame(columns=['totalCost', 'sourceProject', 'isDifferentTargetProject', 'distance', 'distanceTotalPairCount', 'distanceTotalSourceCount', 'distanceTotalTargetCount', 'nodeCount', 'pairCount'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 319,
+   "id": "d2d60597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_if_data_available(is_data_available: bool, cypher_file_name: str, parameters: dict) -> pd.DataFrame: \n",
+    "    \"\"\"\n",
+    "    Runs the cypher query in the file given as cypherFileName with the given parameters if the data is available,\n",
+    "    or returns an empty result if the projection failed due to missing data.\n",
+    "    \n",
+    "    is_data_available\n",
+    "    ----------\n",
+    "    Pass the returned boolean from the projection creation here. Will return an empty result if false and otherwise execute the query.\n",
+    "\n",
+    "    cypher_file_name\n",
+    "    ----------\n",
+    "    Name of the file containing the Cypher query that executes node embeddings procedure.\n",
+    "\n",
+    "    parameters\n",
+    "    ----------\n",
+    "    dependencies_projection : str\n",
+    "        The name prefix for the in-memory projection for dependencies. Example: \"java-package-path-finding-notebook\"\n",
+    "    dependencies_projection_node : str\n",
+    "        The label of the nodes that will be used for the projection. Example: \"Package\"\n",
+    "    dependencies_projection_weight_property : str\n",
+    "        The name of the node property that contains the dependency weight. Example: \"weight25PercentInterfaces\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return query_cypher_to_data_frame(cypher_file_name, parameters) if is_data_available else empty_projection_result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 320,
+   "id": "5ef848fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_total_distance_distribution(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the DataFrame only containing the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\", \"distanceTotalPairCount\", \"distanceTotalSourceCount\" and \"distanceTotalTargetCount\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return data_frame[['distance', 'distanceTotalPairCount', 'distanceTotalSourceCount', 'distanceTotalTargetCount']].drop_duplicates().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 344,
+   "id": "a9211397",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_longest_path_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the DataFrame grouped by the source project (e.g. Java artifact or Typescript project) containing their max/longest distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"isDifferentTargetProject\", \"distance\" and \"sourceProject\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return data_frame.groupby('sourceProject')['distance'].max().sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 322,
+   "id": "036264ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_distance_distribution_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "\n",
+    "    data_frame = data_frame.copy()\n",
+    "\n",
+    "    # Rows contain the source project (e.g. Java artifact or Typescript project) and its the pair count.\n",
+    "    # The columns contain the distances.\n",
+    "    data_frame = data_frame.pivot(index='distance', columns='sourceProject', values='pairCount')\n",
+    "\n",
+    "    # Sort by column sum and then take only the first 40 columns\n",
+    "    sum_of_pair_count = data_frame.sum()\n",
+    "    data_frame = data_frame[sum_of_pair_count.sort_values(ascending=False).index[:40]]\n",
+    "\n",
+    "    # Fill missing values with zeroes\n",
+    "    data_frame = data_frame.fillna(0)\n",
+    "\n",
+    "    # Transpose the table (flip columns and rows) to have a row for every source project\n",
+    "    data_frame = data_frame.transpose()\n",
+    "\n",
+    "    return data_frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 323,
+   "id": "de2e71ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize_distance_distribution_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the normalized data in percentage of the DataFrame for each source project\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Pivot dataframe with source projects in rows, distances in columns and pair count values\n",
+    "    \"\"\"\n",
+    "    return data_frame.div(data_frame.sum(axis=1), axis=0) * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 324,
+   "id": "27a583e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_total_distances_bar_chart(data_frame: pd.DataFrame, title: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the total number of pairs for each distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"All pairs shortest path for Java package dependencies in total (bar)\"\n",
+    "\n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"total number of Java package pairs\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        data_frame.plot(\n",
+    "            title=title,\n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            x='distance',\n",
+    "            y='distanceTotalPairCount',\n",
+    "            xlabel='path length',\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(9,7),\n",
+    "            legend=False,\n",
+    "            fontsize=8,\n",
+    "            cmap=main_color_map\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 325,
+   "id": "e63ddc97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_total_distances_pie_chart(data_frame: pd.DataFrame, title: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the total number of pairs for each distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"All pairs shortest path for Java package dependencies in total (pie)\".\n",
+    "\n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Total number of Java package pairs\"\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        explode_all=np.full(data_frame.shape[0], 0.01)\n",
+    "        total_number_of_pairs=data_frame['distanceTotalPairCount'].sum()\n",
+    "        def custom_auto_percentage_format(percentage):\n",
+    "            return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_pairs*percentage/100)\n",
+    "\n",
+    "        plot.figure();\n",
+    "        data_frame.plot(\n",
+    "            title=title, \n",
+    "            kind='pie', \n",
+    "            labels=data_frame['distance'],\n",
+    "            y='distanceTotalPairCount', \n",
+    "            ylabel=ylabel,\n",
+    "            legend=True,\n",
+    "            labeldistance=None,\n",
+    "            autopct=custom_auto_percentage_format,\n",
+    "            explode=explode_all,\n",
+    "            textprops={'fontsize': 8},\n",
+    "            pctdistance=1.2,\n",
+    "            figsize=(8,8),\n",
+    "            cmap=main_color_map\n",
+    "        )\n",
+    "        plot.legend(bbox_to_anchor=(1.05, 1), loc='upper left', title='path length')\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 326,
+   "id": "7243fbfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_longest_distance_per_source_project(data_frame: pd.DataFrame, title: str, xlabel: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the longest distance per source project \n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: 'Longest shortest path (\"diameter\") for Java package dependencies per artifact'\n",
+    "\n",
+    "    xlabel\n",
+    "    ----------\n",
+    "    X-axis label. Example: \"Artifact\".\n",
+    "    \n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Java package pairs\".    \n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        plot.figure();\n",
+    "        axes = data_frame.transpose().plot(\n",
+    "            title=title, \n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            xlabel=xlabel,\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(10,6),\n",
+    "            legend=False,\n",
+    "            cmap=main_color_map\n",
+    "        )\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 327,
+   "id": "5262a4ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_source_projects_distances_stacked(data_frame: pd.DataFrame, title: str, xlabel: str, ylabel: str, logy: bool = False):\n",
+    "    \"\"\"\n",
+    "    Plots each source project (e.g. Java artifact or Typescript project) stacked by distance (number of dependency pairs)\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the output of \"get_distance_distribution_for_each_source_project\" with the \n",
+    "    source projects as rows, distances as columns and number of pairs as values.\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"Longest shortest path (\"diameter\") for Java packages \".\n",
+    "\n",
+    "    xlabel\n",
+    "    ----------\n",
+    "    X-axis label. Example: \"Artifact\".\n",
+    "    \n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Java package pairs\".\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        plot.figure();\n",
+    "        axes = data_frame.plot(\n",
+    "            title=title, \n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            stacked=True,\n",
+    "            logy=logy,\n",
+    "            xlabel=xlabel,\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(10,6),\n",
+    "            legend=True,\n",
+    "            cmap=main_color_map\n",
+    "        ).legend(bbox_to_anchor=(1.0, 1.0), title=\"path length\")\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b42163d",
+   "metadata": {},
+   "source": [
+    "## 1. Java Packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1ce698",
+   "metadata": {},
+   "source": [
+    "## 1.1 All pairs shortest path\n",
+    "\n",
+    "Use \"[All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path)\" algorithm to get the shortest path distance between all pairs of dependent Java packages. It shows how many Packages have a direct dependency (distance 1), how many are reachable with one dependency in between (distance 2), and so on..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b468bae",
+   "metadata": {},
+   "source": [
+    "### 1.1.1 Create a projection of all Java package dependencies\n",
+    "\n",
+    "Creates a in-memory projection of \"Java:Package\" nodes and their \"DEPENDS_ON\" relationships as a preparation to run the Graph algorithms. The weight property is not used for now (September 2024) but may be needed for other algorithms/variants some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 328,
+   "id": "1ecc41b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "package_path_finding_parameters={\n",
+    "    \"dependencies_projection\": \"java-package-path-finding-notebook\",\n",
+    "    \"dependencies_projection_node\": \"Package\",\n",
+    "    \"dependencies_projection_weight_property\": \"weight25PercentInterfaces\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 329,
+   "id": "0b637ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the directed and unweighted projection with the parameters defined directly above\n",
+    "is_package_data_available=create_directed_unweighted_projection(package_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf7a594",
+   "metadata": {},
+   "source": [
+    "#### Projected Graph statistics for Java package dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf414643",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Projection data available: \" + str(is_package_data_available))\n",
+    "package_projection_statistics=query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_12_Get_Projection_Statistics.cypher\", package_path_finding_parameters)\n",
+    "package_projection_statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "924c9b26",
+   "metadata": {},
+   "source": [
+    "### 1.1.2 All pairs shortest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the all pairs shortest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 331,
+   "id": "62f50f28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"All pairs shortest path\" and query overall and artifact specific results\n",
+    "all_pairs_shortest_paths_distribution_per_artifact=query_if_data_available(is_package_data_available, \"../cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher\", package_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6f93160",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Longest shortest path (Graph Diameter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce1621b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "package_dependencies_graph_diameter=all_pairs_shortest_paths_distribution_per_artifact['distance'].max()\n",
+    "print('The diameter (longest shortest path) of the projected package dependencies Graph is:', package_dependencies_graph_diameter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e502afa1",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9ebcaa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_artifact_in_total=get_total_distance_distribution(all_pairs_shortest_paths_distribution_per_artifact)\n",
+    "all_pairs_shortest_paths_distribution_per_artifact_in_total.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df87dc06",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fee79fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_artifact_in_total, \n",
+    "    title='All pairs shortest path for Java package dependencies in total (bar)',\n",
+    "    ylabel='total number of java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf4b2733",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Pie chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab444978",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_artifact_in_total,\n",
+    "    title='All pairs shortest path for Java package dependencies in total (pie)',\n",
+    "    ylabel='total number of Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1129f77",
+   "metadata": {},
+   "source": [
+    "### 1.1.3 All pairs shortest path in detail\n",
+    "\n",
+    "The following table shows the first 10 rows with all details of the query above. It contains the results of the \"all pairs shortest path\" algorithm including the artifact the source node belong to and if the target node is the same or not. The main intuition here is to show how the data is structured. It provides the basis for tables and charts shown in following sections below, that filter and group the data accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64ab393b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_artifact.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae9d8868",
+   "metadata": {},
+   "source": [
+    "### 1.1.4 All pairs shortest path for each artifact\n",
+    "\n",
+    "In this section we'll focus only on pairs of nodes that both belong to the same artifact, filtering out every line that has `isDifferentTargetProject==False`. The first ten rows are shown in a table followed by charts that show the distribution of shortest path distances across different artifacts in stacked bar charts (absolute and normalized).\n",
+    "\n",
+    "**Note:** It is possible that a (shortest) path could have nodes in between that belong to different artifacts. Therefore, the data of each artifact isn't perfectly isolated. However, it shows how the dependencies interact across artifacts \"in real life\" while still providing a decent isolation of each artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f84af34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_artifact_isolated=all_pairs_shortest_paths_distribution_per_artifact.query('isDifferentTargetProject == False')\n",
+    "all_pairs_shortest_paths_distribution_per_artifact_isolated.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c400fc8c",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each artifact - Longest shortest path (Diameter) for each artifact\n",
+    "\n",
+    "Shows the top 20 artifacts with the longest shortest path (=Graph Diameter)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bc3b27d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph_diameter_per_artifact = get_longest_path_for_each_source_project(all_pairs_shortest_paths_distribution_per_artifact_isolated)\n",
+    "graph_diameter_per_artifact.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c65fd16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_longest_distance_per_source_project(\n",
+    "    data_frame=graph_diameter_per_artifact,\n",
+    "    title='Longest shortest path (\"diameter\") for Java package dependencies per artifact',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='longest path length'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1138de0c",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each artifact - Bar chart (absolute)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b90cfbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_artifact_isolated_pivot = get_distance_distribution_for_each_source_project(all_pairs_shortest_paths_distribution_per_artifact_isolated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebeaf685",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_artifact_isolated_pivot,\n",
+    "    title='All pairs shortest path for Java package dependencies stacked per artifact (absolute, logarithmic)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths',\n",
+    "    logy=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f8f817",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each artifact - Bar chart (normalized)\n",
+    "\n",
+    "Shows the top 50 artifacts with the highest number of dependency paths stacked by their length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "533d1b9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize data (percent of sum pairs)\n",
+    "all_pairs_shortest_paths_distribution_per_artifact_isolated_normalized_pivot=normalize_distance_distribution_for_each_source_project(all_pairs_shortest_paths_distribution_per_artifact_isolated_pivot)\n",
+    "all_pairs_shortest_paths_distribution_per_artifact_isolated_normalized_pivot.head(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2721c41d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_artifact_isolated_normalized_pivot.head(50),\n",
+    "    title='All pairs shortest path for Java package dependencies stacked per artifact (normalized in %)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37da9d90",
+   "metadata": {},
+   "source": [
+    "## 1.2 Longest path\n",
+    "\n",
+    "Use [Longest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path) algorithm to get the longest paths between Java packages. It is typically higher than the longest shortest path (diameter) and helps together with it to get a good overview of the complexity.\n",
+    "\n",
+    "**Note:** This algorithm requires a Directed Acyclic Graph (DAG) and will lead to inaccurate results when the Graph contains cycles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9f9b8bb",
+   "metadata": {},
+   "source": [
+    "### 1.2.1 Longest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the longest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b43628b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"longest path (for directed acyclic graphs)\" and query overall and artifact specific results\n",
+    "longest_paths_distribution_per_artifact=query_if_data_available(is_package_data_available, \"../cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_per_project.cypher\", package_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaa7ae83",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Max longest path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aef9c47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "package_dependencies_max_longest_path=longest_paths_distribution_per_artifact['distance'].max()\n",
+    "print('The max. longest path of the projected package dependencies is:', package_dependencies_max_longest_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cf188a8",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Paths per length - Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4141d7d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, display only the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "longest_paths_distribution_per_artifact_in_total=get_total_distance_distribution(longest_paths_distribution_per_artifact)\n",
+    "longest_paths_distribution_per_artifact_in_total.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46544c70",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9db65656",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=longest_paths_distribution_per_artifact_in_total, \n",
+    "    title='Longest path for Java package dependencies in total (bar)',\n",
+    "    ylabel='total number of Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4962464",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Pie chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf2efa87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=longest_paths_distribution_per_artifact_in_total,\n",
+    "    title='Longest path for Java package dependencies in total (pie)',\n",
+    "    ylabel='total number of Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d53beaf7",
+   "metadata": {},
+   "source": [
+    "### 1.2.2 Longest path in detail\n",
+    "\n",
+    "The following table shows the first 10 rows with all details of the query above. It contains the results of the \"longest path\" algorithm including the artifact the source node belongs to and if the target node is in the same artifact or not. The main intuition is to show how the data is structured. It provides the basis for tables and charts shown in following sections below, that filter and group the data accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdea2997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_artifact.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ec96376",
+   "metadata": {},
+   "source": [
+    "### 1.2.3 Longest path for each artifact\n",
+    "\n",
+    "In this section we'll focus only on pairs of nodes that both belong to the same artifact, filtering out every line that has `isDifferentTargetProject==False`. The first ten rows are shown in a table followed by charts that show the distribution of longest path distances across different artifacts in stacked bar charts (absolute and normalized).\n",
+    "\n",
+    "**Note:** It is possible that a (longest) path could have nodes in between that belong to different artifacts. Therefore, the data of each artifact isn't perfectly isolated. However, it shows how the dependencies interact across artifacts \"in real life\" while still providing a decent isolation of each artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb6e2ff7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_artifact_isolated=longest_paths_distribution_per_artifact.query('isDifferentTargetProject == False')\n",
+    "longest_paths_distribution_per_artifact_isolated.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2adbdac",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Max. longest path for each artifact\n",
+    "\n",
+    "Shows the top 20 artifacts with their max. longest path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f0ddb2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_path_per_artifact = get_longest_path_for_each_source_project(longest_paths_distribution_per_artifact_isolated)\n",
+    "longest_path_per_artifact.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd4a7f36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_longest_distance_per_source_project(\n",
+    "    data_frame=longest_path_per_artifact,\n",
+    "    title='Max. longest path for Java package dependencies per artifact',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='max. longest path length'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e0e1442",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Bar chart (absolute)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "id": "9765cec6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_artifact_isolated_pivot = get_distance_distribution_for_each_source_project(longest_paths_distribution_per_artifact_isolated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7a73b97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=longest_paths_distribution_per_artifact_isolated_pivot,\n",
+    "    title='Longest path for Java package dependencies stacked per artifact (absolute, logarithmic)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths',\n",
+    "    logy=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03bf4b28",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Bar chart (normalized)\n",
+    "\n",
+    "Shows the top 50 artifacts with the highest number of dependency paths stacked by their length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cdfed61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize data (percent of sum pairs)\n",
+    "longest_paths_distribution_per_artifact_isolated_normalized_pivot=normalize_distance_distribution_for_each_source_project(longest_paths_distribution_per_artifact_isolated_pivot)\n",
+    "longest_paths_distribution_per_artifact_isolated_normalized_pivot.head(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2cc0a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=longest_paths_distribution_per_artifact_isolated_normalized_pivot.head(50),\n",
+    "    title='Longest path for Java package dependencies stacked per artifact (normalized in %)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32d844b5",
+   "metadata": {},
+   "source": [
+    "## 2. Java Artifacts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b46ab138",
+   "metadata": {},
+   "source": [
+    "## 2.1 All pairs shortest path\n",
+    "\n",
+    "Use [All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path) algorithm to get the shortest path distance between all pairs of dependent Java artifacts. It shows how many artifacts have a direct dependency (distance 1), how many are reachable with one dependency in between (distance 2), and so on..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6659bca",
+   "metadata": {},
+   "source": [
+    "### 2.1.1 Create a projection of all Java artifacts dependencies\n",
+    "\n",
+    "Creates a in-memory projection of \"Java:Artifact\" nodes and their \"DEPENDS_ON\" relationships as a preparation to run the Graph algorithms. The weight property is not used for now (September 2024) but may be needed for other algorithms/variants some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 223,
+   "id": "cec6c79b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_path_finding_parameters={\n",
+    "    \"dependencies_projection\": \"java-artifact-path-finding-notebook\",\n",
+    "    \"dependencies_projection_node\": \"Artifact\",\n",
+    "    \"dependencies_projection_weight_property\": \"weight\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "id": "deda506f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the directed and unweighted projection with the parameters defined directly above\n",
+    "is_artifact_data_available=create_directed_unweighted_projection(artifact_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57e8dbb7",
+   "metadata": {},
+   "source": [
+    "#### Projected Graph statistics for Java Artifact dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6c8cdd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_projection_statistics=query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_12_Get_Projection_Statistics.cypher\", artifact_path_finding_parameters)\n",
+    "artifact_projection_statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f72d6360",
+   "metadata": {},
+   "source": [
+    "### 2.1.2 All pairs shortest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the all pairs shortest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0cdf8c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"All pairs shortest path\" and query overall and artifact specific results\n",
+    "all_pairs_shortest_paths_distribution_for_artifacts=query_if_data_available(is_artifact_data_available, \"../cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher\", artifact_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23b9718a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, display only the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "all_pairs_shortest_paths_distribution_for_artifacts=get_total_distance_distribution(all_pairs_shortest_paths_distribution_for_artifacts)\n",
+    "all_pairs_shortest_paths_distribution_for_artifacts.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa9c2a84",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Longest shortest path (Diameter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49447fdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_dependencies_graph_diameter=all_pairs_shortest_paths_distribution_for_artifacts['distance'].max()\n",
+    "print('The diameter (longest shortest path) of the projected artifact dependencies Graph is:', artifact_dependencies_graph_diameter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba3c98d6",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df331765",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_for_artifacts, \n",
+    "    title='All pairs shortest path for Java artifact dependencies in total (bar)',\n",
+    "    ylabel='total number of java artifact paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3903b5b",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cceddc5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_for_artifacts,\n",
+    "    title='All pairs shortest path for Java artifact dependencies in total (pie)',\n",
+    "    ylabel='total number of Java artifact paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a28bbb56",
+   "metadata": {},
+   "source": [
+    "## 2.2 Longest path\n",
+    "\n",
+    "Use [Longest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path) algorithm to get the longest paths between Java artifacts. This is especially interesting because an artifact can only be built when the artifacts it depends on are built (and published). The longest path shows in this case the total/max. number of build levels that are needed in case everything needs to be rebuild (\"worst case\"). Its also an interesting metric for complexity. It is typically higher than the longest shortest path (diameter) and helps together with it to get a good overview of the complexity.\n",
+    "\n",
+    "**Note:** This algorithm requires a Directed Acyclic Graph (DAG) and might lead to inaccurate results when the Graph contains cycles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33ee6d3a",
+   "metadata": {},
+   "source": [
+    "### 2.2.1 Longest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the longest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29e4e8f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"longest path (for directed acyclic graphs)\" and query overall and artifact specific results\n",
+    "longest_artifact_paths_distribution=query_if_data_available(is_package_data_available, \"../cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_per_project.cypher\", artifact_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14dcd571",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Max longest path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1ebd6bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_dependencies_max_longest_path=longest_artifact_paths_distribution['distance'].max()\n",
+    "print('The max. longest path of the projected artifact dependencies is:', artifact_dependencies_max_longest_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa8d248b",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04ff6b16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, display only the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "longest_artifact_paths_distribution_per_artifact_in_total=get_total_distance_distribution(longest_artifact_paths_distribution)\n",
+    "longest_artifact_paths_distribution_per_artifact_in_total.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9370f59f",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1354a31d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=longest_artifact_paths_distribution_per_artifact_in_total, \n",
+    "    title='Longest path for Java artifact dependencies in total (bar)',\n",
+    "    ylabel='total number of java artifact paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd161655",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Pie chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d443ede4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=longest_artifact_paths_distribution_per_artifact_in_total,\n",
+    "    title='Longest path for Java artifact dependencies in total (pie)',\n",
+    "    ylabel='total number of Java artifact paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82025919",
+   "metadata": {},
+   "source": [
+    "## 3. Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "701bcb1c",
+   "metadata": {},
+   "source": [
+    "### 3.1 Java packages summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6d16c65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "package_path_algorithm_summary_values = {\n",
+    "    'count': package_projection_statistics.nodeCount[0] if not package_projection_statistics.empty else 0, \n",
+    "    'degree density': package_projection_statistics.density[0] if not package_projection_statistics.empty else 0.0, \n",
+    "    'degree median': package_projection_statistics['degreeDistribution.p50'][0] if not package_projection_statistics.empty else 0,\n",
+    "    'degree max': package_projection_statistics['degreeDistribution.max'][0] if not package_projection_statistics.empty else 0,\n",
+    "    'longest shortest path (diameter)': package_dependencies_graph_diameter,\n",
+    "    'max. longest path': package_dependencies_max_longest_path\n",
+    "}\n",
+    "package_path_algorithm_summary = pd.DataFrame.from_records([package_path_algorithm_summary_values])\n",
+    "package_path_algorithm_summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d9f68ec",
+   "metadata": {},
+   "source": [
+    "### 3.2 Java artifacts summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fcf82e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_path_algorithm_summary_values = {\n",
+    "    'count': artifact_projection_statistics.nodeCount[0] if not artifact_projection_statistics.empty else 0,\n",
+    "    'degree density': artifact_projection_statistics.density[0] if not artifact_projection_statistics.empty else 0, \n",
+    "    'degree median': artifact_projection_statistics['degreeDistribution.p50'][0] if not artifact_projection_statistics.empty else 0,\n",
+    "    'degree max': artifact_projection_statistics['degreeDistribution.max'][0] if not artifact_projection_statistics.empty else 0,\n",
+    "    'longest shortest path (diameter)': artifact_dependencies_graph_diameter,\n",
+    "    'max. longest path': artifact_dependencies_max_longest_path\n",
+    "}\n",
+    "artifact_path_algorithm_summary = pd.DataFrame.from_records([artifact_path_algorithm_summary_values])\n",
+    "artifact_path_algorithm_summary"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "code_graph_analysis_pipeline_data_validation": "ValidateJavaPackageDependencies",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "title": "Path finding algorithms for Java package and artifact dependencies with Neo4j"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter/PathFindingTypescript.ipynb
+++ b/jupyter/PathFindingTypescript.ipynb
@@ -1,0 +1,1312 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2f0eabc4",
+   "metadata": {},
+   "source": [
+    "# Path Finding for Typescript\n",
+    "\n",
+    "This notebook demonstrates different ways on how path finding algorithms can be utilized for code analysis. \n",
+    "\n",
+    "Path algorithms in Graphs are famous for e.g. finding the fastest way from one place to another. How can these be applied to static code analysis and how can the results be interpreted?\n",
+    "\n",
+    "One promising algorithm is [All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path). It shows dependencies from a different perspective and provides an overview on how directly or indirectly dependencies are connected to each other. The longest shortest path has an additional meaning: It is also known as the [**Graph Diameter**](https://mathworld.wolfram.com/GraphDiameter.html) and is very useful as a metric for the complexity of the Graph (or Subgraphs). The same applies to the longest path (for directed acyclic graphs) that can uncover long dependency chains.\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "### References\n",
+    "- [jqassistant](https://jqassistant.org)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)\n",
+    "- [All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path)\n",
+    "- [Longest Path for DAG (neo4j)](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path)\n",
+    "- [Graph Diameter](https://mathworld.wolfram.com/GraphDiameter.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec6baa64",
+   "metadata": {},
+   "source": [
+    "## What GPT-4 has to say about it\n",
+    "\n",
+    "### All pairs shortest path\n",
+    "\n",
+    "Interpreting the results of the \"all pairs shortest path\" algorithm on a graph of statically analyzed code modules and their dependencies involves understanding the structure and implications of the paths between nodes (modules) in the graph. Here are some specific steps and insights to consider:\n",
+    "\n",
+    "1. **Graph Structure**: Each node represents a code module, and edges indicate dependencies. A directed edge from module A to module B implies that A depends on B.\n",
+    "\n",
+    "2. **Shortest Paths**: The results will give you the shortest path lengths between all pairs of modules. This helps identify:\n",
+    "  - **Direct Dependencies**: A length of 1 indicates a direct dependency.\n",
+    "  - **Transitive Dependencies**: A length greater than 1 shows indirect dependencies. For example, if the path from A to C is 2, it could mean A → B → C, indicating A indirectly depends on C via B.\n",
+    "\n",
+    "3. **Module Isolation**: If a module has very long paths to others, it might be more isolated. This could signal potential issues in the code structure, suggesting that module might be overly complex or decoupled from the rest of the system.\n",
+    "\n",
+    "4. **Critical Paths**: Identify the shortest paths that connect key modules (e.g., core functionalities). These paths can highlight the most crucial dependencies that, if modified, might have extensive impacts on the system.\n",
+    "\n",
+    "5. **Cycle Detection**: If any pairs have paths that loop back to themselves with a length not equal to 0, it indicates a cycle. Cycles can complicate dependency management, potentially leading to recursive dependencies, which can be problematic in terms of maintainability.\n",
+    "\n",
+    "6. **Refactoring Opportunities**: By examining the lengths of paths, you might identify modules that could benefit from refactoring to decrease dependency complexity. For example, a module that has dependencies on many others (with longer path lengths) might be a candidate for breaking into smaller, more manageable components.\n",
+    "\n",
+    "7. **Performance Considerations**: In large systems, long paths could impact performance. If certain modules are far from frequently accessed modules, consider whether they can be optimized for speed.\n",
+    "\n",
+    "8. **Visual Representation**: Creating a visual representation of the graph with the shortest paths highlighted can be immensely helpful. Tools like Graphviz or D3.js can illustrate these relationships clearly, aiding in your analysis.\n",
+    "\n",
+    "By focusing on these aspects, you can glean actionable insights from the results of the all pairs shortest path algorithm in the context of your statically analyzed code modules and their dependencies.\n",
+    "\n",
+    "### Graph diameter (shortest longest path)\n",
+    "\n",
+    "The longest shortest path in a dependency graph (often referred to in graph theory as the \"diameter\" of the graph) represents the maximum distance (in terms of the number of edges or dependencies) between any two nodes (modules) in the graph. Here’s how you can interpret this metric in the context of statically analyzed code modules and their dependencies:\n",
+    "\n",
+    "1. **Network Complexity**: The longest shortest path indicates the overall complexity of the network of dependencies. A longer path suggests a more complicated interrelationship among modules. For example, a longest shortest path of 6 could indicate that there is at least one pair of modules in your system that rely on a chain of 6 other modules to communicate or function together.\n",
+    "\n",
+    "2. **Potential Bottlenecks**: If the longest shortest path is significant, it may suggest potential bottlenecks in your architecture. For instance, if a core module at the beginning of a long path is slow or error-prone, it could affect numerous other modules dependent on it, resulting in systemic performance issues.\n",
+    "\n",
+    "3. **Critical Communication Points**: The endpoints of the longest shortest path can be seen as critical communication points within your codebase. Understanding these connections can help identify which modules should be prioritized for testing and monitoring, especially during changes.\n",
+    "\n",
+    "4. **Isolation and Coupling**: A long longest shortest path might indicate that some modules are isolated and far removed from others, which can suggest low cohesion. This can be a sign that the architecture might benefit from refactoring to reduce unnecessary dependencies or to improve modularity.\n",
+    "\n",
+    "5. **Refactoring Opportunities**: If the longest shortest path is disproportionately long, it may highlight areas in the codebase where modules are too tightly coupled. This situation presents an opportunity for refactoring to create more independent modules or components that can interact with fewer dependencies.\n",
+    "\n",
+    "6. **Impact of Changes**: Modules that lie along or are endpoints of the longest shortest paths are likely to have a significant impact on the overall system. Changes to them should be approached with caution and accompanied by rigorous testing.\n",
+    "\n",
+    "7. **Cycle Detection**: In some cases, a long shortest path can indicate the presence of cycles in the graph. If there are paths that seem to loop back on themselves, it suggests potential design flaws that could lead to recursion or infinite loops, complicating maintenance.\n",
+    "\n",
+    "8. **Architectural Decisions**: The longest shortest path can inform architectural decisions by providing insights into which dependencies might need to be revised or eliminated. For instance, if certain modules are consistently part of the longest path, it could justify investing resources in redesigning their interactions.\n",
+    "\n",
+    "In summary, interpreting the longest shortest path provides a comprehensive view of the interdependencies among modules in your system, focusing on complexity, potential bottlenecks, and opportunities for improvement in architecture and design.\n",
+    "\n",
+    "### Longest path\n",
+    "\n",
+    "1. **Complex Dependencies**: Longest paths indicate modules that have extensive dependencies before reaching another module. For instance, if you find a path like A → B → C → D with a length of 4, it highlights a complex chain of dependencies. This can suggest that changes in module A might have far-reaching implications across the system.\n",
+    "\n",
+    "2. **Potential Bottlenecks**: Modules located at the beginning of long paths could be performance bottlenecks. If a frequently used module is several layers deep in dependencies (e.g., A → B → C), it may slow down the entire system. Optimizing or refactoring these modules could improve performance.\n",
+    "\n",
+    "3. **Maintenance Challenges**: Long paths may indicate parts of the code that are difficult to maintain or understand. For example, if module A requires multiple intermediary modules (B, C, D) for its functionality, developers may struggle to trace how changes propagate, leading to potential bugs.\n",
+    "\n",
+    "4. **Risk of Change**: A module with a long dependency path can be more risky to modify. If A has dependencies on several modules down the line (e.g., A → B → C → D → E), any changes to A could inadvertently affect E, which might be critical or sensitive. This insight can help prioritize testing and reviews around such modules.\n",
+    "\n",
+    "5. **Decoupling Opportunities**: Identifying the longest paths can highlight areas where you might want to break up dependencies. If there’s a long chain that could be simplified (e.g., by creating intermediary modules or interfaces), it may lead to a more modular and maintainable architecture.\n",
+    "\n",
+    "6. **Redundancy**: Long paths may also reveal redundancy in dependencies. For instance, if multiple modules depend on a series of others (A → B → C → D and A → B → E), it could indicate unnecessary coupling that can be streamlined.\n",
+    "\n",
+    "7. **System Understanding**: Long paths can help map out the architecture of your codebase. Understanding which modules are pivotal in long chains can provide insights into the overall design and help inform architectural decisions.\n",
+    "\n",
+    "8. **Documentation & Knowledge Transfer**: If certain modules consistently appear in the longest paths, they may require better documentation. Ensuring that their roles and the reasons for their lengthy dependencies are well understood can facilitate knowledge transfer among team members.\n",
+    "\n",
+    "By focusing on the longest paths in your dependency graph, you can uncover areas requiring attention for optimization, maintenance, and improved system architecture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "d19447e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from IPython.display import display\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "import typing as typ\n",
+    "import numpy as np\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "807bba03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb92ef74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "648e2a5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main Colormap\n",
+    "main_color_map = 'nipy_spectral'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "e49ca888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pandas DataFrame Display Configuration\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "1c5dab37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\". \n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "c1db254b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename):\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "59310f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_cypher_to_data_frame(filename, parameters_: typ.Optional[typ.Dict[str, typ.Any]] = None):\n",
+    "    records, summary, keys = driver.execute_query(get_cypher_query_from_file(filename),parameters_=parameters_)\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "7d2e62d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_directed_unweighted_projection(parameters: dict) -> bool: \n",
+    "    \"\"\"\n",
+    "    Creates an directed homogenous unweighted in-memory Graph projection for/with Neo4j Graph Data Science Plugin.\n",
+    "    It returns True if there is data available for the given parameter and False otherwise.\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    dependencies_projection : str\n",
+    "        The name prefix for the in-memory projection for dependencies. Example: \"typescript-module-path-finding-notebook\"\n",
+    "    dependencies_projection_node : str\n",
+    "        The label of the nodes that will be used for the projection. Example: \"Module\"\n",
+    "    dependencies_projection_weight_property : str\n",
+    "        The name of the node property that contains the dependency weight. Example: \"lowCouplingElement25PercentWeight\"\n",
+    "    dependencies_projection_embedding_dimension : str\n",
+    "        The number of the dimensions and therefore size of the resulting array of floating point numbers\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    is_data_missing=query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_0_Check_Projectable.cypher\", parameters).empty\n",
+    "    if is_data_missing: return False\n",
+    "\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_1_Delete_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_2_Delete_Subgraph.cypher\", parameters)\n",
+    "    # To exclude the direction of the relationships use the following line to create the projection:\n",
+    "    # query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_4_Create_Undirected_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_3_Create_Projection.cypher\", parameters)\n",
+    "    query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_5_Create_Subgraph.cypher\", parameters)\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "3f2e905c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def empty_projection_result() -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Creates an empty result and is meant to be used in case there is no data for the projection.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    print(\"No projected data for path finding available\")\n",
+    "    return pd.DataFrame(columns=['totalCost', 'sourceProject', 'isDifferentTargetProject', 'distance', 'distanceTotalPairCount', 'distanceTotalSourceCount', 'distanceTotalTargetCount', 'nodeCount', 'pairCount'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "d2d60597",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_if_data_available(is_data_available: bool, cypher_file_name: str, parameters: dict) -> pd.DataFrame: \n",
+    "    \"\"\"\n",
+    "    Runs the cypher query in the file given as cypherFileName with the given parameters if the data is available,\n",
+    "    or returns an empty result if the projection failed due to missing data.\n",
+    "    \n",
+    "    is_data_available\n",
+    "    ----------\n",
+    "    Pass the returned boolean from the projection creation here. Will return an empty result if false and otherwise execute the query.\n",
+    "\n",
+    "    cypher_file_name\n",
+    "    ----------\n",
+    "    Name of the file containing the Cypher query that executes node embeddings procedure.\n",
+    "\n",
+    "    parameters\n",
+    "    ----------\n",
+    "    dependencies_projection : str\n",
+    "        The name prefix for the in-memory projection for dependencies. Example: \"typescript-module-path-finding-notebook\"\n",
+    "    dependencies_projection_node : str\n",
+    "        The label of the nodes that will be used for the projection. Example: \"Module\"\n",
+    "    dependencies_projection_weight_property : str\n",
+    "        The name of the node property that contains the dependency weight. Example: \"lowCouplingElement25PercentWeight\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return query_cypher_to_data_frame(cypher_file_name, parameters) if is_data_available else empty_projection_result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "5ef848fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_total_distance_distribution(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the DataFrame only containing the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\", \"distanceTotalPairCount\", \"distanceTotalSourceCount\" and \"distanceTotalTargetCount\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return data_frame[['distance', 'distanceTotalPairCount', 'distanceTotalSourceCount', 'distanceTotalTargetCount']].drop_duplicates().reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "a9211397",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_longest_path_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the DataFrame grouped by the source project (e.g. Java artifact or Typescript project) containing their max/longest distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"isDifferentTargetProject\", \"distance\" and \"sourceProject\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    return data_frame.groupby('sourceProject')['distance'].max().sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "036264ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_distance_distribution_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "\n",
+    "    data_frame = data_frame.copy()\n",
+    "\n",
+    "    # Rows contain the source project (e.g. Java artifact or Typescript project) and its the pair count.\n",
+    "    # The columns contain the distances.\n",
+    "    data_frame = data_frame.pivot(index='distance', columns='sourceProject', values='pairCount')\n",
+    "\n",
+    "    # Sort by column sum and then take only the first 40 columns\n",
+    "    sum_of_pair_count = data_frame.sum()\n",
+    "    data_frame = data_frame[sum_of_pair_count.sort_values(ascending=False).index[:40]]\n",
+    "\n",
+    "    # Fill missing values with zeroes\n",
+    "    data_frame = data_frame.fillna(0)\n",
+    "\n",
+    "    # Transpose the table (flip columns and rows) to have a row for every source project\n",
+    "    data_frame = data_frame.transpose()\n",
+    "\n",
+    "    return data_frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "de2e71ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize_distance_distribution_for_each_source_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Returns the normalized data in percentage of the DataFrame for each source project\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Pivot dataframe with source projects in rows, distances in columns and pair count values\n",
+    "    \"\"\"\n",
+    "    return data_frame.div(data_frame.sum(axis=1), axis=0) * 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "27a583e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_total_distances_bar_chart(data_frame: pd.DataFrame, title: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the total number of pairs for each distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"All pairs shortest path for Typescript module dependencies in total (bar)\"\n",
+    "\n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"total number of Typescript module pairs\"\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        data_frame.plot(\n",
+    "            title=title,\n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            x='distance',\n",
+    "            y='distanceTotalPairCount',\n",
+    "            xlabel='path length',\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(9,7),\n",
+    "            legend=False,\n",
+    "            fontsize=8,\n",
+    "            cmap=main_color_map\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "e63ddc97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_total_distances_pie_chart(data_frame: pd.DataFrame, title: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the total number of pairs for each distance.\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"All pairs shortest path for Typescript module dependencies in total (pie)\".\n",
+    "\n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Total number of Typescript module pairs\"\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        explode_all=np.full(data_frame.shape[0], 0.01)\n",
+    "        total_number_of_pairs=data_frame['distanceTotalPairCount'].sum()\n",
+    "        def custom_auto_percentage_format(percentage):\n",
+    "            return '{:1.2f}% ({:.0f})'.format(percentage, total_number_of_pairs*percentage/100)\n",
+    "\n",
+    "        plot.figure();\n",
+    "        data_frame.plot(\n",
+    "            title=title, \n",
+    "            kind='pie', \n",
+    "            labels=data_frame['distance'],\n",
+    "            y='distanceTotalPairCount', \n",
+    "            ylabel=ylabel,\n",
+    "            legend=True,\n",
+    "            labeldistance=None,\n",
+    "            autopct=custom_auto_percentage_format,\n",
+    "            explode=explode_all,\n",
+    "            textprops={'fontsize': 8},\n",
+    "            pctdistance=1.2,\n",
+    "            figsize=(8,8),\n",
+    "            cmap=main_color_map\n",
+    "        )\n",
+    "        plot.legend(bbox_to_anchor=(1.05, 1), loc='upper left', title='path length')\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "7243fbfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_longest_distance_per_source_project(data_frame: pd.DataFrame, title: str, xlabel: str, ylabel: str):\n",
+    "    \"\"\"\n",
+    "    Plots the longest distance per source project \n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the path algorithm result including the columns \"distance\" and \"distanceTotalPairCount\"\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: 'Longest shortest path (\"diameter\") for Typescript module dependencies per project'\n",
+    "\n",
+    "    xlabel\n",
+    "    ----------\n",
+    "    X-axis label. Example: \"Project\".\n",
+    "    \n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Typescript module pairs\".    \n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        plot.figure();\n",
+    "        axes = data_frame.transpose().plot(\n",
+    "            title=title, \n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            xlabel=xlabel,\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(10,6),\n",
+    "            legend=False,\n",
+    "            cmap=main_color_map\n",
+    "        )\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "5262a4ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_source_projects_distances_stacked(data_frame: pd.DataFrame, title: str, xlabel: str, ylabel: str, logy: bool = False):\n",
+    "    \"\"\"\n",
+    "    Plots each source project (e.g. Java artifact or Typescript project) stacked by distance (number of dependency pairs)\n",
+    "    \n",
+    "    data_frame\n",
+    "    ----------\n",
+    "    Contains the output of \"get_distance_distribution_for_each_source_project\" with the \n",
+    "    source projects as rows, distances as columns and number of pairs as values.\n",
+    "\n",
+    "    title\n",
+    "    ----------\n",
+    "    Title of the plot. Example: \"Longest shortest path (\"diameter\") for Typescript packages \".\n",
+    "\n",
+    "    xlabel\n",
+    "    ----------\n",
+    "    X-axis label. Example: \"Project\".\n",
+    "    \n",
+    "    ylabel\n",
+    "    ----------\n",
+    "    Y-axis label. Example: \"Typescript module pairs\".\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if data_frame.empty:\n",
+    "        print(\"No data to plot '\" + title + \"'\")\n",
+    "    else:\n",
+    "        plot.figure();\n",
+    "        axes = data_frame.plot(\n",
+    "            title=title, \n",
+    "            kind='bar', \n",
+    "            grid=True,\n",
+    "            stacked=True,\n",
+    "            logy=logy,\n",
+    "            xlabel=xlabel,\n",
+    "            ylabel=ylabel,\n",
+    "            figsize=(10,6),\n",
+    "            legend=True,\n",
+    "            cmap=main_color_map\n",
+    "        ).legend(bbox_to_anchor=(1.0, 1.0), title=\"path length\")\n",
+    "        plot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "6afb912b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def group_to_others_below_threshold(data_frame : pd.DataFrame, value_column : str, name_column: str, threshold: float) -> pd.DataFrame:    \n",
+    "    \"\"\"\n",
+    "    Adds a new percentage column for the value column and \n",
+    "    groups all values below the given threshold to \"others\" in the name column.\n",
+    "\n",
+    "    Parameters:\n",
+    "    - data_frame (pd.DataFrame): Input pandas DataFrame\n",
+    "    - value_column (str): Name of the column that contains the numeric value\n",
+    "    - name_column (str): Name of the column that contains the group name that will be replaced by \"others\" for small values\n",
+    "    - threshold (float): Threshold in % that is used to group values below it into the \"others\" group\n",
+    "\n",
+    "    Returns:\n",
+    "    int:Returning value\n",
+    "\n",
+    "    \"\"\"\n",
+    "    result_data_frame = data_frame.copy();\n",
+    "\n",
+    "    percent_column_name = value_column + 'Percent';\n",
+    "\n",
+    "    # Add column with the name given in \"percent_column_name\" with the percentage of the value column.\n",
+    "    result_data_frame[percent_column_name] = result_data_frame[value_column] / result_data_frame[value_column].sum() * 100.0;\n",
+    "\n",
+    "    # Change the external module name to \"others\" if it is called less than the specified threshold\n",
+    "    result_data_frame.loc[result_data_frame[percent_column_name] < threshold, name_column] = 'others';\n",
+    "\n",
+    "    # Group external module name (foremost the new \"others\" entries) and sum their percentage\n",
+    "    result_data_frame = result_data_frame.groupby(name_column)[percent_column_name].sum();\n",
+    "\n",
+    "    # Sort by values descending\n",
+    "    return result_data_frame.sort_values(ascending=False);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "40653fe5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def group_to_others_below_threshold(data_frame : pd.DataFrame, value_column : str, name_column: str, threshold: float) -> pd.DataFrame:    \n",
+    "    \"\"\"Adds a new percentage column for the value column and \n",
+    "    groups all values below the given threshold to \"others\" in the name column.\n",
+    "\n",
+    "    Parameters:\n",
+    "    - data_frame (pd.DataFrame): Input pandas DataFrame\n",
+    "    - value_column (str): Name of the column that contains the numeric value\n",
+    "    - name_column (str): Name of the column that contains the group name that will be replaced by \"others\" for small values\n",
+    "    - threshold (float): Threshold in % that is used to group values below it into the \"others\" group\n",
+    "\n",
+    "    Returns:\n",
+    "    int:Returning value\n",
+    "\n",
+    "    \"\"\"\n",
+    "    result_data_frame = data_frame.copy();\n",
+    "\n",
+    "    percent_column_name = value_column + 'Percent';\n",
+    "\n",
+    "    # Add column with the name given in \"percent_column_name\" with the percentage of the value column.\n",
+    "    result_data_frame[percent_column_name] = result_data_frame[value_column] / result_data_frame[value_column].sum() * 100.0;\n",
+    "\n",
+    "    # Change the external module name to \"others\" if it is called less than the specified threshold\n",
+    "    result_data_frame.loc[result_data_frame[percent_column_name] < threshold, name_column] = 'others';\n",
+    "\n",
+    "    # Group external module name (foremost the new \"others\" entries) and sum their percentage\n",
+    "    result_data_frame = result_data_frame.groupby(name_column)[percent_column_name].sum();\n",
+    "\n",
+    "    # Sort by values descending\n",
+    "    return result_data_frame.sort_values(ascending=False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b42163d",
+   "metadata": {},
+   "source": [
+    "## 1. Typescript Modules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1ce698",
+   "metadata": {},
+   "source": [
+    "## 1.1 All pairs shortest path\n",
+    "\n",
+    "Use \"[All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path)\" algorithm to get the shortest path distance between all pairs of dependent Typescript packages. It shows how many Packages have a direct dependency (distance 1), how many are reachable with one dependency in between (distance 2), and so on..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b468bae",
+   "metadata": {},
+   "source": [
+    "### 1.1.1 Create a projection of all Typescript module dependencies\n",
+    "\n",
+    "Creates a in-memory projection of \"TS:Module\" nodes and their \"DEPENDS_ON\" relationships as a preparation to run the Graph algorithms. The weight property is not used for now (September 2024) but may be needed for other algorithms/variants some time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "1ecc41b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module_path_finding_parameters={\n",
+    "    \"dependencies_projection\": \"typescript-module-path-finding-notebook\",\n",
+    "    \"dependencies_projection_node\": \"Module\",\n",
+    "    \"dependencies_projection_weight_property\": \"lowCouplingElement25PercentWeight\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "0b637ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the directed and unweighted projection with the parameters defined directly above\n",
+    "is_module_data_available=create_directed_unweighted_projection(module_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf7a594",
+   "metadata": {},
+   "source": [
+    "#### Projected Graph statistics for Typescript module dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf414643",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module_projection_statistics=query_cypher_to_data_frame(\"../cypher/Dependencies_Projection/Dependencies_12_Get_Projection_Statistics.cypher\", module_path_finding_parameters)\n",
+    "module_projection_statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "924c9b26",
+   "metadata": {},
+   "source": [
+    "### 1.1.2 All pairs shortest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the all pairs shortest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62f50f28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"All pairs shortest path\" and query overall and project specific results\n",
+    "all_pairs_shortest_paths_distribution_per_project=query_if_data_available(is_module_data_available, \"../cypher/Path_Finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher\", module_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6f93160",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Longest shortest path (Graph diameter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce1621b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module_dependencies_graph_diameter=all_pairs_shortest_paths_distribution_per_project['distance'].max()\n",
+    "print('The diameter (longest shortest path) of the projected module dependencies Graph is:', module_dependencies_graph_diameter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e502afa1",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9ebcaa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_project_in_total=get_total_distance_distribution(all_pairs_shortest_paths_distribution_per_project)\n",
+    "all_pairs_shortest_paths_distribution_per_project_in_total.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df87dc06",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fee79fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_project_in_total, \n",
+    "    title='All pairs shortest path for Typescript module dependencies in total (bar)',\n",
+    "    ylabel='total number of Typescript module paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf4b2733",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path in total - Path count per length - Pie chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "1d6fdf9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# all_pairs_shortest_paths_distribution_per_project_in_total_significant = group_to_others_below_threshold(\n",
+    "#     data_frame=all_pairs_shortest_paths_distribution_per_project_in_total,\n",
+    "#     value_column='distanceTotalPairCount',\n",
+    "#     name_column='distance',\n",
+    "#     threshold= 0.7\n",
+    "# );\n",
+    "# all_pairs_shortest_paths_distribution_per_project_in_total_significant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab444978",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_project_in_total,\n",
+    "    # data_frame=all_pairs_shortest_paths_distribution_per_project_in_total_significant,\n",
+    "    title='All pairs shortest path for Typescript module dependencies in total (pie)',\n",
+    "    ylabel='total number of Typescript module paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1129f77",
+   "metadata": {},
+   "source": [
+    "### 1.1.3 All pairs shortest path in detail\n",
+    "\n",
+    "The following table shows the first 10 rows with all details of the query above. It contains the results of the \"all pairs shortest path\" algorithm including the project the source node belong to and if the target node is the same or not. The main intuition here is to show how the data is structured. It provides the basis for tables and charts shown in following sections below, that filter and group the data accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64ab393b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_project.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae9d8868",
+   "metadata": {},
+   "source": [
+    "### 1.1.4 All pairs shortest path for each project\n",
+    "\n",
+    "In this section we'll focus only on pairs of nodes that both belong to the same project, filtering out every line that has `isDifferentTargetProject==False`. The first ten rows are shown in a table followed by charts that show the distribution of shortest path distances across different projects in stacked bar charts (absolute and normalized).\n",
+    "\n",
+    "**Note:** It is possible that a (shortest) path could have nodes in between that belong to different projects. Therefore, the data of each project isn't perfectly isolated. However, it shows how the dependencies interact across projects \"in real life\" while still providing a decent isolation of each project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f84af34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_project_isolated=all_pairs_shortest_paths_distribution_per_project.query('isDifferentTargetProject == False')\n",
+    "all_pairs_shortest_paths_distribution_per_project_isolated.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c400fc8c",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each project - Longest shortest path (Diameter) for each project\n",
+    "\n",
+    "Shows the top 20 projects with the longest shortest path (=Graph Diameter)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bc3b27d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph_diameter_per_project = get_longest_path_for_each_source_project(all_pairs_shortest_paths_distribution_per_project_isolated)\n",
+    "graph_diameter_per_project.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c65fd16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_longest_distance_per_source_project(\n",
+    "    data_frame=graph_diameter_per_project,\n",
+    "    title='Longest shortest path (\"diameter\") for Typescript module dependencies per project',\n",
+    "    xlabel='Project',\n",
+    "    ylabel='longest path length'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1138de0c",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each project - Bar chart (absolute)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "7b90cfbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_pairs_shortest_paths_distribution_per_project_isolated_pivot = get_distance_distribution_for_each_source_project(all_pairs_shortest_paths_distribution_per_project_isolated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebeaf685",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_project_isolated_pivot,\n",
+    "    title='All pairs shortest path for Typescript module dependencies stacked per project (absolute, logarithmic)',\n",
+    "    xlabel='Project',\n",
+    "    ylabel='Typescript module paths',\n",
+    "    logy=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5f8f817",
+   "metadata": {},
+   "source": [
+    "#### All pairs shortest path for each project - Bar chart (normalized)\n",
+    "\n",
+    "Shows the top 50 projects with the highest number of dependency paths stacked by their length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "533d1b9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize data (percent of sum pairs)\n",
+    "all_pairs_shortest_paths_distribution_per_project_isolated_normalized_pivot=normalize_distance_distribution_for_each_source_project(all_pairs_shortest_paths_distribution_per_project_isolated_pivot)\n",
+    "all_pairs_shortest_paths_distribution_per_project_isolated_normalized_pivot.head(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2721c41d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=all_pairs_shortest_paths_distribution_per_project_isolated_normalized_pivot.head(50),\n",
+    "    title='All pairs shortest path for Typescript module dependencies stacked per project (normalized in %)',\n",
+    "    xlabel='Project',\n",
+    "    ylabel='Typescript module paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37da9d90",
+   "metadata": {},
+   "source": [
+    "## 1.2 Longest path\n",
+    "\n",
+    "Use [Longest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path) algorithm to get the longest paths between Typescript packages. It is typically higher than the longest shortest path (diameter) and helps together with it to get a good overview of the complexity.\n",
+    "\n",
+    "**Note:** This algorithm requires a Directed Acyclic Graph (DAG) and will lead to inaccurate results when the Graph contains cycles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9f9b8bb",
+   "metadata": {},
+   "source": [
+    "### 1.2.1 Longest path in total\n",
+    "\n",
+    "First, we'll have a look at the overall/total result of the longest path algorithm for all dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b43628b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Execute algorithm \"longest path (for directed acyclic graphs)\" and query overall and project specific results\n",
+    "longest_paths_distribution_per_project=query_if_data_available(is_module_data_available, \"../cypher/Path_Finding/Path_Finding_6_Longest_paths_distribution_per_project.cypher\", module_path_finding_parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaa7ae83",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Max longest path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aef9c47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module_dependencies_max_longest_path=longest_paths_distribution_per_project['distance'].max()\n",
+    "print('The max. longest path of the projected module dependencies is:', module_dependencies_max_longest_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cf188a8",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Paths per length - Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4141d7d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, display only the overall/total distances, their pair count and the count of the distinct source and target nodes\n",
+    "longest_paths_distribution_per_project_in_total=get_total_distance_distribution(longest_paths_distribution_per_project)\n",
+    "longest_paths_distribution_per_project_in_total.head(50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46544c70",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Bar chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9db65656",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_bar_chart(\n",
+    "    data_frame=longest_paths_distribution_per_project_in_total, \n",
+    "    title='Longest path for Typescript module dependencies in total (bar)',\n",
+    "    ylabel='total number of Typescript module paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4962464",
+   "metadata": {},
+   "source": [
+    "#### Longest path in total - Path count per length - Pie chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf2efa87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_total_distances_pie_chart(\n",
+    "    data_frame=longest_paths_distribution_per_project_in_total,\n",
+    "    title='Longest path for Typescript module dependencies in total (pie)',\n",
+    "    ylabel='total number of Typescript module paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "904db536",
+   "metadata": {},
+   "source": [
+    "### 1.2.2 Longest path in detail\n",
+    "\n",
+    "The following table shows the first 10 rows with all details of the query above. It contains the results of the \"longest path\" algorithm including the artifact the source node belongs to and if the target node is in the same artifact or not. The main intuition is to show how the data is structured. It provides the basis for tables and charts shown in following sections below, that filter and group the data accordingly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f13cf0e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_project.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57aee73a",
+   "metadata": {},
+   "source": [
+    "### 1.2.3 Longest path for each project\n",
+    "\n",
+    "In this section we'll focus only on pairs of nodes that both belong to the same artifact, filtering out every line that has `isDifferentTargetProject==False`. The first ten rows are shown in a table followed by charts that show the distribution of longest path distances across different artifacts in stacked bar charts (absolute and normalized).\n",
+    "\n",
+    "**Note:** It is possible that a (longest) path could have nodes in between that belong to different artifacts. Therefore, the data of each artifact isn't perfectly isolated. However, it shows how the dependencies interact across artifacts \"in real life\" while still providing a decent isolation of each artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "964bff35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_project_isolated=longest_paths_distribution_per_project.query('isDifferentTargetProject == False')\n",
+    "longest_paths_distribution_per_project_isolated.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34ec57d5",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Max. longest path for each artifact\n",
+    "\n",
+    "Shows the top 20 artifacts with their max. longest path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c09f2926",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_path_per_project = get_longest_path_for_each_source_project(longest_paths_distribution_per_project_isolated)\n",
+    "longest_path_per_project.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "874f20b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_longest_distance_per_source_project(\n",
+    "    data_frame=longest_path_per_project,\n",
+    "    title='Max. longest path for Java package dependencies per artifact',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='max. longest path length'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0c2d8ba",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Bar chart (absolute)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "47bd1a08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_paths_distribution_per_project_isolated_pivot = get_distance_distribution_for_each_source_project(longest_paths_distribution_per_project_isolated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b9c50a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=longest_paths_distribution_per_project_isolated_pivot,\n",
+    "    title='Longest path for Java package dependencies stacked per artifact (absolute, logarithmic)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths',\n",
+    "    logy=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc4c2036",
+   "metadata": {},
+   "source": [
+    "#### Longest path for each artifact - Bar chart (normalized)\n",
+    "\n",
+    "Shows the top 50 artifacts with the highest number of dependency paths stacked by their length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9219023",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Normalize data (percent of sum pairs)\n",
+    "longest_paths_distribution_per_project_isolated_normalized_pivot=normalize_distance_distribution_for_each_source_project(longest_paths_distribution_per_project_isolated_pivot)\n",
+    "longest_paths_distribution_per_project_isolated_normalized_pivot.head(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e2e15eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_source_projects_distances_stacked(\n",
+    "    data_frame=longest_paths_distribution_per_project_isolated_normalized_pivot.head(50),\n",
+    "    title='Longest path for Java package dependencies stacked per artifact (normalized in %)',\n",
+    "    xlabel='Artifact',\n",
+    "    ylabel='Java package paths'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82025919",
+   "metadata": {},
+   "source": [
+    "## 3. Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "701bcb1c",
+   "metadata": {},
+   "source": [
+    "### 3.1 Typescript modules summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6d16c65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module_path_algorithm_summary_values = {\n",
+    "    'count': module_projection_statistics.nodeCount[0] if not module_projection_statistics.empty else 0, \n",
+    "    'degree density': module_projection_statistics.density[0] if not module_projection_statistics.empty else 0, \n",
+    "    'degree median': module_projection_statistics['degreeDistribution.p50'][0] if not module_projection_statistics.empty else 0,\n",
+    "    'degree max': module_projection_statistics['degreeDistribution.max'][0] if not module_projection_statistics.empty else 0,\n",
+    "    'longest shortest path (diameter)': module_dependencies_graph_diameter,\n",
+    "    'max. longest path': module_dependencies_max_longest_path\n",
+    "}\n",
+    "module_path_algorithm_summary = pd.DataFrame.from_records([module_path_algorithm_summary_values])\n",
+    "module_path_algorithm_summary"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "JohT"
+   }
+  ],
+  "code_graph_analysis_pipeline_data_validation": "ValidateTypescriptModuleDependencies",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "title": "Path finding algorithms for Typescript module dependencies with Neo4j"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/configuration/template-neo4jv4-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv4-jqassistant.yaml
@@ -194,10 +194,10 @@ jqassistant:
     # -Djqassistant.analyze.concepts[0]
     #  Migration to v2: https://github.com/jQAssistant/jqa-java-plugin/blob/master/src/main/asciidoc/release-notes.adoc
     concepts:
+     - classpath:Resolve
      - dependency:Package
      - dependency:Artifact
      - java:JavaVersion
-     - classpath:Resolve
 
     # The constraints to be validated.
     #

--- a/scripts/configuration/template-neo4jv5-jqassistant.yaml
+++ b/scripts/configuration/template-neo4jv5-jqassistant.yaml
@@ -194,9 +194,9 @@ jqassistant:
     # -Djqassistant.analyze.concepts[0]
     # https://github.com/jQAssistant/jqa-java-plugin/blob/e17fc3032fb0d4258d4f5ca0c64099a6c789c070/src/main/asciidoc/release-notes.adoc#L9
     concepts:
+     - java-classpath:Resolve
      - java:PackageDependency
      - java:ArtifactDependency
-     - java-classpath:Resolve
      - java:JavaVersion
 
     # The constraints to be validated.

--- a/scripts/prepareAnalysis.sh
+++ b/scripts/prepareAnalysis.sh
@@ -40,6 +40,7 @@ EXTERNAL_DEPENDENCIES_CYPHER_DIR="$CYPHER_DIR/External_Dependencies"
 ARTIFACT_DEPENDENCIES_CYPHER_DIR="$CYPHER_DIR/Artifact_Dependencies"
 TYPES_CYPHER_DIR="$CYPHER_DIR/Types"
 TYPESCRIPT_CYPHER_DIR="$CYPHER_DIR/Typescript_Enrichment"
+GENERAL_ENRICHMENT_CYPHER_DIR="${CYPHER_DIR}/General_Enrichment"
 
 COLOR_RED='\033[0;31m'
 COLOR_DEFAULT='\033[0m'
@@ -56,6 +57,9 @@ fi
 execute_cypher "${CYPHER_DIR}/Create_Java_Type_index_for_full_qualified_name.cypher"
 execute_cypher "${CYPHER_DIR}/Create_Typescript_index_for_full_qualified_name.cypher"
 execute_cypher "${CYPHER_DIR}/Create_Typescript_index_for_name.cypher"
+
+# Preparation - General Enrichment - Add properties "name" and "extension" to all File nodes
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Add_file_name and_extension.cypher"
 
 # Preparation - Enrich Graph for Typescript by adding "module" and "name" properties
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Index_module_name.cypher"
@@ -104,7 +108,7 @@ execute_cypher_summarized "${METRICS_CYPHER_DIR}/Set_Outgoing_Java_Package_Depen
 
 # Preparation - Label external types and annotations
 #               "external" means that there is no byte code available, not a primitive type and not a java type
-#               "annoatation" means that there is a ANNOTATED_BY to that external type
+#               "annotation" means that there is a ANNOTATED_BY to that external type
 execute_cypher "${TYPES_CYPHER_DIR}/Remove_extended_type_labels.cypher"
 execute_cypher "${TYPES_CYPHER_DIR}/Label_base_java_types.cypher"
 execute_cypher "${TYPES_CYPHER_DIR}/Label_buildin_java_types.cypher"

--- a/scripts/reports/PathFindingCsv.sh
+++ b/scripts/reports/PathFindingCsv.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# Uses path finding algorithms from the Graph Data Science Library of Neo4j and creates CSV reports.
+# It requires an already running Neo4j graph database with already scanned and analyzed artifacts.
+# The reports (csv files) will be written into the sub directory reports/path-finding-csv.
+# Note that "scripts/prepareAnalysis.sh" is required to run prior to this script.
+
+# Requires executeQueryFunctions.sh, projectionFunctions.sh, cleanupAfterReportGeneration.sh
+
+# Overrideable Constants (defaults also defined in sub scripts)
+REPORTS_DIRECTORY=${REPORTS_DIRECTORY:-"reports"}
+
+# Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
+set -o errexit -o pipefail
+
+## Get this "scripts/reports" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
+echo "pathFindingCsv: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+
+# Get the "scripts" directory by taking the path of this script and going one directory up.
+SCRIPTS_DIR=${SCRIPTS_DIR:-"${REPORTS_SCRIPT_DIR}/.."} # Repository directory containing the shell scripts
+echo "pathFindingCsv: SCRIPTS_DIR=${SCRIPTS_DIR}"
+
+# Get the "cypher" directory by taking the path of this script and going two directory up and then to "cypher".
+CYPHER_DIR=${CYPHER_DIR:-"${REPORTS_SCRIPT_DIR}/../../cypher"}
+echo "pathFindingCsv: CYPHER_DIR=$CYPHER_DIR"
+
+# Define functions to execute a cypher query from within the given file (first and only argument)
+source "${SCRIPTS_DIR}/executeQueryFunctions.sh"
+
+# Define functions to create and delete Graph Projections like "createDirectedDependencyProjection"
+source "${SCRIPTS_DIR}/projectionFunctions.sh"
+
+# Create report directory
+REPORT_NAME="path-finding-csv"
+FULL_REPORT_DIRECTORY="${REPORTS_DIRECTORY}/${REPORT_NAME}"
+mkdir -p "${FULL_REPORT_DIRECTORY}"
+
+# Run the path finding algorithm "All Pairs Shortest Path".
+# 
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-path-finding"
+# - dependencies_projection_node=...
+#   Label of the nodes that will be used for the projection. Example: "Type"
+# - dependencies_projection_weight_property=...
+#   Name of the node property that contains the dependency weight. Example: "weight"
+allPairsShortestPath() {
+    local PATH_FINDING_CYPHER_DIR="${CYPHER_DIR}/Path_Finding"
+    local nodeLabel; nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
+    
+    # Run the algorithm using "stream" and write the results into a CSV file
+    execute_cypher "${PATH_FINDING_CYPHER_DIR}/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_all_pairs_shortest_paths_distribution_per_project.csv"
+}
+
+# Run the path finding algorithm "Longest Path" (for directed acyclic graphs (DAG)).
+# 
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "type-path-finding"
+# - dependencies_projection_node=...
+#   Label of the nodes that will be used for the projection. Example: "Type"
+# - dependencies_projection_weight_property=...
+#   Name of the node property that contains the dependency weight. Example: "weight"
+longestPath() {
+    local PATH_FINDING_CYPHER_DIR="${CYPHER_DIR}/Path_Finding"
+    local nodeLabel; nodeLabel=$( extractQueryParameter "dependencies_projection_node" "${@}" )
+
+    # Run the algorithm using "stream" and write the results into a CSV file
+    execute_cypher "${PATH_FINDING_CYPHER_DIR}/Path_Finding_6_Longest_paths_distribution_per_project.cypher" "${@}" > "${FULL_REPORT_DIRECTORY}/${nodeLabel}_longest_paths_distribution.csv"
+}
+
+# Run all contained path finding algorithms.
+# 
+# Required Parameters:
+# - dependencies_projection=...
+#   Name prefix for the in-memory projection name for dependencies. Example: "artifact-path-finding"
+# - dependencies_projection_node=...
+#   Label of the nodes that will be used for the projection. Example: "Artifact"
+# - dependencies_projection_weight_property=...
+#   Name of the node property that contains the dependency weight. Example: "weight"
+runPathFindingAlgorithms() {
+    time allPairsShortestPath "${@}"
+    time longestPath "${@}"
+}
+
+# -- Java Artifact Path Finding ------------------------------------
+
+ARTIFACT_PROJECTION="dependencies_projection=artifact-path-finding" 
+ARTIFACT_NODE="dependencies_projection_node=Artifact" 
+ARTIFACT_WEIGHT="dependencies_projection_weight_property=weight" 
+
+if createDirectedDependencyProjection "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"; then
+    runPathFindingAlgorithms "${ARTIFACT_PROJECTION}" "${ARTIFACT_NODE}" "${ARTIFACT_WEIGHT}"
+fi
+
+# -- Java Package Path Finding -------------------------------------
+
+PACKAGE_PROJECTION="dependencies_projection=package-path-finding" 
+PACKAGE_NODE="dependencies_projection_node=Package" 
+PACKAGE_WEIGHT="dependencies_projection_weight_property=weight25PercentInterfaces" 
+
+if createDirectedDependencyProjection "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"; then
+    runPathFindingAlgorithms "${PACKAGE_PROJECTION}" "${PACKAGE_NODE}" "${PACKAGE_WEIGHT}"
+fi
+
+# -- Java Type Path Finding ----------------------------------------
+# Note: This is deactivated for now. It might be too granular to be valuable and require too many resources,  
+
+#TYPE_PROJECTION="dependencies_projection=type-path-finding" 
+#TYPE_NODE="dependencies_projection_node=Type" 
+#TYPE_WEIGHT="dependencies_projection_weight_property=weight" 
+#
+#if createDirectedJavaTypeDependencyProjection "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"; then
+#    runPathFindingAlgorithms "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
+#fi
+
+# -- Java Method Path Finding --------------------------------------
+# Note: This is deactivated for now. It might be too granular to be valuable and require too many resources,  
+
+#METHOD_PROJECTION="dependencies_projection=method-path-finding" 
+#METHOD_NODE="dependencies_projection_node=Method" 
+#METHOD_WEIGHT="dependencies_projection_weight_property=" 
+
+#if createDirectedJavaMethodDependencyProjection "${METHOD_PROJECTION}"; then
+#    runPathFindingAlgorithms "${METHOD_PROJECTION}" "${METHOD_NODE}" "${METHOD_WEIGHT}"
+#fi
+
+# -- Typescript Modules Path Finding -------------------------------
+
+MODULE_LANGUAGE="dependencies_projection_language=Typescript" 
+MODULE_PROJECTION="dependencies_projection=typescript-module-path-finding" 
+MODULE_NODE="dependencies_projection_node=Module" 
+MODULE_WEIGHT="dependencies_projection_weight_property=lowCouplingElement25PercentWeight"
+
+if createDirectedDependencyProjection "${MODULE_LANGUAGE}" "${MODULE_PROJECTION}" "${MODULE_NODE}" "${MODULE_WEIGHT}"; then
+    runPathFindingAlgorithms "${MODULE_PROJECTION}" "${MODULE_NODE}" "${MODULE_WEIGHT}"
+fi
+
+# ---------------------------------------------------------------
+
+# Clean-up after report generation. Empty reports will be deleted.
+source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"
+
+echo "pathFindingCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Successfully finished."


### PR DESCRIPTION
### 🚀 Feature

- [Add report for path finding algorithms on dependencies](https://github.com/JohT/code-graph-analysis-pipeline/pull/216/commits/c1d57137f6a533ad6da4db67afb1b06588893fe6). With the newly added path finding algorithm reports there are now fully automated results for "All pairs shortest path" and "Longest path". This includes the "Graph Diameter", which is the longest shortest path and an important Graph metric to get an overview of the complexity of the Graph. The same applies to the max. longest path that gives even more insights.

### ⚙️ Optimization

- [Refactor inline Artifact name detection to enriched File property "name"](https://github.com/JohT/code-graph-analysis-pipeline/pull/216/commits/1a7a26fc7d67af37802e8d30fd9fa43bc4d1b323). Now, the "name" of an artifact is assembled once within a data enrichment step and can then simply be queried as a property. Additionally, "name" is the default property for visualizations, which leads to a reasonable name for all those nodes. Before that, every query needed to extract the pure name out of the file name. This was great for self containment of the queries (they don't "expect" previous enrichment), but grew in a direction where there were far too many duplications and resulting complexity.

### 🛠 Fix

- [Fix issues in projection check queries](https://github.com/JohT/code-graph-analysis-pipeline/pull/216/commits/ac20302dc975b7efd1708506b01b911c3d0bdd64). Since these queries are examples/templates for manual use and not executed within the pipeline, the contained issues hadn't been discovered yet. Now, these queries work (again) and can be used to query the contents of projections.
- [Fix missing Java package dependencies spanning Artifacts](https://github.com/JohT/code-graph-analysis-pipeline/pull/216/commits/239e555d91a037d6a258abb521a99ee189971ef7). With jQAssistant it is very important to configure the Java classpath resolver before any other "concepts". Otherwise, dependencies between e.g. Packages are incomplete when analyzing multiple artifacts.
- [Fix typo](https://github.com/JohT/code-graph-analysis-pipeline/pull/216/commits/9230c530d4abf5afce08e21a9f46723dc1889bd3). Topology sort now has the column "overallMaxDistance" instead of "overallMaxDistance".