### PR TITLE
Revert GH-356 to migrate back to Java 17.

### DIFF
--- a/.github/workflows/public-analyze-code-graph.yml
+++ b/.github/workflows/public-analyze-code-graph.yml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         include:
         - os: ubuntu-22.04
-          java: 21
+          java: 17
           python: 3.12
           miniforge: 24.9.0-0
     steps:

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -78,7 +78,7 @@ a profile, the newest versions will be used. Other profiles can be found in the 
 
 ### Notes
 
-- Be sure to use Java 21 for Neo4j v5 and Java 11 for Neo4j v4
+- Be sure to use Java 17 for Neo4j v5 and Java 11 for Neo4j v4
 - Use your own initial Neo4j password
 - For more details have a look at the script [analyze.sh](./scripts/analysis/analyze.sh)
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Contained within this repository is a comprehensive and automated code graph ana
 - Example analysis for [AxonFramework](https://github.com/AxonFramework/AxonFramework)
 - Example analysis for [react-router](https://github.com/remix-run/react-router)
 
-### :newspaper: News
-
-- April 2025: Migrated to Java 21 in preparation for [Neo4j 2025.x](https://neo4j.com/docs/upgrade-migration-guide/current/version-2025/upgrade).
-
 ### :notebook: Jupyter Notebook Reports
 
 Here is an overview of [Jupyter Notebooks](https://jupyter.org) reports from [code-graph-analysis-examples](https://github.com/JohT/code-graph-analysis-examples). For a complete list, see the [Jupyter Notebook Report Reference](#page_with_curl-jupyter-notebook-report-reference).
@@ -70,7 +66,7 @@ Here are some fully automated graph visualizations utilizing [GraphViz](https://
 
 ## :hammer_and_wrench: Prerequisites
 
-- Java 21 is [required for Neo4j 2025.x](https://neo4j.com/docs/operations-manual/current/installation/requirements/#deployment-requirements-software). See also [Changes from Neo4j 5 to 2025.x](https://neo4j.com/docs/upgrade-migration-guide/current/version-2025/upgrade).
+- Java 17 is [required for Neo4j](https://neo4j.com/docs/operations-manual/current/installation/requirements/#deployment-requirements-software) (Neo4j 5.x requirement).
 - On Windows it is recommended to use the git bash provided by [git for windows](https://github.com/git-guides/install-git#install-git-on-windows).
 - [jq](https://github.com/jqlang/jq) the "lightweight and flexible command-line JSON processor" needs to be installed. Latest releases: https://github.com/jqlang/jq/releases/latest. Check using `jq --version`.
 - Set environment variable `NEO4J_INITIAL_PASSWORD` to a password of your choice. For example:


### PR DESCRIPTION
### 🛠 Fix

- [Revert](https://github.com/JohT/code-graph-analysis-pipeline/pull/370/commits/01f6945b11579a764e0993b19311dccbc72d34c2) https://github.com/JohT/code-graph-analysis-pipeline/pull/356 [to migrate back to Java 17.](https://github.com/JohT/code-graph-analysis-pipeline/pull/370/commits/01f6945b11579a764e0993b19311dccbc72d34c2): This enables to do a fix without introducing back-porting. Reverted commit: 3e691affac1