### PR TITLE
Add details to algorithm result code unit names

### DIFF
--- a/cypher/Centrality/Centrality_10d_Bridges_Stream.cypher
+++ b/cypher/Centrality/Centrality_10d_Bridges_Stream.cypher
@@ -4,12 +4,10 @@ CALL gds.bridges.stream($dependencies_projection + '-cleaned')
  YIELD from, to
   WITH gds.util.asNode(from) AS fromMember
       ,gds.util.asNode(to)   AS toMember
-OPTIONAL MATCH (fromType:Type)-[:DECLARES]->(fromMember)
-  WITH *, coalesce(fromType.fqn + ': ', '')              +
+  WITH *, coalesce(fromMember.declaringType + ': ', '')  +
           coalesce(fromMember.rootProjectName + '/', '') +
           coalesce(fromMember.signature,  fromMember.name) AS fromMemberNameWithDetails
-OPTIONAL MATCH (toType:Type)-[:DECLARES]->(toMember)
-  WITH *, coalesce(toType.fqn + ': ', '')                +
+  WITH *, coalesce(toMember.declaringType + ': ', '')    +
           coalesce(toMember.rootProjectName + '/', '')   +
           coalesce(toMember.signature,  toMember.name)     AS toMemberNameWithDetails
 RETURN coalesce(fromMember.fqn, fromMemberNameWithDetails, fromMember.fileName, fromMember.name) AS fromMemberName

--- a/cypher/Centrality/Centrality_10d_Bridges_Stream.cypher
+++ b/cypher/Centrality/Centrality_10d_Bridges_Stream.cypher
@@ -4,11 +4,16 @@ CALL gds.bridges.stream($dependencies_projection + '-cleaned')
  YIELD from, to
   WITH gds.util.asNode(from) AS fromMember
       ,gds.util.asNode(to)   AS toMember
-  WITH *
-      ,toMember.rootProjectName + '/' + toMember.name     AS toMemberNameWithRoot
-      ,fromMember.rootProjectName + '/' + fromMember.name AS fromMemberNameWithRoot
-RETURN coalesce(fromMember.fqn, fromMemberNameWithRoot, fromMember.name, fromMember.fileName) AS fromMemberName
-      ,coalesce(toMember.fqn,   toMemberNameWithRoot,   toMember.name,   toMember.fileName)   AS toMemberName
+OPTIONAL MATCH (fromType:Type)-[:DECLARES]->(fromMember)
+  WITH *, coalesce(fromType.fqn + ': ', '')              +
+          coalesce(fromMember.rootProjectName + '/', '') +
+          coalesce(fromMember.signature,  fromMember.name) AS fromMemberNameWithDetails
+OPTIONAL MATCH (toType:Type)-[:DECLARES]->(toMember)
+  WITH *, coalesce(toType.fqn + ': ', '')                +
+          coalesce(toMember.rootProjectName + '/', '')   +
+          coalesce(toMember.signature,  toMember.name)     AS toMemberNameWithDetails
+RETURN coalesce(fromMember.fqn, fromMemberNameWithDetails, fromMember.fileName, fromMember.name) AS fromMemberName
+      ,coalesce(toMember.fqn,   toMemberNameWithDetails,   toMember.fileName,   toMember.name)   AS toMemberName
       ,fromMember.incomingDependencies AS fromIncomingDependencies
       ,fromMember.outgoingDependencies AS fromOutgoingDependencies
       ,toMember.incomingDependencies   AS toIncomingDependencies

--- a/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
+++ b/cypher/Centrality/Centrality_9d_Hyperlink_Induced_Topic_Search_HITS_Stream_Mutated.cypher
@@ -1,4 +1,4 @@
-// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream Mutated. Requires "Add_file_name and_extension.cypher".
+// Centrality 9d Hyperlink-Induced Topic Search (HITS) Stream Mutated. Requires "Add_file_name and_extension.cypher", "Set_localRootPath_for_modules", "Set_declaring_type_on_method_nodes".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -10,10 +10,13 @@ CALL gds.graph.nodeProperties.stream(
 YIELD nodeId, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,collect(propertyValue)  AS values
-RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
-     ,codeUnit.name      AS shortCodeUnitName
-     ,values[0] AS centralityHyperlinkInducedTopicSearchAuthority
-     ,values[1] AS centralityHyperlinkInducedTopicSearchHub
+  WITH *, coalesce(codeUnit.declaringType + ': ', '')        +
+          coalesce(codeUnit.rootProjectName + '/', '') +
+          coalesce(codeUnit.signature,  codeUnit.name) AS codeUnitNameWithDetails
+RETURN DISTINCT coalesce(codeUnit.fqn, codeUnitNameWithDetails, codeUnit.fileName, codeUnit.name) AS codeUnitName
+     ,codeUnit.name                 AS shortCodeUnitName
+     ,values[0]                     AS centralityHyperlinkInducedTopicSearchAuthority
+     ,values[1]                     AS centralityHyperlinkInducedTopicSearchHub
      ,codeUnit.incomingDependencies AS incomingDependencies
      ,codeUnit.outgoingDependencies AS outgoingDependencies
 ORDER BY centralityHyperlinkInducedTopicSearchAuthority DESCENDING, codeUnitName ASCENDING

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
+// Read a property from projected nodes unordered. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher", "Set_localRootPath_for_modules", "Set_declaring_type_on_method_nodes".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -8,7 +8,10 @@ YIELD nodeId, nodeProperty, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,nodeProperty            AS propertyName
      ,propertyValue
-RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
+  WITH *, coalesce(codeUnit.declaringType + ': ', '')  +
+          coalesce(codeUnit.rootProjectName + '/', '') +
+          coalesce(codeUnit.signature,  codeUnit.name) AS codeUnitNameWithDetails
+RETURN DISTINCT coalesce(codeUnit.fqn, codeUnitNameWithDetails, codeUnit.fileName, codeUnit.name) AS codeUnitName
      ,codeUnit.name      AS shortCodeUnitName
      ,propertyName
      ,propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Extended.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection into the Graph. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
+// Read a property from projected nodes extended by some details. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher", "Set_localRootPath_for_modules", "Set_declaring_type_on_method_nodes".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -6,13 +6,16 @@ CALL gds.graph.nodeProperties.stream(
 )
 YIELD nodeId, nodeProperty, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
-     ,nodeProperty AS propertyName
+     ,nodeProperty            AS propertyName
      ,propertyValue
-OPTIONAL MATCH (artifact:Artifact)-[:CONTAINS]->(codeUnit)
-RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.name) AS codeUnitName
+  WITH *, coalesce(codeUnit.declaringType + ': ', '')  +
+          coalesce(codeUnit.rootProjectName + '/', '') +
+          coalesce(codeUnit.signature,  codeUnit.name) AS codeUnitNameWithDetails
+OPTIONAL MATCH (project:Artifact|Project)-[:CONTAINS]->(codeUnit)
+RETURN DISTINCT coalesce(codeUnit.fqn, codeUnitNameWithDetails, codeUnit.fileName, codeUnit.name) AS codeUnitName
      ,codeUnit.name AS shortCodeUnitName
      ,propertyName
      ,propertyValue
-     ,coalesce(codeUnit.communityLeidenId, 0) AS communityId // optional, might be null
-     ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality // optional, might be null
-     ,artifact.name AS owningArtifactName
+     ,coalesce(codeUnit.communityLeidenId, 0)        AS communityId // optional, might be null
+     ,coalesce(codeUnit.centralityPageRank, 0.00001) AS centrality // optional, might be null
+     ,project.name AS owningProject

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Grouped.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
+// Read a property from projected nodes. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher", "Set_localRootPath_for_modules", "Set_declaring_type_on_method_nodes".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -8,9 +8,12 @@ YIELD nodeId, nodeProperty, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,nodeProperty            AS propertyName
      ,propertyValue
+  WITH *, coalesce(codeUnit.declaringType + ': ', '')  +
+          coalesce(codeUnit.rootProjectName + '/', '') +
+          coalesce(codeUnit.signature,  codeUnit.name) AS codeUnitNameWithDetails
  WITH propertyName
      ,propertyValue
-     ,coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.name)                          AS codeUnitName
+     ,coalesce(codeUnit.fqn, codeUnitNameWithDetails, codeUnit.fileName, codeUnit.name) AS codeUnitName
      ,codeUnit.name AS shortCodeUnitName
  WITH propertyName
      ,propertyValue

--- a/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
+++ b/cypher/Dependencies_Projection/Dependencies_8_Stream_Mutated_Value_Descending.cypher
@@ -1,4 +1,4 @@
-// Read a property from the projection and order it by its value descending. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher".
+// Read a property from projected nodes ordered by their value descending. Variables: dependencies_projection, dependencies_projection_write_property. Requires "Add_file_name and_extension.cypher", "Set_localRootPath_for_modules", "Set_declaring_type_on_method_nodes".
 
 CALL gds.graph.nodeProperties.stream(
      $dependencies_projection + '-cleaned'
@@ -8,7 +8,10 @@ YIELD nodeId, nodeProperty, propertyValue
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,nodeProperty            AS propertyName
      ,propertyValue
-RETURN DISTINCT coalesce(codeUnit.fqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
+  WITH *, coalesce(codeUnit.declaringType + ': ', '')  +
+          coalesce(codeUnit.rootProjectName + '/', '') +
+          coalesce(codeUnit.signature,  codeUnit.name) AS codeUnitNameWithDetails
+RETURN DISTINCT coalesce(codeUnit.fqn, codeUnitNameWithDetails, codeUnit.fileName, codeUnit.name) AS codeUnitName
      ,codeUnit.name      AS shortCodeUnitName
      ,propertyName
      ,propertyValue

--- a/cypher/Types/Set_declaring_type_on_method_nodes.cypher
+++ b/cypher/Types/Set_declaring_type_on_method_nodes.cypher
@@ -1,0 +1,6 @@
+// Set property "declaringType" on Method nodes.
+
+ MATCH (javaType:Type)-[:DECLARES]->(javaMethod:Method)
+   SET javaMethod.declaringType = javaType.fqn
+RETURN count(DISTINCT javaMethod) AS numberOfMethods
+      ,count(DISTINCT javaType)   AS numberOfTypes

--- a/scripts/prepareAnalysis.sh
+++ b/scripts/prepareAnalysis.sh
@@ -112,6 +112,9 @@ execute_cypher_summarized "${METRICS_CYPHER_DIR}/Set_Outgoing_Typescript_Module_
 execute_cypher_summarized "${METRICS_CYPHER_DIR}/Set_Incoming_Java_Package_Dependencies.cypher"
 execute_cypher_summarized "${METRICS_CYPHER_DIR}/Set_Outgoing_Java_Package_Dependencies.cypher"
 
+# Preparation - Add Java Method node property "declaringType"
+execute_cypher "${TYPES_CYPHER_DIR}/Set_declaring_type_on_method_nodes.cypher"
+
 # Preparation - Label external types and annotations
 #               "external" means that there is no byte code available, not a primitive type and not a java type
 #               "annotation" means that there is a ANNOTATED_BY to that external type

--- a/scripts/reports/CentralityCsv.sh
+++ b/scripts/reports/CentralityCsv.sh
@@ -375,7 +375,7 @@ runUndirectedCentralityAlgorithms() {
 # -- Java Artifact Centrality ------------------------------------
 
 ARTIFACT_PROJECTION="dependencies_projection=artifact-centrality" 
-ARTIFACT_PROJECTION_UNDIRECTED="dependencies_projection=${ARTIFACT_PROJECTION}-undirected" 
+ARTIFACT_PROJECTION_UNDIRECTED="dependencies_projection=artifact-centrality-undirected" 
 ARTIFACT_NODE="dependencies_projection_node=Artifact" 
 ARTIFACT_WEIGHT="dependencies_projection_weight_property=weight" 
 
@@ -389,7 +389,7 @@ fi
 # -- Java Package Centrality -------------------------------------
 
 PACKAGE_PROJECTION="dependencies_projection=package-centrality" 
-PACKAGE_PROJECTION_UNDIRECTED="dependencies_projection=${PACKAGE_PROJECTION}-undirected" 
+PACKAGE_PROJECTION_UNDIRECTED="dependencies_projection=package-centrality-undirected" 
 PACKAGE_NODE="dependencies_projection_node=Package" 
 PACKAGE_WEIGHT="dependencies_projection_weight_property=weight25PercentInterfaces" 
 
@@ -402,17 +402,21 @@ fi
 
 # -- Java Type Centrality ----------------------------------------
 
-TYPE_PROJECTION="dependencies_projection=type-centrality" 
+TYPE_PROJECTION="dependencies_projection=type-centrality"
+TYPE_PROJECTION_UNDIRECTED="dependencies_projection=type-centrality-undirected" 
 TYPE_NODE="dependencies_projection_node=Type" 
 TYPE_WEIGHT="dependencies_projection_weight_property=weight" 
 
 if createDirectedJavaTypeDependencyProjection "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"; then
     runCentralityAlgorithms "${TYPE_PROJECTION}" "${TYPE_NODE}" "${TYPE_WEIGHT}"
 fi
+if createUndirectedJavaTypeDependencyProjection "${TYPE_PROJECTION_UNDIRECTED}"; then
+    runUndirectedCentralityAlgorithms "${TYPE_PROJECTION_UNDIRECTED}" "${TYPE_NODE}"
+fi
 
 # -- Java Method Centrality --------------------------------------
 
-METHOD_PROJECTION="dependencies_projection=method-centrality" 
+METHOD_PROJECTION="dependencies_projection=method-centrality"
 METHOD_NODE="dependencies_projection_node=Method" 
 METHOD_WEIGHT="dependencies_projection_weight_property=" 
 
@@ -424,7 +428,7 @@ fi
 
 MODULE_LANGUAGE="dependencies_projection_language=Typescript" 
 MODULE_PROJECTION="dependencies_projection=typescript-module-centrality" 
-MODULE_PROJECTION_UNDIRECTED="dependencies_projection=${MODULE_PROJECTION}-undirected" 
+MODULE_PROJECTION_UNDIRECTED="dependencies_projection=typescript-module-centrality-undirected" 
 MODULE_NODE="dependencies_projection_node=Module" 
 MODULE_WEIGHT="dependencies_projection_weight_property=lowCouplingElement25PercentWeight"
 


### PR DESCRIPTION
### 🚀 Feature

- [Improve code unit name in graph algorithm result reports](https://github.com/JohT/code-graph-analysis-pipeline/pull/285/commits/47ba715990af0de78f1e9c24e12bf79482ee20ed). The name of the analyzed code unit (Java Type, Java Method, Typescript Module,...) is now more expressive for all algorithms. For Typescript modules ,e.g., it includes the root project name.

### ⚙️ Optimization

- [Optimize Bridges centrality output and run it for Java Types](https://github.com/JohT/code-graph-analysis-pipeline/pull/285/commits/91429059c25771093de5e28ccadbff7592bf5766). Now, bridges are also detected for Java Types (Classes,...). Additionally, the list of found bridges contains a more detailed name of the analyzed code units. For Typescript modules ,e.g., it includes the root project name.