### PR TITLE
Improve internal dependencies reports

### DIFF
--- a/cypher/GitLog/Set_number_of_aggregated_git_commits.cypher
+++ b/cypher/GitLog/Set_number_of_aggregated_git_commits.cypher
@@ -2,6 +2,6 @@
 
 MATCH (code_file:File&!Git)<-[:RESOLVES_TO]-(git_file:File&Git)
 MATCH (git_file)<-[:CONTAINS_CHANGED]-(git_changespan:Git:ChangeSpan)
- WITH code_file, sum(git_changespan.commits) AS numberOfGitCommits
+ WITH code_file, toInteger(sum(git_changespan.commits)) AS numberOfGitCommits
   SET code_file.numberOfGitCommits = numberOfGitCommits
 RETURN count(DISTINCT coalesce(code_file.absoluteFileName, code_file.fileName)) AS changedCodeFiles

--- a/cypher/Internal_Dependencies/List_all_Typescript_modules.cypher
+++ b/cypher/Internal_Dependencies/List_all_Typescript_modules.cypher
@@ -1,9 +1,11 @@
-// List all existing internal Typescript modules
+// List all existing internal Typescript modules. Requires "Set_localRootPath_for_modules.cypher", "Set_number_of...commits.cypher".
 
 MATCH (internalModule:TS:Module)-[:EXPORTS]->(internalElement:TS)
- WITH internalModule.name                       AS moduleName
-     ,internalModule.globalFqn                  AS moduleFullQualifiedName
-     ,internalModule.incomingDependencies       AS incomingDependencies
-     ,internalModule.outgoingDependencies       AS outgoingDependencies
-     ,COUNT(DISTINCT internalElement.globalFqn) AS numberOfElements
-RETURN moduleName, numberOfElements, incomingDependencies, outgoingDependencies, moduleFullQualifiedName
+ WITH internalModule.name                            AS moduleName
+     ,internalModule.rootProjectName                 AS rootProjectName
+     ,internalModule.localModuleDir                  AS localModuleDir
+     ,internalModule.incomingDependencies            AS incomingDependencies
+     ,internalModule.outgoingDependencies            AS outgoingDependencies
+     ,coalesce(internalModule.numberOfGitCommits, 0) AS numberOfGitCommits
+     ,COUNT(DISTINCT internalElement.globalFqn)      AS numberOfElements
+RETURN rootProjectName, moduleName, numberOfElements, numberOfGitCommits, incomingDependencies, outgoingDependencies

--- a/cypher/Typescript_Enrichment/Set_localRootPath_for_modules.cypher
+++ b/cypher/Typescript_Enrichment/Set_localRootPath_for_modules.cypher
@@ -1,18 +1,24 @@
-
-// Set "localProjectPath", "localProjectPath" and "localModulePath" on Typescript Module nodes
+// Set "rootProjectName" and some local path properties for Typescript modules
 
  MATCH (module:TS:Module)
   WITH *, ltrim(module.localFqn, '.')                              AS trimmedLocalFqn
   WITH *, split(module.globalFqn, trimmedLocalFqn)[0]              AS rootPath
   WITH *, reverse(split(reverse(rootPath), reverse('source/'))[0]) AS localProjectPath
+  WITH *, localProjectPath + trimmedLocalFqn                       AS localModulePath
   WITH *, split(localProjectPath, '/')[0]                          AS rootProjectName
+  WITH *, split(split(trimmedLocalFqn, '/' + module.moduleName)[0], '/src')[0] AS trimmedLocalFqnWithoutModuleAndSourceFolder
+  WITH *, localProjectPath + trimmedLocalFqnWithoutModuleAndSourceFolder       AS localModuleDir
    SET module.localProjectPath = localProjectPath
+      ,module.localModulePath  = localModulePath
+      ,module.localModuleDir   = localModuleDir
       ,module.rootProjectName  = rootProjectName
-      ,module.localModulePath  = localProjectPath + trimmedLocalFqn
 RETURN count(DISTINCT localProjectPath) AS identifiedLocalProjectPaths
 // Debugging
-//RETURN rootPath
-//      ,localProjectPath
-//      ,count(*)
-//      ,collect(DISTINCT module.localFqn)[0..2] AS exampleModuleLocalFqn
-//      ,collect(DISTINCT trimmedLocalFqn)[0..2] AS exampleTrimmedModuleLocalFqn
+// RETURN rootPath
+//       ,localProjectPath
+//       ,rootProjectName
+//       ,count(*)
+//       ,collect(DISTINCT localModulePath)[0..4] AS exampleLocalModulePath
+//       ,collect(DISTINCT localModuleDir) [0..4] AS exampleLocalModuleDir
+//       ,collect(DISTINCT module.localFqn)[0..4] AS exampleModuleLocalFqn
+//       ,collect(DISTINCT trimmedLocalFqn)[0..4] AS exampleTrimmedModuleLocalFqn

--- a/jupyter/InternalDependenciesJava.ipynb
+++ b/jupyter/InternalDependenciesJava.ipynb
@@ -122,6 +122,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6323e85e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pandas DataFrame Display Configuration\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "91d80bf7",
@@ -614,7 +625,7 @@
   ],
   "code_graph_analysis_pipeline_data_validation": "ValidateJavaInternalDependencies",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "codegraph",
    "language": "python",
    "name": "python3"
   },

--- a/jupyter/InternalDependenciesTypescript.ipynb
+++ b/jupyter/InternalDependenciesTypescript.ipynb
@@ -122,6 +122,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1ee8a6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pandas DataFrame Display Configuration\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "91d80bf7",
@@ -456,7 +467,7 @@
   ],
   "code_graph_analysis_pipeline_data_validation": "ValidateTypescriptModuleDependencies",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "codegraph",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### 🚀 Feature

- [Improve internal dependencies reports](https://github.com/JohT/code-graph-analysis-pipeline/pull/255/commits/6ddfe343bc506be19b11a7a161ea2b5f4792e192). Now, internal Typescript module dependencies reports also contain the name of the project and the important part of the module path. Previously, it was harder to read the tables since the globalFqn can be a very long absolute file path masking the important part. 

### ⚙️ Optimization

- [Improve module name if path ends with `/src/index.ts`](https://github.com/JohT/code-graph-analysis-pipeline/pull/255/commits/291ac594c4edbcf0a7ee4df13c3b178185bef2d2). Previously, modules with their path ending with `../module-name/src/index.ts` got `src` as name. Now, the module-name is extracted as expected.