### PR TITLE
Fix minor Typescript issues

### DIFF
--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_Backward_Only_for_Typescript.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_Backward_Only_for_Typescript.cypher
@@ -2,22 +2,16 @@
 
 MATCH (module:TS:Module)-[:EXPORTS]->(forwardSource:TS)-[:DEPENDS_ON]->(forwardTarget:TS)<-[:EXPORTS]-(dependentModule:TS:Module)
 MATCH (dependentModule)-[:EXPORTS]->(backwardSource:TS)-[:DEPENDS_ON]->(backwardTarget:TS)<-[:EXPORTS]-(module)
-// Get the project of the module if available
-OPTIONAL MATCH (project:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(module)
-OPTIONAL MATCH (dependentProject:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(dependentModule)
 WHERE module.globalFqn <> dependentModule.globalFqn
- WITH project.absoluteFileName                                            AS projectFileName
-     ,replace(
-         module.globalFqn
-        ,project.absoluteFileName + '/', ''
-      )                                                                   AS moduleName
-     ,dependentProject.absoluteFileName                                   AS dependentProjectFileName
-     ,replace(
-         dependentModule.globalFqn
-        ,dependentProject.absoluteFileName + '/', ''
-      )                                                                   AS dependentModulePathName
-     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
-     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name)  AS backwardDependencies
+// Get the project of the module if available
+OPTIONAL MATCH (project:TS:Project)-[:CONTAINS]->(module)
+OPTIONAL MATCH (dependentProject:TS:Project)-[:CONTAINS]->(dependentModule)
+ WITH project.name                                                       AS projectFileName
+     ,module.localFqn                                                    AS moduleName
+     ,dependentProject.name                                              AS dependentProjectFileName
+     ,dependentModule.localFqn                                           AS dependentModulePathName
+     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)  AS forwardDependencies
+     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name) AS backwardDependencies
  WITH projectFileName
      ,moduleName
      ,dependentProjectFileName

--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_for_Typescript.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies_Breakdown_for_Typescript.cypher
@@ -2,22 +2,16 @@
 
 MATCH (module:TS:Module)-[:EXPORTS]->(forwardSource:TS)-[:DEPENDS_ON]->(forwardTarget:TS)<-[:EXPORTS]-(dependentModule:TS:Module)
 MATCH (dependentModule)-[:EXPORTS]->(backwardSource:TS)-[:DEPENDS_ON]->(backwardTarget:TS)<-[:EXPORTS]-(module)
-// Get the project of the module if available
-OPTIONAL MATCH (project:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(module)
-OPTIONAL MATCH (dependentProject:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(dependentModule)
 WHERE module.globalFqn <> dependentModule.globalFqn
- WITH project.absoluteFileName                                            AS projectFileName
-     ,replace(
-         module.globalFqn
-        ,project.absoluteFileName + '/', ''
-      )                                                                   AS moduleName
-     ,dependentProject.absoluteFileName                                   AS dependentProjectFileName
-     ,replace(
-         dependentModule.globalFqn
-        ,dependentProject.absoluteFileName + '/', ''
-      )                                                                   AS dependentModulePathName
-     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
-     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name)  AS backwardDependencies
+// Get the project of the module if available
+OPTIONAL MATCH (project:TS:Project)-[:CONTAINS]->(module)
+OPTIONAL MATCH (dependentProject:TS:Project)-[:CONTAINS]->(dependentModule)
+ WITH project.name                                                       AS projectFileName
+     ,module.localFqn                                                    AS moduleName
+     ,dependentProject.name                                              AS dependentProjectFileName
+     ,dependentModule.localFqn                                           AS dependentModulePathName
+     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)  AS forwardDependencies
+     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name) AS backwardDependencies
  WITH projectFileName
      ,moduleName
      ,dependentProjectFileName

--- a/cypher/Cyclic_Dependencies/Cyclic_Dependencies_for_Typescript.cypher
+++ b/cypher/Cyclic_Dependencies/Cyclic_Dependencies_for_Typescript.cypher
@@ -2,22 +2,16 @@
 
 MATCH (module:TS:Module)-[:EXPORTS]->(forwardSource:TS)-[:DEPENDS_ON]->(forwardTarget:TS)<-[:EXPORTS]-(dependentModule:TS:Module)
 MATCH (dependentModule)-[:EXPORTS]->(backwardSource:TS)-[:DEPENDS_ON]->(backwardTarget:TS)<-[:EXPORTS]-(module)
-// Get the project of the module if available
-OPTIONAL MATCH (project:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(module)
-OPTIONAL MATCH (dependentProject:Directory)<-[:HAS_ROOT]-(:TS:Project)-[:CONTAINS]->(dependentModule)
 WHERE module.globalFqn <> dependentModule.globalFqn
- WITH project.absoluteFileName                                            AS projectFileName
-     ,replace(
-         module.globalFqn
-        ,project.absoluteFileName + '/', ''
-      )                                                                   AS moduleName
-     ,dependentProject.absoluteFileName                                   AS dependentProjectFileName
-     ,replace(
-         dependentModule.globalFqn
-        ,dependentProject.absoluteFileName + '/', ''
-      )                                                                   AS dependentModulePathName
-     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)   AS forwardDependencies
-     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name)  AS backwardDependencies
+// Get the project of the module if available
+OPTIONAL MATCH (project:TS:Project)-[:CONTAINS]->(module)
+OPTIONAL MATCH (dependentProject:TS:Project)-[:CONTAINS]->(dependentModule)
+ WITH project.name                                                       AS projectFileName
+     ,module.localFqn                                                    AS moduleName
+     ,dependentProject.name                                              AS dependentProjectFileName
+     ,dependentModule.localFqn                                           AS dependentModulePathName
+     ,collect(DISTINCT forwardSource.name  + '->' + forwardTarget.name)  AS forwardDependencies
+     ,collect(DISTINCT backwardTarget.name + '<-' + backwardSource.name) AS backwardDependencies
  WITH projectFileName
      ,moduleName
      ,dependentProjectFileName

--- a/cypher/Typescript_Enrichment/Add_RESOLVES_TO_relationship_for_matching_modules.cypher
+++ b/cypher/Typescript_Enrichment/Add_RESOLVES_TO_relationship_for_matching_modules.cypher
@@ -7,7 +7,7 @@ MATCH (module:TS:Module)<-[:CONTAINS]-(package:TS:Project)
 WHERE module.globalFqn IS NOT NULL
   AND EXISTS { (module)-[:EXPORTS]->(:TS) } // only when module exports something
 MATCH (externalModule:TS:ExternalModule)
-WHERE module.globalFqn IS NOT NULL
+WHERE externalModule.globalFqn IS NOT NULL
   AND externalModule     <> module
   AND externalModule.name = module.name // Base requirement: Same module name
   AND EXISTS { (externalModule)-[:EXPORTS]->(:TS:ExternalDeclaration)<-[]-(used:TS) } // only when external declarations are used
@@ -21,13 +21,12 @@ WHERE module.globalFqn IS NOT NULL
      // Find internal and external modules with identical "globalFqn"
      ,(module.globalFqn = externalModule.globalFqn) AS equalGlobalFqn
      // Find internal and external modules with identical "module"
-     ,(module.module = externalModule.module)       AS equalModule
+     ,(module.module    = externalModule.module)    AS equalModule
      // Find matching internal and external modules within the same package and namespace
-     ,(    externalModule.namespace    > ''
+     ,(    externalModule.namespace   <> ''
        AND externalModule.namespace    = module.namespace
        AND externalModule.packageName  = package.name     
        AND normalizedExternalExtension = module.extensionExtended
-       AND externalModule.globalFqn ENDS WITH module.localModulePath
       ) AS equalNameAndNamespace
      // Find matching internal and external module without a namespace with matching local module path
      ,(    module.namespace            = ''


### PR DESCRIPTION
### ⚙️ Optimization

- [Simplify cyclic dependencies project and module column](https://github.com/JohT/code-graph-analysis-pipeline/pull/259/commits/de8bf4f5cb03cb4570df4bed7640952e58ae649f). Now, the cyclic dependencies reports for Typescript are easier to read since they only contain the name of the project and the local path of the module instead of the absolute filename that can be very long, repetitive and hard to read.

### 🛠 Fix

- [Match modules by namespace regardless of their localModulePath](https://github.com/JohT/code-graph-analysis-pipeline/pull/259/commits/0418146829ec969168c14528fddb0dab2ecab0bd). `RESOLVES_TO` relationships between external and internal modules were missing when they had the same namespace but a different folder structure. This is now fixed.