### PR TITLE
Add Hierarchical Density-Based Spatial Clustering (HDBSCAN) Community Detection

### DIFF
--- a/.github/workflows/internal-java-code-analysis.yml
+++ b/.github/workflows/internal-java-code-analysis.yml
@@ -120,3 +120,4 @@ jobs:
       analysis-name: ${{ needs.prepare-code-to-analyze.outputs.analysis-name }}
       artifacts-upload-name: ${{ needs.prepare-code-to-analyze.outputs.artifacts-upload-name }}
       sources-upload-name: ${{ needs.prepare-code-to-analyze.outputs.sources-upload-name }}
+      jupyter-pdf: "false"

--- a/.github/workflows/internal-typescript-code-analysis.yml
+++ b/.github/workflows/internal-typescript-code-analysis.yml
@@ -118,3 +118,4 @@ jobs:
     with:
       analysis-name: ${{ needs.prepare-code-to-analyze.outputs.analysis-name }}
       sources-upload-name: ${{ needs.prepare-code-to-analyze.outputs.sources-upload-name }}
+      jupyter-pdf: "false"

--- a/.github/workflows/public-analyze-code-graph.yml
+++ b/.github/workflows/public-analyze-code-graph.yml
@@ -55,6 +55,12 @@ on:
         required: false
         type: number
         default: 5
+      jupyter-pdf:
+        description: >
+          Enable PDF generation for Jupyter Notebooks ("true") or disable it ("false").
+        required: false
+        type: string
+        default: 'true'
     outputs:
       uploaded-analysis-results:
         description: >
@@ -159,7 +165,7 @@ jobs:
         shell: bash -el {0}
         env:
           NEO4J_INITIAL_PASSWORD: ${{ steps.generate-neo4j-initial-password.outputs.neo4j-initial-password }}
-          ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION: "true"
+          ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION: ${{ inputs.jupyter-pdf }}
           IMPORT_GIT_LOG_DATA_IF_SOURCE_IS_PRESENT: "" # Options: "none", "aggregated", "full". default = "plugin" or ""
           PREPARE_CONDA_ENVIRONMENT: "false" # Had already been done in step with id "prepare-conda-environment".
         run: |

--- a/cypher/Community_Detection/Community_Detection_11a_HDBSCAN_Estimate.cypher
+++ b/cypher/Community_Detection/Community_Detection_11a_HDBSCAN_Estimate.cypher
@@ -1,0 +1,26 @@
+// Community Detection: Hierarchical Density-Based Spatial Clustering (HDBSCAN) - Estimate
+
+CALL gds.hdbscan.write.estimate(
+ $dependencies_projection + '-cleaned', {
+    nodeProperty: $dependencies_projection_node_embeddings_property,
+    writeProperty: $dependencies_projection_write_property,
+    samples: 3
+})
+ YIELD requiredMemory
+      ,nodeCount
+      ,relationshipCount
+      ,bytesMin
+      ,bytesMax
+      ,heapPercentageMin
+      ,heapPercentageMax
+      ,treeView
+      ,mapView
+RETURN requiredMemory
+      ,nodeCount
+      ,relationshipCount
+      ,bytesMin
+      ,bytesMax
+      ,heapPercentageMin
+      ,heapPercentageMax
+      ,treeView
+      //,mapView //doesn't work on Windows with git bash jq version jq-1.7-dirty

--- a/cypher/Community_Detection/Community_Detection_11b_HDBSCAN_Statistics.cypher
+++ b/cypher/Community_Detection/Community_Detection_11b_HDBSCAN_Statistics.cypher
@@ -1,0 +1,9 @@
+// Community Detection: Hierarchical Density-Based Spatial Clustering (HDBSCAN) - Statistics
+
+CALL gds.hdbscan.stats(
+ $dependencies_projection + '-cleaned', {
+    nodeProperty: $dependencies_projection_node_embeddings_property,
+    samples: 3
+})
+ YIELD nodeCount, numberOfClusters, numberOfNoisePoints, preProcessingMillis, computeMillis, postProcessingMillis
+RETURN nodeCount, numberOfClusters, numberOfNoisePoints, preProcessingMillis, computeMillis, postProcessingMillis

--- a/cypher/Community_Detection/Community_Detection_11c_HDBSCAN_Mutate.cypher
+++ b/cypher/Community_Detection/Community_Detection_11c_HDBSCAN_Mutate.cypher
@@ -1,0 +1,10 @@
+// Community Detection: Hierarchical Density-Based Spatial Clustering (HDBSCAN) - Mutate
+
+CALL gds.hdbscan.mutate(
+ $dependencies_projection + '-cleaned', {
+    nodeProperty: $dependencies_projection_node_embeddings_property,
+    mutateProperty: $dependencies_projection_write_property,
+    samples: 3
+})
+ YIELD nodeCount, numberOfClusters, numberOfNoisePoints, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, mutateMillis
+RETURN nodeCount, numberOfClusters, numberOfNoisePoints, nodePropertiesWritten, preProcessingMillis, computeMillis, postProcessingMillis, mutateMillis

--- a/cypher/Community_Detection/Community_Detection_11d_HDBSCAN_Stream.cypher
+++ b/cypher/Community_Detection/Community_Detection_11d_HDBSCAN_Stream.cypher
@@ -1,0 +1,20 @@
+// Community Detection: Hierarchical Density-Based Spatial Clustering (HDBSCAN) - Stream
+
+CALL gds.hdbscan.stream(
+ $dependencies_projection + '-cleaned', {
+    nodeProperty: $dependencies_projection_node_embeddings_property,
+    samples: 3
+})
+ YIELD nodeId, label
+  WITH gds.util.asNode(nodeId) AS member
+      ,label
+  WITH member
+      ,coalesce(member.fqn, member.fileName, member.name) AS memberName
+      ,label
+  WITH count(DISTINCT member)       AS memberCount
+      ,collect(DISTINCT memberName) AS memberNames
+      ,label
+RETURN memberCount
+      ,label
+      ,memberNames
+ ORDER BY memberCount DESC, label ASC

--- a/cypher/Community_Detection/Community_Detection_11e_HDBSCAN_Write.cypher
+++ b/cypher/Community_Detection/Community_Detection_11e_HDBSCAN_Write.cypher
@@ -1,0 +1,25 @@
+// Community Detection: Hierarchical Density-Based Spatial Clustering (HDBSCAN) -  write node property e.g. communityHdbscanLabel
+
+CALL gds.hdbscan.write(
+ $dependencies_projection + '-cleaned', {
+    nodeProperty: $dependencies_projection_node_embeddings_property,
+    writeProperty: $dependencies_projection_write_property,
+    samples: 3
+})
+// Samples = 3 turned out to be needed for 
+YIELD nodeCount
+     ,numberOfClusters
+     ,numberOfNoisePoints
+     ,preProcessingMillis
+     ,computeMillis
+     ,writeMillis
+     ,postProcessingMillis
+     ,nodePropertiesWritten
+RETURN nodeCount
+      ,numberOfClusters
+      ,numberOfNoisePoints
+      ,preProcessingMillis
+      ,computeMillis
+      ,writeMillis
+      ,postProcessingMillis
+      ,nodePropertiesWritten

--- a/scripts/executeJupyterNotebook.sh
+++ b/scripts/executeJupyterNotebook.sh
@@ -20,7 +20,10 @@
 # Fail on any error ("-e" = exit on first error, "-o pipefail" exist on errors within piped commands)
 set -o errexit -o pipefail
 
-ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION=${ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION:-""} # Enable PDF generation for Jupyter Notebooks if set to any non empty value e.g. "true"
+ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION=${ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION:-""} # Enable PDF generation for Jupyter Notebooks if set to any non empty value like "true" or disable it with "" or "false".
+if [ "${ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION}" == "false" ]; then
+    ENABLE_JUPYTER_NOTEBOOK_PDF_GENERATION="" # Reset PDF generation if explicitly set to false
+fi
 
 ## Get this "scripts" directory if not already set
 # Even if $BASH_SOURCE is made for Bourne-like shells it is also supported by others and therefore here the preferred solution. 

--- a/scripts/reports/compilations/CsvReports.sh
+++ b/scripts/reports/compilations/CsvReports.sh
@@ -17,8 +17,6 @@ LOG_GROUP_END=${LOG_GROUP_END:-"::endgroup::"} # Prefix to end a log group. Defa
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
-echo "CsvReports: REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR}"
-
 REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$(dirname -- "${REPORT_COMPILATIONS_SCRIPT_DIR}")}
 echo "CsvReports: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
 

--- a/scripts/reports/compilations/JupyterReports.sh
+++ b/scripts/reports/compilations/JupyterReports.sh
@@ -20,18 +20,18 @@ LOG_GROUP_END=${LOG_GROUP_END:-"::endgroup::"} # Prefix to end a log group. Defa
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
-echo "JupyterReports: REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR}"
-
 REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$(dirname -- "${REPORT_COMPILATIONS_SCRIPT_DIR}")}
-echo "JupyterReports: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
-
 # Get the "scripts" directory by taking the scripts report path and going one directory up.
 SCRIPTS_DIR=${SCRIPTS_DIR:-$(dirname -- "${REPORTS_SCRIPT_DIR}")}
-echo "JupyterReports: SCRIPTS_DIR=${SCRIPTS_DIR}"
-
 # Get the "jupyter" directory by taking the path of the scripts directory, going up one directory and change then into "jupyter".
 JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY:-"${SCRIPTS_DIR}/../jupyter"} # Repository directory containing the Jupyter Notebooks
+
+echo "${LOG_GROUP_START}Initialize Jupyter Notebook Reports";
+echo "JupyterReports: REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR}"
+echo "JupyterReports: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+echo "JupyterReports: SCRIPTS_DIR=${SCRIPTS_DIR}"
 echo "JupyterReports: JUPYTER_NOTEBOOK_DIRECTORY=${JUPYTER_NOTEBOOK_DIRECTORY}"
+echo "${LOG_GROUP_END}";
 
 # Run all jupiter notebooks
 for jupyter_notebook_file in "${JUPYTER_NOTEBOOK_DIRECTORY}"/*.ipynb; do 

--- a/scripts/reports/compilations/VisualizationReports.sh
+++ b/scripts/reports/compilations/VisualizationReports.sh
@@ -20,10 +20,12 @@ LOG_GROUP_END=${LOG_GROUP_END:-"::endgroup::"} # Prefix to end a log group. Defa
 # CDPATH reduces the scope of the cd command to potentially prevent unintended directory changes.
 # This way non-standard tools like readlink aren't needed.
 REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
-echo "VisualizationReports: REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR}"
-
 REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR:-$(dirname -- "${REPORT_COMPILATIONS_SCRIPT_DIR}")}
+
+echo "${LOG_GROUP_START}Initialize Visualization Reports";
+echo "VisualizationReports: REPORT_COMPILATIONS_SCRIPT_DIR=${REPORT_COMPILATIONS_SCRIPT_DIR}"
 echo "VisualizationReports: REPORTS_SCRIPT_DIR=${REPORTS_SCRIPT_DIR}"
+echo "${LOG_GROUP_END}";
 
 # Run all visualization scripts
 for visualization_script_file in "${REPORTS_SCRIPT_DIR}"/*Visualization.sh; do 


### PR DESCRIPTION
### 🚀 Feature

- [Add Hierarchical Density-Based Spatial Clustering (HDBSCAN) Community Detection](https://github.com/JohT/code-graph-analysis-pipeline/pull/376/commits/37d60ad34196c8d3fa0c7e8bdcb7741315dc4675): This is just a basic and simplified example for clustering and might not provide useable data. It is meant to try out [Neo4j Graph Data Science's version of HDBSCAN](https://neo4j.com/docs/graph-data-science/2.18/algorithms/hdbscan).

### ⚙️ Optimization

- [Put initialization logs in compilations into own log group](https://github.com/JohT/code-graph-analysis-pipeline/pull/376/commits/005eca97e2dfc5d18c45321fc9b6e9e813228ed7): With this, the log output on GitHub is even more readable since the initialization is now also collapsed into a group and makes it easier to spot the main groups.
- [Add PDF generation to pipeline parameters](https://github.com/JohT/code-graph-analysis-pipeline/pull/376/commits/5c68339e4f7f64b7ed53db60ab4e7d5b175094ac)

### 🛠 Fix

- [Switch off PDF generation in the local pipeline temporarily](https://github.com/JohT/code-graph-analysis-pipeline/pull/376/commits/88128224352db2e21bebd2a093cefcaa4dc5cda9): To overcome pipeline fails due to chrome browser download and a timeout when generating the PDFs, PDF generation is temporarily deactivated for the internal pipeline.