### PR TITLE
Improve RESOLVES_TO relationships between external and internal Typescript modules

### DIFF
--- a/cypher/External_Dependencies/Label_external_types_and_annotations.cypher
+++ b/cypher/External_Dependencies/Label_external_types_and_annotations.cypher
@@ -1,6 +1,6 @@
 // Label external types and external annotations. Requires 'Label_base_java_types', 'Label_buildin_java_types' and 'Label_resolved_duplicate_types' of 'Types' directory.
 
-  MATCH (type:Type&!PrimitiveType&!Void&!JavaType&!ResolvedDuplicateType)
+  MATCH (type:Type&!PrimitiveType&!Void&!JavaType&!ResolvedDuplicateType&!TS)
    WITH type
        ,type.byteCodeVersion IS NULL                      AS isExternalType
        ,exists((type)<-[:OF_TYPE]-()<-[:ANNOTATED_BY]-()) AS isAnnotation

--- a/cypher/Typescript_Enrichment/Add_RESOLVES_TO_relationship_for_matching_modules.cypher
+++ b/cypher/Typescript_Enrichment/Add_RESOLVES_TO_relationship_for_matching_modules.cypher
@@ -3,21 +3,66 @@
 // Inspired by https://github.com/jQAssistant/jqassistant/blob/4cd7face5d6d2953449d8e6ff5b484f00ffbdc2f/plugin/java/src/main/resources/META-INF/jqassistant-rules/java-classpath.xml#L5
 // Related to https://github.com/jqassistant-plugin/jqassistant-typescript-plugin/issues/35
 
-MATCH (module:TS:Module)
-WHERE  module.globalFqn IS NOT NULL
+MATCH (module:TS:Module)<-[:CONTAINS]-(package:TS:Project)
+WHERE module.globalFqn IS NOT NULL
+  AND EXISTS { (module)-[:EXPORTS]->(:TS) } // only when module exports something
 MATCH (externalModule:TS:ExternalModule)
 WHERE module.globalFqn IS NOT NULL
-  AND ((module.globalFqn = externalModule.globalFqn)
-   OR  (module.module    = externalModule.module)
-   OR  (  externalModule.name              = module.name 
-      AND externalModule.moduleName        = module.moduleName 
-      AND externalModule.namespace         = module.namespace
-      AND externalModule.extensionExtended = module.extensionExtended
-      AND externalModule.globalFqn ENDS WITH module.localModulePath
-       )
-      )
-  AND module <> externalModule
+  AND externalModule     <> module
+  AND externalModule.name = module.name // Base requirement: Same module name
+  AND EXISTS { (externalModule)-[:EXPORTS]->(:TS:ExternalDeclaration)<-[]-(used:TS) } // only when external declarations are used
+ WITH *, size(externalModule.extensionExtended) AS externalExtensionSize
+ WITH *, CASE externalModule.extensionExtended
+            WHEN ENDS WITH '.js'  THEN left(externalModule.extensionExtended, externalExtensionSize - 3) + module.extension
+            WHEN ENDS WITH 'd.ts' THEN left(externalModule.extensionExtended, externalExtensionSize - 4) + module.extension
+            ELSE externalModule.extensionExtended
+          END AS normalizedExternalExtension
+ WITH *
+     // Find internal and external modules with identical "globalFqn"
+     ,(module.globalFqn = externalModule.globalFqn) AS equalGlobalFqn
+     // Find internal and external modules with identical "module"
+     ,(module.module = externalModule.module)       AS equalModule
+     // Find matching internal and external modules within the same package and namespace
+     ,(    externalModule.namespace    > ''
+       AND externalModule.namespace    = module.namespace
+       AND externalModule.packageName  = package.name     
+       AND normalizedExternalExtension = module.extensionExtended
+       AND externalModule.globalFqn ENDS WITH module.localModulePath
+      ) AS equalNameAndNamespace
+     // Find matching internal and external module without a namespace with matching local module path
+     ,(    module.namespace            = ''
+       AND externalModule.namespace    = ''
+       AND normalizedExternalExtension = module.extensionExtended
+       AND externalModule.globalFqn ENDS WITH
+           replace(module.localModulePath, '/' + module.moduleName, '/' + externalModule.moduleName)
+      ) AS equalNameWithoutNamespace     
+     // Find matching module name, npm package name and npm package namespace
+     ,(    externalModule.namespace    = module.namespace
+       AND externalModule.packageName  = module.packageName
+       AND externalModule.packageName  > ''
+       AND normalizedExternalExtension = module.extensionExtended
+      ) AS equalNameAndNpmPackage
+WHERE equalGlobalFqn
+   OR equalModule
+   OR equalNameAndNamespace
+   OR equalNameWithoutNamespace
+   OR equalNameAndNpmPackage
  CALL {  WITH module, externalModule
         MERGE (externalModule)-[:RESOLVES_TO]->(module)
       } IN TRANSACTIONS
-RETURN count(*) AS resolvedModules
+RETURN CASE WHEN equalGlobalFqn            THEN 'equalGlobalFqn'
+            WHEN equalModule               THEN 'equalModule'
+            WHEN equalNameWithoutNamespace THEN 'equalNameWithoutNamespace'
+            WHEN equalNameAndNamespace     THEN 'equalNameAndNamespace'
+            WHEN equalNameAndNpmPackage    THEN 'equalNameAndNpmPackage'
+        END AS equality
+       ,count(*) AS resolvedModules
+       ,collect(externalModule.globalFqn + ' -> ' + module.globalFqn)[0..4] AS examples
+// Debugging
+// RETURN module.globalFqn  ,externalModule.globalFqn
+//       ,module.name       ,externalModule.name
+//       ,module.moduleName ,externalModule.moduleName
+//       ,module.namespace  ,externalModule.namespace
+//       ,module.extensionExtended, externalModule.extensionExtended
+//       ,module.localModulePath
+//       ,split(module.module, '/')[-2] AS moduleDirectory

--- a/cypher/Typescript_Enrichment/Add_module_properties.cypher
+++ b/cypher/Typescript_Enrichment/Add_module_properties.cypher
@@ -17,7 +17,8 @@ OPTIONAL MATCH (class:TS:Class)-[:DECLARES]->(ts)
       ,nullif(reverse(split(reverse(moduleName), '.')[0]), moduleName)                      AS moduleNameExtension
       ,coalesce('@' + nullif(namespaceName, ''), '')                                        AS namespaceNameWithAtPrefixed
       ,replace(symbolName, coalesce(optionalClassName + '.', ''), '')                       AS symbolNameWithoutClassName
-    SET ts.namespace          = namespaceNameWithAtPrefixed
+      ,coalesce(split(split(ts.globalFqn, nullif(namespaceName, '') + '/')[1], '/')[0], '') AS packageName
+    SET ts.namespace          = coalesce(nullif(namespaceNameWithAtPrefixed, ''), ts.namespace, '')
        ,ts.module             = modulePathNameWithoutIndexAndDefault
        ,ts.moduleName         = moduleName
        ,ts.name               = coalesce(symbolNameWithoutClassName, indexAndExtensionOmittedName)
@@ -26,6 +27,7 @@ OPTIONAL MATCH (class:TS:Class)-[:DECLARES]->(ts)
        ,ts.isNodeModule       = isNodeModule
        ,ts.isUnresolvedImport = isUnresolvedImport
        ,ts.isExternalImport   = isNodeModule OR isUnresolvedImport
+       ,ts.packageName        = packageName
 RETURN count(*) AS updatedModules
 // For debugging
 // RETURN namespaceNameWithAtPrefixed         AS namespace

--- a/cypher/Typescript_Enrichment/Add_name_to_property_on_projects.cypher
+++ b/cypher/Typescript_Enrichment/Add_name_to_property_on_projects.cypher
@@ -3,11 +3,13 @@
  MATCH (project:TS:Project)-[:HAS_ROOT]->(root:Directory)
 OPTIONAL MATCH (project)-[:HAS_CONFIG]->(config:File)<-[:CONTAINS]-(config_dir:Directory)
   WITH *
-      ,reverse(split(reverse(root.absoluteFileName), '/')[0])       AS projectNameFromRoot
-      ,reverse(split(reverse(config_dir.absoluteFileName), '/')[0]) AS projectNameFromConfig
+      ,reverse(split(reverse(root.absoluteFileName), '/')[0])         AS projectNameFromRoot
+      ,reverse(split(reverse(config_dir.absoluteFileName), '/')[0])   AS projectNameFromConfig
+      ,nullif(substring(replace(config.name, 'tsconfig', ''), 1), '') AS projectAddOnFromConfig
   WITH *
       ,projectNameFromRoot + '/' + 
-       nullif(projectNameFromConfig, projectNameFromRoot) AS projectNameWithDifferentConfigIfPresent
+       nullif(projectNameFromConfig, projectNameFromRoot) +
+       coalesce(' (' + projectAddOnFromConfig + ')', '') AS projectNameWithDifferentConfigIfPresent
   WITH *
       ,coalesce(projectNameWithDifferentConfigIfPresent, projectNameFromRoot) AS projectName
    SET project.name = projectName
@@ -15,7 +17,7 @@ RETURN count(*) AS numberOfNamesProjects
 // For debugging
 //RETURN projectNameFromRoot
 //      ,projectNameFromConfig
-//      ,projectNameWithDifferentConfig
+//      ,projectNameWithDifferentConfigIfPresent
 //      ,projectName
 //      ,project, root, config
 //LIMIT 10

--- a/cypher/Typescript_Enrichment/Add_namespace_property_on_nodes_from_linked_npm_packages.cypher
+++ b/cypher/Typescript_Enrichment/Add_namespace_property_on_nodes_from_linked_npm_packages.cypher
@@ -1,0 +1,16 @@
+// Add namespace property to Typescript nodes if a npm a package is linked. Requires Link_projects_to_npm_packages.
+
+MATCH (element:TS)<-[:CONTAINS]-(project:TS:Project)-[:HAS_NPM_PACKAGE]->(package:NPM:Package)
+WHERE  element.globalFqn IS NOT NULL
+ WITH *
+     ,coalesce(nullif(split(package.name, '/')[0], package.name), '') AS npmPackageNamespace
+     ,coalesce(split(package.name, '/')[1], package.name)             AS packageName 
+  SET  element.namespace   = coalesce(nullif(element.namespace,   ''),  npmPackageNamespace)
+  SET  element.packageName = coalesce(nullif(element.packageName, ''),  packageName)
+RETURN labels(element)[0..4] AS nodeLabels, count(*) AS numberOfWrittenNamespaceProperties
+// Debugging
+//RETURN element.globalFqn, element.moduleName, element.namespace
+//      ,package.name, package.fileName
+//      ,npmPackageNamespace
+//      ,packageName
+//LIMIT 10

--- a/cypher/Typescript_Enrichment/Link_npm_dependencies_to_npm_packages.cypher
+++ b/cypher/Typescript_Enrichment/Link_npm_dependencies_to_npm_packages.cypher
@@ -1,0 +1,15 @@
+// Link npm dependencies to the npm package that describe them if it exists
+
+MATCH (npm_dependency:NPM:Dependency)
+MATCH (npm_package:NPM:Package)
+WHERE  npm_package.name = npm_dependency.name
+  AND  npm_package     <> npm_dependency
+ CALL { WITH npm_package, npm_dependency
+       MERGE (npm_dependency)-[:IS_DESCRIBED_IN_NPM_PACKAGE]->(npm_package)
+      } IN TRANSACTIONS
+RETURN count(*)                       AS numberOfWrittenRelationships
+      ,count(DISTINCT npm_dependency) AS numberOfDistinctNpmDependencies
+      ,count(DISTINCT npm_package)    AS numberOfDistinctNpmPackages
+// Debugging
+// RETURN npm_dependency, npm_package
+// LIMIT 1

--- a/cypher/Typescript_Enrichment/Link_projects_to_npm_packages.cypher
+++ b/cypher/Typescript_Enrichment/Link_projects_to_npm_packages.cypher
@@ -24,7 +24,7 @@ MATCH (npmPackage:NPM:Package)
  MERGE (project)-[:HAS_NPM_PACKAGE]->(npmPackage)
 // Set the "relativeFileDirectory" on the npm package to the relative directory 
 // that contains the package.json file 
-   SET npmPackage.relativeFileDirectory = relativeNpmPackageDirectory
+   SET npmPackage.relativeFileDirectory = ltrim(relativeNpmPackageDirectory, '/')
       ,project.version = npmPackage.version
  RETURN count(*) AS numberOfCreatedNpmPackageRelationships
 // Detailed results for debugging

--- a/scripts/prepareAnalysis.sh
+++ b/scripts/prepareAnalysis.sh
@@ -72,15 +72,11 @@ execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Mark_test_modules.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_projects.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_scan_nodes.cypher"
 
-# Preparation - Enrich Graph for Typescript by adding relationships between Modules with the same globalFqn
-execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_RESOLVES_TO_relationship_for_matching_modules.cypher"
-execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_RESOLVES_TO_relationship_for_matching_declarations.cypher"
-execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_DEPENDS_ON_relationship_to_resolved_modules.cypher"
-
 # Preparation - Cleanup Graph for Typescript by removing duplicate relationships
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Remove_duplicate_CONTAINS_relations_between_files.cypher"
 
 # Preparation - Enrich Graph for Typescript by adding relationships between corresponding TS:Project and NPM:Package nodes
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_npm_dependencies_to_npm_packages.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_projects_to_npm_packages.cypher"
 dataVerificationResult=$( execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Verify_projects_linked_to_npm_packages.cypher" "${@}")
 if is_csv_column_greater_zero "${dataVerificationResult}" "unresolvedProjectsCount"; then
@@ -91,6 +87,12 @@ if is_csv_column_greater_zero "${dataVerificationResult}" "unresolvedProjectsCou
     # Since this is now only a warning, execution will be continued.
 fi
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_external_modules_to_corresponding_npm_dependency.cypher"
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_namespace_property_on_nodes_from_linked_npm_packages.cypher"
+
+# Preparation - Enrich Graph for Typescript by adding relationships between Modules with the same globalFqn
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_RESOLVES_TO_relationship_for_matching_modules.cypher"
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_RESOLVES_TO_relationship_for_matching_declarations.cypher"
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_DEPENDS_ON_relationship_to_resolved_modules.cypher"
 
 # Preparation - Add weights to Java Package DEPENDS_ON relationships 
 execute_cypher_summarized "${DEPENDS_ON_CYPHER_DIR}/Add_weight_property_for_Java_Interface_Dependencies_to_Package_DEPENDS_ON_Relationship.cypher"

--- a/scripts/scanTypescript.sh
+++ b/scripts/scanTypescript.sh
@@ -71,6 +71,8 @@ find_directories_with_package_json_file() {
 scan_directory() {
     local source_directory_name; source_directory_name=$(basename "${1}");
     local progress_information; progress_information="${2}"
+    local COLOR_DARK_GREY='\033[0;30m'
+    local COLOR_DEFAULT='\033[0m'
 
     echo "" >&2 # Output an empty line to have a clearer separation between each scan
     
@@ -79,7 +81,9 @@ scan_directory() {
         # Note: For later troubleshooting, the output is also copied to a dedicated log file using "tee".
         # Note: Don't worry about the hardcoded version number. It will be updated by Renovate using a custom Manager.
         # Note: NODE_OPTIONS --max-old-space-size=4096 increases the memory for scanning larger projects
+        echo -e "${COLOR_DARK_GREY}"
         NODE_OPTIONS="${NODE_OPTIONS} --max-old-space-size=${TYPESCRIPT_SCAN_HEAP_MEMORY}" npx --yes @jqassistant/ts-lce@1.3.0 "${1}" --extension React 2>&1 | tee "${LOG_DIRECTORY}/jqassistant-typescript-scan-${source_directory_name}.log" >&2
+        echo -e "${COLOR_DEFAULT}"
     else
         echo "scanTypescript: Skipping scan of ${source_directory_name} (${progress_information}) -----------------" >&2
     fi

--- a/scripts/scanTypescript.sh
+++ b/scripts/scanTypescript.sh
@@ -149,9 +149,13 @@ for source_directory in ${source_directories}; do
 
     processed_source_directories=$((processed_source_directories + 1))
     progress_info_source_dirs="${processed_source_directories}/${total_source_directories}"
-    if scan_directory "${source_directory}" "${progress_info_source_dirs}" && is_valid_scan_result "${source_directory}"; then
+
+    if [ -f "${source_directory}/tsconfig.json" ] \
+    && scan_directory "${source_directory}" "${progress_info_source_dirs}" \
+    && is_valid_scan_result "${source_directory}"
+    then
         write_change_detection_file   
-        continue # successful scan, proceed to next one.
+        continue # successfully scanned a standard Typescript project (with tsconfig.json file). proceed with next one.
     fi
 
     echo "scanTypescript: Info: Unsuccessful or skipped source directory scan. Scan all contained packages individually." >&2


### PR DESCRIPTION
### 🚀 Feature

- [Link NPM dependencies to their packages if possible](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/a31ec918e42477e97df3942065c4743be211c397). Enhancing the data from [jqassistant-npm-plugin](https://github.com/jqassistant-plugin/jqassistant-npm-plugin), package dependencies are now linked to the package they are declared in (if it exists). This makes it easier to navigate by using `(NPM:Dependency)-[:IS_DESCRIBED_IN_NPM_PACKAGE]->(NPM:Package)`.
- [Improve project name to distinguish multiple tsconfigs](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/76c203ecc89218e347525a8f89def3705f710842). A Typescript project can have multiple configuration files for example to treat tests differently. Gathering the name solely from the directory name leads to some `TS:Project` nodes having the same name. Now, the name of the configuration is appended to the name in parentheses. So you can clearly see if a `TS:Project` is for example representing the tests.
- 🥳 [Improve RESOLVES_TO link from external to internal modules](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/c21e3e6e44e68ec440288b2db78497e1696798e7). Now, every method to link external to internal modules is separately listed in the result. The existing methods had been improved. A new method that links them using npm package name (including namespace) is added. Additionally, external dependency file extensions are "normalized" to be able to detect the link between a Typescript declaration `d.ts` to its counterpart, e.g. `.ts` and to link transpiled `.js` files from `dist` folders to their counterpart.

### ⚙️ Optimization

- [Optimize performance for Typescript code bases](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/4d9fdd881b874116e542ec27b400712a08e606ef). Labelling external Java Types now ignores Typescript nodes.
- [Add internal change detection switch for testing & debugging](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/3607dfb83123b47939f800c5daa190b08a3e189e). Now, its easier to internally/manually test and debug Typescript scanning by being also able to switch on/off change detection.
- [Detect changes for Typescript scanning for each source directory](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/00d28a2a3758b4b958f645af7bc5d3ed3379b5b4). For large Typescript projects with many source directories it is beneficial to only rescan those source directoryies that were actually changed instead of rescanning them all in case one of them changes. Therefore, there is now one change detection file per source directory.
- [Scan included packages if there is no top-level tsconfig.json](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/aaeb468f4182e21c2c8f24322bdddab1b76da108). For large monorepos that don't have a top-level `tsconfig.json` file it is beneficial to scan each contained project instead of the whole monorepo. Otherwise it seems that the jQAssistant Typescript Plugin behaves not as expected in that case (seems to pick just one contained tsconfig).
- [Change Typescript scan log color to dark grey](https://github.com/JohT/code-graph-analysis-pipeline/pull/248/commits/85bc48ab4b8057072a14040aa7d6a2bf648e31f3). Now, it is easer to see which log entries come from the JQAssistant Typescript Plugin and distinguish them from the logs of the automating script .