### PR TITLE
Fix broken link check using workaround

### DIFF
--- a/.github/workflows/check-links-in-documentation.yml
+++ b/.github/workflows/check-links-in-documentation.yml
@@ -31,9 +31,11 @@ jobs:
         startsWith(github.event.pull_request.title, 'Update dependency AxonFramework') && 
         github.event.pull_request.user.type == 'Bot'
       run: |
-        echo "Skipping link check on AxonFramework updates since the updated links tto the reports will only be active " 
+        echo "Skipping link check on AxonFramework updates since the updated links to the reports will only be active " 
         echo "skip_link_check=true" >> $GITHUB_ENV
 
     - name: Check links in top level documentation Markdown files
       if: ${{ ! env.skip_link_check}}
-      run: npx --yes markdown-link-check@3.12.2 --config=markdown-lint-check-config.json README.md COMMANDS.md GETTING_STARTED.md
+      run: npx --yes markdown-link-check@3.13.6 --verbose --alive=200,202,206 --retry README.md COMMANDS.md GETTING_STARTED.md
+      # Temporarily, everything is done using command line options rather than with the config file, which doesn't seem to work.
+      # Maybe related to https://github.com/tcort/markdown-link-check/issues/379 ?

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -24,7 +24,7 @@ Use these optional command line options as needed:
   ./scripts/examples/analyzeAxonFramework.sh --report CSV
   ```
 
-- Only explore the graph manually in the [browser](http://localhost:7474/browser). Skip all automated reports. Example:
+- Only explore the graph manually in the browser (`http://localhost:7474/browser`). Skip all automated reports. Example:
 
   ```shell
   ./scripts/examples/analyzeAxonFramework.sh --explore
@@ -108,7 +108,7 @@ Use these optional command line options as needed:
   ./../../scripts/analysis/analyze.sh --explore
   ```
 
-👉 Open your browser and login to your [local Neo4j Web UI](http://localhost:7474/browser) with "neo4j" as user and the initial password you've chosen.
+👉 Open your browser and login to your local Neo4j Web UI (`http://localhost:7474/browser`) with "neo4j" as user and the initial password you've chosen.
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The [Code Structure Analysis Pipeline](./.github/workflows/java-code-analysis.ym
   👉 To get started from scratch see [GETTING_STARTED.md](./GETTING_STARTED.md).
 
 - How can i explore the Graph manually?
-  👉 After analysis [start Neo4j](./COMMANDS.md#start-neo4j-graph-database) and open the [Neo4j Web UI](http://localhost:7474/browser).
+  👉 After analysis [start Neo4j](./COMMANDS.md#start-neo4j-graph-database) and open the Neo4j Web UI (`http://localhost:7474/browser`).
 
 - How can i add a CSV report to the pipeline?  
   👉 Put your new cypher query into the [cypher](./cypher) directory or a suitable (new) sub directory.  


### PR DESCRIPTION
### 🛠 Fix

- [Fix broken link check by using options instead of a config](https://github.com/JohT/code-graph-analysis-pipeline/pull/279/commits/b7c458105ae2a646d53251b1b74192d6cacfbdae). The update to [markdown-link-check v3.13.6](https://github.com/tcort/markdown-link-check/releases/tag/v3.13.6) lead to a failing pipeline. It seems that there is a problem with reading the config maybe related to https://github.com/tcort/markdown-link-check/issues/369 or https://github.com/tcort/markdown-link-check/issues/379. Nevertheless, using command line options seems to work. By removing the local host links (now marked with quotes) and taking over the other configuration parameters as command line options the link check now works again. This was intended as a workaround but seems to reduce complexity and coupling and might also help in future.
