### PR TITLE
Install Typescript project dependencies explicitly

### DIFF
--- a/.github/workflows/typescript-code-analysis.yml
+++ b/.github/workflows/typescript-code-analysis.yml
@@ -118,11 +118,6 @@ jobs:
         key:
           ${{ runner.os }}-${{ hashFiles('**/*.sh') }}
 
-    - name: Setup pnpm for react-router
-      uses: pnpm/action-setup@v4.0.0
-      with:
-        version: 8.10.5
-
     - name: Download ${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}
       working-directory: temp
       run: |
@@ -130,6 +125,16 @@ jobs:
         cd ${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}
         echo "Working directory: $( pwd -P )"
         ./../../scripts/downloader/downloadReactRouter.sh ${{ env.REACT_ROUTER_VERSION }}
+
+    - name: Setup pnpm for react-router
+      uses: pnpm/action-setup@v4.0.0
+      with:
+        package_json_file: temp/${{env.PROJECT_NAME}}-${{env.REACT_ROUTER_VERSION}}/source/${{env.PROJECT_NAME}}-${{env.REACT_ROUTER_VERSION}}/package.json
+          
+    - name: Install dependencies with pnpm
+      working-directory: temp/${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}/source/${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}
+      run: |
+        pnpm install --frozen-lockfile --strict-peer-dependencies
 
     - name: Analyze ${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}
       working-directory: temp/${{ env.PROJECT_NAME }}-${{ env.REACT_ROUTER_VERSION }}

--- a/scripts/downloader/downloadAntDesign.sh
+++ b/scripts/downloader/downloadAntDesign.sh
@@ -2,7 +2,6 @@
 
 # Downloads the Typescript project ant-design (https://github.com/ant-design/ant-design) from GitHub using git clone.
 # The source files are written into the "source" directory of the current analysis directory.
-# After scanning it with jQAssistant Typescript Plugin the resulting JSON will be moved into the "artifacts" directory.
 
 # Note: This script is meant to be started within the temporary analysis directory (e.g. "temp/AnalysisName/")
 

--- a/scripts/downloader/downloadReactRouter.sh
+++ b/scripts/downloader/downloadReactRouter.sh
@@ -2,7 +2,6 @@
 
 # Downloads react-router (https://github.com/remix-run/react-router) from GitHub using git clone.
 # The source files are written into the "source" directory of the current analysis directory.
-# After scanning it with jQAssistant Typescript Plugin the resulting JSON will be moved into the "artifacts" directory.
 
 # Note: This script is meant to be started within the temporary analysis directory (e.g. "temp/AnalysisName/")
 # Note: react-router uses pnpm as package manager which needs to be installed first
@@ -30,5 +29,4 @@ echo "downloadReactRouter: DOWNLOADER_SCRIPTS_DIR=${DOWNLOADER_SCRIPTS_DIR}"
 source "${DOWNLOADER_SCRIPTS_DIR}/downloadTypescriptProject.sh" \
   --url https://github.com/remix-run/react-router.git \
   --version "${projectVersion}" \
-  --tag "react-router@${projectVersion}" \
-  --packageManager pnpm
+  --tag "react-router@${projectVersion}"

--- a/scripts/examples/analyzeReactRouter.sh
+++ b/scripts/examples/analyzeReactRouter.sh
@@ -11,6 +11,10 @@
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
+# Overrideable Defaults
+SOURCE_DIRECTORY=${SOURCE_DIRECTORY:-"source"}
+echo "analyzerReactRouter: SOURCE_DIRECTORY=${SOURCE_DIRECTORY}"
+
 ## Get this "scripts" directory if not already set
 # Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
@@ -53,8 +57,13 @@ cd "./react-router-${projectVersion}"
 # Create the artifacts directory that will contain the code to be analyzed.
 mkdir -p ./artifacts
 
-# Download AxonFramework artifacts (jar files) from Maven
+# Download react-router source code
 ./../../scripts/downloader/downloadReactRouter.sh "${projectVersion}"
+
+(
+  cd "${SOURCE_DIRECTORY}/react-router-${projectVersion}" || exit
+  pnpm install --frozen-lockfile --strict-peer-dependencies || exit
+)
 
 # Start the analysis
 ./../../scripts/analysis/analyze.sh "${@}"


### PR DESCRIPTION
### 🚀 Feature

- [Install Typescript project dependencies explicitly](https://github.com/JohT/code-graph-analysis-pipeline/pull/280/commits/0eaedb720ab423335c57b72000821cb259bcbf9f). Now, `npm install` or `pnpm install`,... aren't executed within the `downloadTypescriptProject` script anymore. It needs to be done separately. This makes it possible to only download the project and let the [pnpm GitHub action](https://github.com/pnpm/action-setup) extract the compatible pnpm version to download by reading the `packageManager` property inside the `package.json` file. Additionally, the code is now simpler since not every package manager and command line option constellation needs to be addressed in a script. To still have a nice "getting started" experience, the installation is built into the example scripts.