### PR TITLE
Improvements for large scala Typescript analysis

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -54,6 +54,12 @@ Use these optional command line options as needed:
     ./init.sh MyAnalysisProjectName
     ```
 
+- Change into the analysis directory.
+
+    ```shell
+    cd ./temp/MyAnalysisProjectName
+    ```
+
 ### 2. Prepare the code to be analyzed
 
 - Move the artifacts (e.g. Java jars json files) you want to analyze into the `artifacts` directory.

--- a/cypher/GitLog/Add_RESOLVES_TO_relationships_to_git_files_for_Typescript.cypher
+++ b/cypher/GitLog/Add_RESOLVES_TO_relationships_to_git_files_for_Typescript.cypher
@@ -3,13 +3,13 @@
 //       The differences are subtle but need to be thought through and tested carefully.
 //       Having separate files makes it obvious that there needs to be one for every new source code language.
 
-MATCH (code_file:!Git&File)
+MATCH (code_file:!Git&File&!Directory&!Scan)
 WHERE (code_file.absoluteFileName IS NOT NULL OR code_file.fileName IS NOT NULL)
-  // Use only original code files, no resolved duplicates
-  AND NOT EXISTS { (code_file)-[:RESOLVES_TO]->(other_file:File&!Git) } 
  WITH code_file
      ,coalesce(code_file.absoluteFileName, code_file.fileName) AS codeFileName
 MATCH (git_file:Git&File)
+WHERE codeFileName      ENDS WITH git_file.fileName
+   OR codeFileName      ENDS WITH git_file.relativePath
 // Use repository if available to overcome ambiguity in multi source analysis
 OPTIONAL MATCH (git_repository:Git&Repository)-[:HAS_FILE]->(git_file)
  WITH *
@@ -19,8 +19,10 @@ OPTIONAL MATCH (git_repository:Git&Repository)-[:HAS_FILE]->(git_file)
               ,coalesce(git_repository.name + '/', '')      + git_file.relativePath
       ) AS gitFileName
 WHERE codeFileName      ENDS WITH gitFileName
-MERGE (git_file)-[:RESOLVES_TO]->(code_file)
-  SET git_file.resolved = true
+ CALL { WITH git_file, code_file
+       MERGE (git_file)-[:RESOLVES_TO]->(code_file)
+          ON CREATE SET git_file.resolved = true
+      } IN TRANSACTIONS
 RETURN count(DISTINCT codeFileName)  AS numberOfCodeFiles
       ,collect(DISTINCT codeFileName + ' <-> ' + gitFileName + '\n')[0..4] AS examples
 // RETURN codeFileName, gitFileName

--- a/init.sh
+++ b/init.sh
@@ -31,6 +31,16 @@ if [ -z "${NEO4J_INITIAL_PASSWORD}" ]; then
     exit 1
 fi
 
+createForwardingScript() {
+    local originalScript="${1}"
+    local scriptName;scriptName=$(basename "$originalScript")
+
+    cp -n "${originalScript}" .
+    echo "#!/usr/bin/env bash" > "./${scriptName}"
+    # shellcheck disable=SC2016
+    echo "${originalScript} \"\${@}\"" >> "./${scriptName}"
+}
+
 # Create the temporary directory for all analysis projects if it hadn't been created yet.
 mkdir -p ./temp
 cd ./temp
@@ -45,9 +55,9 @@ mkdir -p "./${ARTIFACTS_DIRECTORY}"
 # Create the source directory inside the analysis directory for source code projects/repositories if it hadn't been created yet.
 mkdir -p "./${SOURCE_DIRECTORY}"
 
-# Create symbolic links to the most common scripts for code analysis.
-ln -s "./../../scripts/analysis/analyze.sh" .
-ln -s "./../../scripts/startNeo4j.sh" .
-ln -s "./../../scripts/stopNeo4j.sh" .
+# Create forwarding scripts for the most important commands
+createForwardingScript "./../../scripts/analysis/analyze.sh"
+createForwardingScript "./../../scripts/startNeo4j.sh"
+createForwardingScript "./../../scripts/stopNeo4j.sh"
 
 echo "init: Successfully initialized analysis project ${analysisName}" >&2

--- a/scripts/detectChangedFiles.sh
+++ b/scripts/detectChangedFiles.sh
@@ -10,6 +10,7 @@
 #            A second call without this option will be needed for the change detection to work.
 #            This is helpful to decide if an operation should be done based on changes while waiting for its success to finally save the change state.
 # --paths Comma-separated list of file- and directory-names that are used for calculating the hash based on their name and size.
+# --hashfile Path to the file that contains the hash for change detection. Default in environment variable CHANGE_DETECTION_HASH_FILE_PATH
 
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
@@ -88,6 +89,7 @@ file_names_and_sizes() {
           -type d -name "node_modules" -prune -o \
           -type d -name "target" -prune -o \
           -type d -name "temp" -prune -o \
+          -type d -name ".reports" -prune -o \
           -not -path "${hashFilePath}" \
           -type f \
           -exec stat -f "%N %z" {} + \


### PR DESCRIPTION
### ⚙️ Optimization

- [Improve git file to code file matching performance](https://github.com/JohT/code-graph-analysis-pipeline/pull/268/commits/690077a3be7dc4f619cbbed53fd4cc6bf0df1e12). For large Typescript code bases it took very long to link git file nodes to code file nodes. This is now improved and should be around 10 times faster.

### 🛠 Fix

- [Fix init script by providing forwarding scripts](https://github.com/JohT/code-graph-analysis-pipeline/pull/268/commits/0d5d3d962715bafc95078cc877899b54426930c2). Scripts that call the original one are now used Instead of symbolic links, that were not working because of their apparent working directory.
- [Exclude reports from change detection](https://github.com/JohT/code-graph-analysis-pipeline/pull/268/commits/0d9a70b3c78aa2f80d4ff121261041b5566ed506). Scan results from the [jqassistant-typescript-plugin](https://github.com/jqassistant-plugin/jqassistant-typescript-plugin) are now excluded from the change detection. Previously, the Typescript scan was repeated just because the scan reports changed. This could be considered ok, since it is also possible that the scan itself changed and then it would also make sense to trigger a rescan. However, this is an edge case for repeated local analysis and negligible. 