### PR TITLE
Minimize Neo4j transaction log disk space utilization

### DIFF
--- a/graph-visualization/renderVisualizations.js
+++ b/graph-visualization/renderVisualizations.js
@@ -136,7 +136,8 @@ let browser;
       "--disable-component-extensions-with-background-pages",
       "--disable-client-side-phishing-detection",
       "--use-gl=disabled",
-      "--disable-features=Vulkan", 
+      "--disable-features=Vulkan",
+      "--no-sandbox" // See https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
     ],
   }); // { headless: false } for testing
 

--- a/scripts/configuration/template-neo4j-v4.conf
+++ b/scripts/configuration/template-neo4j-v4.conf
@@ -20,3 +20,6 @@ dbms.memory.transaction.global_max_size=6g
 
 # Memory: Limit the amount of memory that a single transaction can consume.
 dbms.memory.transaction.max_size=6g
+
+# Transaction: Retention policy for transaction logs needed to perform recovery and backups.
+dbms.tx_log.rotation.retention_policy=keep_none

--- a/scripts/configuration/template-neo4j.conf
+++ b/scripts/configuration/template-neo4j.conf
@@ -20,3 +20,6 @@ db.memory.transaction.total.max=6g
 
 # Memory: Limit the amount of memory that a single transaction can consume.
 db.memory.transaction.max=6g
+
+# Transaction: Retention policy for transaction logs needed to perform recovery and backups.
+db.tx_log.rotation.retention_policy=keep_none

--- a/scripts/setupNeo4j.sh
+++ b/scripts/setupNeo4j.sh
@@ -98,8 +98,10 @@ if [ ! -d "${NEO4J_INSTALLATION_DIRECTORY}" ] ; then
     echo "setupNeo4j: Commenting out configuration properties that will later be replaced or are not needed"
     if [[ "$NEO4J_MAJOR_VERSION_NUMBER" -ge 5 ]]; then
         sed -i.backup '/^server\.directories\.import=/ s/^/# defined in the directory section further below #/' "${NEO4J_CONFIG}"
+        sed -i.backup '/^db\.tx_log\.rotation\.retention_policy=/ s/^/# defined in the transaction section further below #/' "${NEO4J_CONFIG}"
     else
         sed -i.backup '/^dbms\.directories\.import=/ s/^/# defined in the directory section further below #/' "${NEO4J_CONFIG}"
+        sed -i.backup '/^dbms\.tx_log\.rotation\.retention_policy=/ s/^/# defined in the transaction section further below #/' "${NEO4J_CONFIG}"
     fi
     # Remove the backup file
     rm -f "${NEO4J_CONFIG}.backup"
@@ -161,7 +163,7 @@ if [ ! -d "${NEO4J_INSTALLATION_DIRECTORY}" ] ; then
         } >> "${NEO4J_CONFIG}"
     fi
 
-    echo "setupNeo4j: Configuring static settings (memory, procedure permittions, ...)"
+    echo "setupNeo4j: Configuring static settings (memory, procedure permissions, ...)"
     if [[ "$NEO4J_MAJOR_VERSION_NUMBER" -ge 5 ]]; then
         cat "${SCRIPTS_DIR}/configuration/template-neo4j.conf" >> "${NEO4J_CONFIG}"
     else


### PR DESCRIPTION
### ⚙️ Optimization

- [Minimize Neo4j transaction log disk space utilization](https://github.com/JohT/code-graph-analysis-pipeline/pull/294/commits/2d3ae6ae6eac9c7b6e1c13a3c98f3e1dd9429e38). The transaction log of a database can become quite big. It is needed for incremental backups and helpful for things like "change data capture". In this special case here it is not really needed, since the database can always be recreated. Therefore, the rotation of the transaction logs is switched off an therefore only one file with at most 256Mb is created.
