### PR TITLE
Auto update Conda Environment

### DIFF
--- a/.github/workflows/internal-java-code-analysis.yml
+++ b/.github/workflows/internal-java-code-analysis.yml
@@ -56,6 +56,10 @@ jobs:
     - name: Checkout GIT Repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     
+    - name: Run script tests
+      id: script-tests
+      run: ./scripts/runTests.sh
+
     - name: Set Set output variable 'analysis-name'
       id: set-analysis-name
       run: echo "analysis-name=${{ env.PROJECT_NAME }}-${{ env.AXON_FRAMEWORK_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/public-analyze-code-graph.yml
+++ b/.github/workflows/public-analyze-code-graph.yml
@@ -97,6 +97,7 @@ jobs:
 
       # "Setup Python" can be skipped if jupyter notebook analysis-results aren't needed
       - name: (Python Setup) Use version ${{ matrix.python }} with Conda package manager Miniforge
+        id: prepare-conda-environment
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3
         with:
           python-version: ${{ matrix.python }}
@@ -160,6 +161,7 @@ jobs:
           NEO4J_INITIAL_PASSWORD: ${{ steps.generate-neo4j-initial-password.outputs.neo4j-initial-password }}
           ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION: "true"
           IMPORT_GIT_LOG_DATA_IF_SOURCE_IS_PRESENT: "" # Options: "none", "aggregated", "full". default = "plugin" or ""
+          PREPARE_CONDA_ENVIRONMENT: "false" # Had already been done in step with id "prepare-conda-environment".
         run: |
           TYPESCRIPT_SCAN_HEAP_MEMORY=${{ inputs.typescript-scan-heap-memory }} ./../../scripts/analysis/analyze.sh ${{ inputs.analysis-arguments }}
     

--- a/scripts/activateCondaEnvironment.sh
+++ b/scripts/activateCondaEnvironment.sh
@@ -61,15 +61,15 @@ eval "$(${pathToConda}conda${scriptExtension} shell.bash hook)"
 echo "activateCondaEnvironment: Current conda environment after shell hook=${CONDA_DEFAULT_ENV}"
 
 # Create (if missing) and activate Conda environment for code structure graph analysis
-if { "${pathToConda}conda" env list | grep "$CODEGRAPH_CONDA_ENVIRONMENT "; } >/dev/null 2>&1; then
-    echo "activateCondaEnvironment: Conda environment $CODEGRAPH_CONDA_ENVIRONMENT already created"
+if { "${pathToConda}conda" env list | grep "${CODEGRAPH_CONDA_ENVIRONMENT} "; } >/dev/null 2>&1; then
+    echo "activateCondaEnvironment: Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} already created"
 else
     if [ ! -f "${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml" ] ; then
-        echo "activateCondaEnvironment: Couldn't find environment file ${jupyter_notebook_file_path}/environment.yml."
+        echo "activateCondaEnvironment: Couldn't find environment file ${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml."
         exit 2
     fi
     echo "activateCondaEnvironment: Creating Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT}"
-    "${pathToConda}conda" env create --file "${jupyter_notebook_file_path}/environment.yml" --name "${CODEGRAPH_CONDA_ENVIRONMENT}"
+    "${pathToConda}conda" env create --file "${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml" --name "${CODEGRAPH_CONDA_ENVIRONMENT}"
 fi
 
 echo "activateCondaEnvironment: Activating Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT}"

--- a/scripts/activateCondaEnvironment.sh
+++ b/scripts/activateCondaEnvironment.sh
@@ -37,14 +37,15 @@ echo "activateCondaEnvironment: CONDA_PREFIX=${CONDA_PREFIX}"
 echo "activateCondaEnvironment: Current conda environment=${CONDA_DEFAULT_ENV}"
 echo "activateCondaEnvironment: Target conda environment=${CODEGRAPH_CONDA_ENVIRONMENT}"
 
-# TODO Find out, if conda updates (when needed) should also be done here instead of just returning 0.
-# if [ "${CONDA_DEFAULT_ENV}" = "${CODEGRAPH_CONDA_ENVIRONMENT}" ] ; then
-#     echo "activateCondaEnvironment: Skipping activation. Target conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} is already activated."
-#     # "return" needs to be used here instead of "exit".
-#     # This script is included in another script by using "source". 
-#     # "exit" would end the main script, "return" just ends this sub script.
-#     return 0
-# fi 
+PREPARE_CONDA_ENVIRONMENT=${PREPARE_CONDA_ENVIRONMENT:-"true"} # Wether to prepare then Conda environment if needed (default, "true") or use an already prepared Conda environment ("false")
+
+if [ "${CONDA_DEFAULT_ENV}" = "${CODEGRAPH_CONDA_ENVIRONMENT}" ] && [ "${PREPARE_CONDA_ENVIRONMENT}" = "false" ]; then
+    echo "activateCondaEnvironment: Skipping activation. Target conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} is already activated."
+    # "return" needs to be used here instead of "exit".
+    # This script is included in another script by using "source". 
+    # "exit" would end the main script, "return" just ends this sub script.
+    return 0
+fi 
 
 # Include operation system function to for example detect Windows.
 source "${SCRIPTS_DIR}/operatingSystemFunctions.sh"

--- a/scripts/activateCondaEnvironment.sh
+++ b/scripts/activateCondaEnvironment.sh
@@ -17,11 +17,19 @@ set -o errexit -o pipefail
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 SCRIPTS_DIR=${SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )} # Repository directory containing the shell scripts
-echo "activateCondaEnvironment: SCRIPTS_DIR=$SCRIPTS_DIR"
+echo "activateCondaEnvironment: SCRIPTS_DIR=${SCRIPTS_DIR}"
 
 # Get the "jupyter" directory by taking the path of this script and going two directory up and then to "jupyter".
 JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY:-"${SCRIPTS_DIR}/../jupyter"} # Repository directory containing the Jupyter Notebooks
-echo "activateCondaEnvironment: JUPYTER_NOTEBOOK_DIRECTORY=$JUPYTER_NOTEBOOK_DIRECTORY"
+echo "activateCondaEnvironment: JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY}"
+
+# Get the file name of the environment description file for the conda package and environment manager 
+# that contains all dependencies and their versions.
+CONDA_ENVIRONMENT_FILE=${CONDA_ENVIRONMENT_FILE:-"${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml"} # Conda (package manager for Python) environment file path
+if [ ! -f "${CONDA_ENVIRONMENT_FILE}" ] ; then
+    echo "activateCondaEnvironment: Couldn't find environment file ${CONDA_ENVIRONMENT_FILE}."
+    exit 2
+fi
 
 # Define conda environment to use for code structure analysis. Default "codegraph"
 CODEGRAPH_CONDA_ENVIRONMENT=${CODEGRAPH_CONDA_ENVIRONMENT:-"codegraph"} # Name of the conda environment to use for code graph analysis
@@ -29,13 +37,14 @@ echo "activateCondaEnvironment: CONDA_PREFIX=${CONDA_PREFIX}"
 echo "activateCondaEnvironment: Current conda environment=${CONDA_DEFAULT_ENV}"
 echo "activateCondaEnvironment: Target conda environment=${CODEGRAPH_CONDA_ENVIRONMENT}"
 
-if [ "${CONDA_DEFAULT_ENV}" = "${CODEGRAPH_CONDA_ENVIRONMENT}" ] ; then
-    echo "activateCondaEnvironment: Skipping activation. Target conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} is already activated."
-    # "return" needs to be used here instead of "exit".
-    # This script is included in another script by using "source". 
-    # "exit" would end the main script, "return" just ends this sub script.
-    return 0
-fi
+# TODO Find out, if conda updates (when needed) should also be done here instead of just returning 0.
+# if [ "${CONDA_DEFAULT_ENV}" = "${CODEGRAPH_CONDA_ENVIRONMENT}" ] ; then
+#     echo "activateCondaEnvironment: Skipping activation. Target conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} is already activated."
+#     # "return" needs to be used here instead of "exit".
+#     # This script is included in another script by using "source". 
+#     # "exit" would end the main script, "return" just ends this sub script.
+#     return 0
+# fi 
 
 # Include operation system function to for example detect Windows.
 source "${SCRIPTS_DIR}/operatingSystemFunctions.sh"
@@ -60,18 +69,24 @@ echo "activateCondaEnvironment: scriptExtension=${scriptExtension}"
 eval "$(${pathToConda}conda${scriptExtension} shell.bash hook)"
 echo "activateCondaEnvironment: Current conda environment after shell hook=${CONDA_DEFAULT_ENV}"
 
-# Create (if missing) and activate Conda environment for code structure graph analysis
-if { "${pathToConda}conda" env list | grep "${CODEGRAPH_CONDA_ENVIRONMENT} "; } >/dev/null 2>&1; then
-    echo "activateCondaEnvironment: Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} already created"
-else
-    if [ ! -f "${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml" ] ; then
-        echo "activateCondaEnvironment: Couldn't find environment file ${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml."
-        exit 2
+# If missing, create Conda environment for code graph analysis
+# Note: The curly braces are grouping the outputs of both (piped) operations together to suppress them later (dev/null).
+if "${pathToConda}conda" env list | grep "${CODEGRAPH_CONDA_ENVIRONMENT} " >/dev/null 2>&1; then
+    echo "activateCondaEnvironment: Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} has already been created."
+    
+    # Check if the declaration in the environment file matches the actual environment to find out if it needs to be updated.
+    if "${pathToConda}conda" compare --name "${CODEGRAPH_CONDA_ENVIRONMENT}" "${CONDA_ENVIRONMENT_FILE}" >/dev/null 2>&1; then
+        echo "activateCondaEnvironment: Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} is up-to-date."
+    else
+        echo "activateCondaEnvironment: Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT} needs to be updated."
+        "${pathToConda}conda" env update --file "${CONDA_ENVIRONMENT_FILE}" --name ${CODEGRAPH_CONDA_ENVIRONMENT} --prune
     fi
-    echo "activateCondaEnvironment: Creating Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT}"
-    "${pathToConda}conda" env create --file "${JUPYTER_NOTEBOOK_DIRECTORY}/environment.yml" --name "${CODEGRAPH_CONDA_ENVIRONMENT}"
+else
+    echo "activateCondaEnvironment: Creating Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT}..."
+    "${pathToConda}conda" env create --file "${CONDA_ENVIRONMENT_FILE}" --name "${CODEGRAPH_CONDA_ENVIRONMENT}"
 fi
 
+# Activate code graph Conda environment
 echo "activateCondaEnvironment: Activating Conda environment ${CODEGRAPH_CONDA_ENVIRONMENT}"
 "${pathToConda}conda" activate ${CODEGRAPH_CONDA_ENVIRONMENT}
 

--- a/scripts/detectChangedFiles.sh
+++ b/scripts/detectChangedFiles.sh
@@ -86,21 +86,21 @@ else
 fi
 
 # Check if the paths parameter exist
-if [ -z "${paths}" ] ; then
-    echo 0 # 0=No change detected. The path list is empty. There is nothing to compare. Therefore assume that there are no changes.
-    exit_successful
-  fi
+if [ -z "${paths}" ]; then
+  echo 0 # 0=No change detected. The path list is empty. There is nothing to compare. Therefore assume that there are no changes.
+  exit_successful
+fi
 
 # Check all paths if they are valid files or valid directories
 for path in ${paths//,/ }; do
-    if [ -f "${path}" ] ; then
+    pathWithoutProtocolPrefix=${path/#*::/}
+    if [ -f "${pathWithoutProtocolPrefix}" ] ; then
       continue # Valid file
-    fi
-    if [ -d "${path}" ] ; then
+    elif [ -d "${pathWithoutProtocolPrefix}" ] ; then
       continue # Valid directory
     fi
     # Neither a valid directory and file
-    echo -e "${COLOR_ERROR}detectChangedFiles: Error: Invalid path: ${path}${COLOR_DEFAULT}" >&2
+    echo -e "${COLOR_ERROR}detectChangedFiles: Error: Invalid path: ${pathWithoutProtocolPrefix}${COLOR_DEFAULT}" >&2
     exit_failed
 done
 
@@ -166,7 +166,8 @@ get_md5_checksum_of_all_file_names_and_sizes() {
   local processed_paths=0
 
   for path in ${paths//,/ }; do
-      local files_and_their_size; files_and_their_size=$(file_names_and_sizes "${path}")
+      pathWithoutProtocolPrefix=${path/#*::/}
+      local files_and_their_size; files_and_their_size=$(file_names_and_sizes "${pathWithoutProtocolPrefix}")
       all_files_and_sizes="${all_files_and_sizes}${files_and_their_size}"
       processed_paths=$((processed_paths + 1))
       echo -ne "${COLOR_INFO}detectChangedFiles: Calculate checksum progress: ($processed_paths/$total_paths)\r${COLOR_DEFAULT}" >&2

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -45,11 +45,6 @@ if [[ -z ${downloadUrl} ]]; then
   exit 1
 fi
 
-if ! curl --head --fail ${downloadUrl} >/dev/null 2>&1; then
-  echo "download: Error: Invalid URL: ${downloadUrl}"
-  exit 1
-fi
-
 if [[ -z ${filename} ]]; then
   filename=$(basename -- "${downloadUrl}")
 fi
@@ -64,6 +59,14 @@ fi
 # Download the file if it doesn't exist in the shared downloads directory 
 if [ ! -f "${SHARED_DOWNLOADS_DIRECTORY}/${filename}" ] ; then
     echo "download: Downloading ${filename} from ${downloadUrl} into ${SHARED_DOWNLOADS_DIRECTORY}"
+
+    # Check if the URL is valid
+    # The check is deferred and not done in the input validation block at the beginning.
+    # This is because the check needs a network connection which shouldn't be required when the file had already been downloaded.
+    if ! curl --head --fail ${downloadUrl} >/dev/null 2>&1; then
+      echo "download: Error: Invalid URL: ${downloadUrl}"
+      exit 1
+    fi
 
     # Download the file
     if ! curl -L --fail-with-body -o "${SHARED_DOWNLOADS_DIRECTORY}/${filename}" "${downloadUrl}"; then

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Runs all test scripts (no Python and Chromium required).
+# It only considers scripts in the "scripts" directory.
+
+# Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
+set -o errexit -o pipefail
+
+# Overrideable Constants (defaults also defined in sub scripts)
+LOG_GROUP_START=${LOG_GROUP_START:-"::group::"} # Prefix to start a log group. Defaults to GitHub Actions log group start command.
+LOG_GROUP_END=${LOG_GROUP_END:-"::endgroup::"} # Prefix to end a log group. Defaults to GitHub Actions log group end command.
+
+## Get this "scripts" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+SCRIPTS_DIR=${SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )} # Repository directory containing the shell scripts
+echo "runTests: SCRIPTS_DIR=${SCRIPTS_DIR}" >&2
+
+# Run all report scripts
+for test_script_file in "${SCRIPTS_DIR}"/test*.sh; do
+    test_script_filename=$(basename -- "${test_script_file}");
+    test_script_filename="${test_script_filename%.*}" # Remove file extension
+
+    echo "${LOG_GROUP_START}Run ${test_script_filename}";
+    echo "runTests: $(date +'%Y-%m-%dT%H:%M:%S%z') Starting ${test_script_filename}...";
+
+    source "${test_script_file}"
+
+    echo "runTests: $(date +'%Y-%m-%dT%H:%M:%S%z') Finished ${test_script_filename}";
+    echo "${LOG_GROUP_END}";
+done

--- a/scripts/scanTypescript.sh
+++ b/scripts/scanTypescript.sh
@@ -115,14 +115,10 @@ is_valid_scan_result() {
 }
 
 is_change_detected() {
-    local COLOR_DARK_GREY='\033[0;30m'
-    local COLOR_DEFAULT='\033[0m'    
     local source_directory_name; source_directory_name=$(basename "${source_directory}");
 
-    echo -e "${COLOR_DARK_GREY}"
     changeDetectionHashFilePath="./${SOURCE_DIRECTORY}/typescriptScanChangeDetection-${source_directory_name}.sha"
     changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --readonly --hashfile "${changeDetectionHashFilePath}" --paths "${source_directory}")
-    echo -e "${COLOR_DEFAULT}"
     
     if [ "${changeDetectionReturnCode}" == "0" ] && [ "${TYPESCRIPT_SCAN_CHANGE_DETECTION}" = true ]; then
         true

--- a/scripts/testDetectChangedFiles.sh
+++ b/scripts/testDetectChangedFiles.sh
@@ -41,95 +41,92 @@ fail() {
 echo "testDetectChangedFiles: Starting tests...."
 
 # Create testing resources
-testCaseNumber=0
 temporaryTestDirectory=$(mktemp -d 2>/dev/null || mktemp -d -t 'temporaryTestDirectory')
 testHashFile="${temporaryTestDirectory}/testHashFile.sha"
 testFileForChangeDetection="${temporaryTestDirectory}/testFileForChangeDetection.txt"
 echo "Some Test Content" > "${testFileForChangeDetection}"
 
 # Test cases
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Create missing hashfile and report that as changed file."
+echo "testDetectChangedFiles: 1.) Create missing hashfile and report that as changed file."
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
 if [ "${changeDetectionReturnCode}" != "1" ]; then
-  fail "${testCaseNumber}.) Test failed: Expected return code 1 for non existing hash file (change detected), but got ${changeDetectionReturnCode}."
+  fail "1.) Test failed: Expected return code 1 for non existing hash file (change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged file when the hashfile contains the same value as the newly calculated one."
+echo "testDetectChangedFiles: 2.) Detect an unchanged file when the hashfile contains the same value as the newly calculated one."
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
 if [ "${changeDetectionReturnCode}" != "0" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+  fail "2.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile contains a different value as the current one."
+echo "testDetectChangedFiles: 3.) Detect a changed file when the hashfile contains a different value as the current one."
 echo "Some CHANGED Test Content" > "${testFileForChangeDetection}"
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
 if [ "${changeDetectionReturnCode}" != "2" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+  fail "3.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed directory when the hashfile contains a different value as the current one."
+echo "testDetectChangedFiles: 4.) Detect an unchanged file when the hashfile contains the same value as the current one again. Same as 2.) but different after 3.)."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" != "0" ]; then
+  fail "4.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+fi
+
+echo "testDetectChangedFiles: 5.) Detect a changed directory when the hashfile contains a different value as the current one."
 echo "Some CHANGED Test Directory Content" > "${testFileForChangeDetection}"
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${temporaryTestDirectory}")
 if [ "${changeDetectionReturnCode}" != "2" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+  fail "5.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged directory when the hashfile contains the same value as the newly calculated one."
+echo "testDetectChangedFiles: 6.) Detect an unchanged directory when the hashfile contains the same value as the newly calculated one."
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${temporaryTestDirectory}")
 if [ "${changeDetectionReturnCode}" != "0" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+  fail "6.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged file when the hashfile contains the same value as the current one again. Same as 2.) but different after 3.)."
-changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
-if [ "${changeDetectionReturnCode}" != "0" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
-fi
-
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile contains a different value as the current one in read-only mode."
+echo "testDetectChangedFiles: 7.) Detect a changed file when the hashfile contains a different value as the current one in read-only mode."
 echo "Some CHANGED AGAIN Test Content" > "${testFileForChangeDetection}"
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}" --readonly)
 if [ "${changeDetectionReturnCode}" != "2" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+  fail "7.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile hadn't been update with the last change detection in read-only mode."
+echo "testDetectChangedFiles: 8.) Detect a changed file when the hashfile hadn't been update with the last change detection in read-only mode."
 changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}" --readonly)
 if [ "${changeDetectionReturnCode}" != "2" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+  fail "8.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
 fi
 
-testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not existing first path"
+echo "testDetectChangedFiles: 9.) Fail on not existing first path"
 if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "./nonExistingFile.txt,${testFileForChangeDetection}"); then
-  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
+  fail "9.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
 fi
 
 testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not existing second path"
+echo "testDetectChangedFiles: 10.) Fail on not existing second path"
 if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection},./nonExistingFile2.txt"); then
-  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
+  fail "10.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
 fi
 
 testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Interpret missing paths as 'nothing changed'."
-changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths)
+echo "testDetectChangedFiles: 11.) Interpret missing paths as 'nothing changed'."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "")
 if [ "${changeDetectionReturnCode}" != "0" ]; then
-  fail "${testCaseNumber}.) Tests failed: Expected return code 0 if there are no files to check, but got ${changeDetectionReturnCode}."
+  fail "11.) Tests failed: Expected return code 0 if there are no paths to check, but got ${changeDetectionReturnCode}."
 fi
 
 testCaseNumber=$((testCaseNumber + 1))
-echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not unknown command-line option"
+echo "testDetectChangedFiles: 12.) Fail on not unknown command-line option"
 if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "./nonExistingFile.txt,${testFileForChangeDetection}" --unknown); then
-  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a an unknown command-line option, but got ${changeDetectionReturnCode}."
+  fail "12.) Tests failed: Expected to fail due to a an unknown command-line option, but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: 13.) Ignore protocol prefix in file path like 'typescript:project::./myfile.txt'."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "typescript:project::${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" = "0" ]; then
+  fail "13.) Tests failed: Expected return code 0 if nothing changed with a protocol prefixed file, but got ${changeDetectionReturnCode}."
 fi
 
 successful

--- a/scripts/testDetectChangedFiles.sh
+++ b/scripts/testDetectChangedFiles.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# Tests "detectChangedFiles.sh".
+
+# Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
+set -o errexit -o pipefail
+
+## Get this "scripts" directory if not already set
+# Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 
+# CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
+# This way non-standard tools like readlink aren't needed.
+SCRIPTS_DIR=${SCRIPTS_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )} # Repository directory containing the shell scripts
+echo "testDetectChangedFiles: SCRIPTS_DIR=${SCRIPTS_DIR}" >&2
+
+tearDown() {
+  # echo "testDetectChangedFiles: Tear down tests...."
+  rm -rf "${temporaryTestDirectory}"
+}
+
+successful() {
+  local COLOR_SUCCESSFUL="\033[0;32m" # green 
+  local COLOR_DEFAULT='\033[0m'
+
+  echo -e "testDetectChangedFiles: ${COLOR_SUCCESSFUL}Tests finished successfully.${COLOR_DEFAULT}"
+
+  tearDown
+  exit 0
+}
+
+fail() {
+  local COLOR_ERROR='\033[0;31m' # red
+  local COLOR_DEFAULT='\033[0m'
+
+  local errorMessage="${1}"
+
+  echo -e "testDetectChangedFiles: ${COLOR_ERROR}${errorMessage}${COLOR_DEFAULT}"
+  tearDown
+  exit 1
+}
+
+echo "testDetectChangedFiles: Starting tests...."
+
+# Create testing resources
+testCaseNumber=0
+temporaryTestDirectory=$(mktemp -d 2>/dev/null || mktemp -d -t 'temporaryTestDirectory')
+testHashFile="${temporaryTestDirectory}/testHashFile.sha"
+testFileForChangeDetection="${temporaryTestDirectory}/testFileForChangeDetection.txt"
+echo "Some Test Content" > "${testFileForChangeDetection}"
+
+# Test cases
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Create missing hashfile and report that as changed file."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" != "1" ]; then
+  fail "${testCaseNumber}.) Test failed: Expected return code 1 for non existing hash file (change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged file when the hashfile contains the same value as the newly calculated one."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" != "0" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile contains a different value as the current one."
+echo "Some CHANGED Test Content" > "${testFileForChangeDetection}"
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" != "2" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed directory when the hashfile contains a different value as the current one."
+echo "Some CHANGED Test Directory Content" > "${testFileForChangeDetection}"
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${temporaryTestDirectory}")
+if [ "${changeDetectionReturnCode}" != "2" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged directory when the hashfile contains the same value as the newly calculated one."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${temporaryTestDirectory}")
+if [ "${changeDetectionReturnCode}" != "0" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect an unchanged file when the hashfile contains the same value as the current one again. Same as 2.) but different after 3.)."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}")
+if [ "${changeDetectionReturnCode}" != "0" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 0 for an existing hash file with matching value (no change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile contains a different value as the current one in read-only mode."
+echo "Some CHANGED AGAIN Test Content" > "${testFileForChangeDetection}"
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}" --readonly)
+if [ "${changeDetectionReturnCode}" != "2" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Detect a changed file when the hashfile hadn't been update with the last change detection in read-only mode."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection}" --readonly)
+if [ "${changeDetectionReturnCode}" != "2" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 2 for an existing hash file with differing value (change detected), but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not existing first path"
+if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "./nonExistingFile.txt,${testFileForChangeDetection}"); then
+  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not existing second path"
+if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "${testFileForChangeDetection},./nonExistingFile2.txt"); then
+  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a wrong paths option, but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Interpret missing paths as 'nothing changed'."
+changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths)
+if [ "${changeDetectionReturnCode}" != "0" ]; then
+  fail "${testCaseNumber}.) Tests failed: Expected return code 0 if there are no files to check, but got ${changeDetectionReturnCode}."
+fi
+
+testCaseNumber=$((testCaseNumber + 1))
+echo "testDetectChangedFiles: ${testCaseNumber}.) Fail on not unknown command-line option"
+if changeDetectionReturnCode=$( source "${SCRIPTS_DIR}/detectChangedFiles.sh" --hashfile "${testHashFile}" --paths "./nonExistingFile.txt,${testFileForChangeDetection}" --unknown); then
+  fail "${testCaseNumber}.) Tests failed: Expected to fail due to a an unknown command-line option, but got ${changeDetectionReturnCode}."
+fi
+
+successful


### PR DESCRIPTION
### 🚀 Feature

- [Update conda environment if its outdated compared to the `environment.yml`](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/7f5b2811963b94631d7bb4ef4da57bad98a8f0d4): Previously, Jupyter notebooks failed to import libraries that had been added lately. An already existing Conda environment "codegraph" was sufficient, even it was outdated. Now, it will automatically be updated if necessary so that there are no more import errors. 

- [Add PREPARE_CONDA_ENVIRONMENT to skip Conda environment setup](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/f13df113a691b55168dbc02cf5b94d5d838b688e): Previously, Conda environment activation was skipped when the `codegraph` environment was already active. Now, `PREPARE_CONDA_ENVIRONMENT="false` needs to be set additionally to explicitly skip that part. This is needed in GitHub Action pipelines because `conda init` doesn't work as expected but is taken care of by [setup-miniconda](https://github.com/marketplace/actions/setup-miniconda#important).

- [Introduce script testing](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/7b735b0abfa037e090580ca5e5cfc80835b80e16): The first (for now framework-free) script test is implemented in the pipeline 🎉.

### ⚙️ Optimization

- [Improve change file detection](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/41260dfb02dc6ed7f4f3ff88ff463330b809efd3)): 
  - Log output is now colored (red = error, dark grey = info)
  - Given `--paths` are now validated
  - File statistics are now correctly extracted for MacOS and Linux

### 🛠 Fix

- [Defer download URL check for offline mode](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/a1d141fee5398fd32c57a453c39aa78f40b63d2c): Previously, it was not possible to get an artifact from the download script in offline mode, even if it had already been downloaded and ready to use in the cache. This is now resolved by deferring the check of the URL until right before the actual download, since it needs an internet connection.
- [Fix wrong variable for Jupyter notebook directory](https://github.com/JohT/code-graph-analysis-pipeline/pull/353/commits/59571c42f9b7c2f9bbb67554a08c1643deb56bb4): Conda environment creation still used an old variable from another file that kept working since these files are called consecutively. However, can break easily and is now resolved.