### PR TITLE
Make markdown summaries LLM context friendly

### DIFF
--- a/domains/anomaly-detection/summary/report.template.md
+++ b/domains/anomaly-detection/summary/report.template.md
@@ -38,85 +38,81 @@ Each abstraction level includes anomaly statistics, SHAP feature importance, arc
 
 ## 3. Plot Interpretation Guide
 
-> **Purpose:** Understand each plot type’s diagnostic value.  
 > **Applies to:** All abstraction levels.
 
-| Plot Type | Best For | Adds | Why It Matters |
-| --- | --- | --- | --- |
-| **Anomalies Plot** | Seeing distribution of anomalies in clusters | Context of clusters & outliers | Reveals isolation or cluster-based anomalies |
-| **SHAP Summary** | Global feature importance | Feature impact direction | Shows what drives anomalies overall |
-| **Local SHAP Force** | Explaining a single anomaly | Feature contribution breakdown | Useful for debugging individual outliers |
-| **Dependence Plot** | Understanding feature influence | Interaction visualization | Reveals nonlinear feature effects |
-| **Cluster Metrics** | Cluster characteristics | Radius, cohesion, noise | Identifies weakly defined or noisy clusters |
+| Plot | Purpose |
+|------|----------|
+| **Anomalies Plot** | 2D visualization showing clusters & anomalies. Guides investigation. |
+| **SHAP Summary** | Global feature importance ranked by impact magnitude & direction. |
+| **Local SHAP Force** | Per-sample feature contributions. Explains individual anomalies. |
+| **Dependence Plot** | Feature–anomaly relationships revealing nonlinear effects. |
+| **Cluster Metrics** | Cluster cohesion, size, noise; identifies weak groupings. |
 
-## 3. Plot Interpretation Guide
-
-> **Purpose:** Provide a direct mapping between all plots and their analytical meaning.  
-> **Scope:** Applies to plots for *Java Type*, *Java Package*, and similar abstraction levels.  
-> **Format:** Each entry includes `Best for`, `Adds`, and `Why`, matching the in-report descriptions.
+> **Scope:** Applies to plots for *Java Type*, *Java Package*, and similar abstraction levels.
 
 ---
 
 ### 📘 Main Plots
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Anomalies** | 2D visualization of all code units showing clusters and anomalies. | Understanding the overall distribution of anomalies in relation to clusters. | Context of clusters and outliers. | Reveals whether anomalies are isolated or cluster-based, guiding investigation. |
-| **Global Feature Importance (SHAP Summary)** | Mean absolute SHAP values ranking global feature impact. | Global understanding of which features drive anomalies. | Direction of impact (color shows feature value). | Explains which metrics consistently influence anomaly detection. |
-| **Feature Dependence (Top Important Features)** | Shows how specific feature values affect anomaly score; colored by interacting feature. | Understanding how one feature affects anomaly scores. | Color shows feature interaction or threshold effect. | Helps identify nonlinear relationships and feature interactions. |
+| Plot | Purpose |
+|------|----------|
+| **Anomalies** | 2D visualization of all code units showing clusters and anomalies. Reveals isolated vs cluster-based anomalies. |
+| **Global Feature Importance (SHAP Summary)** | Mean absolute SHAP values ranking global feature impact. Shows what drives anomalies consistently. |
+| **Feature Dependence (Top Important Features)** | Shows how specific feature values affect anomaly score. Identifies nonlinear relationships & interactions. |
 
 ---
 
 ### 📙 Local Explanation Plots
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Local SHAP Force Plots (Top Anomalies 1–6)** | Visualizes per-feature contributions to each anomaly’s score relative to baseline. | Explaining *why a specific data point* is anomalous. | Visual breakdown of how each feature contributes to anomaly score. | Enables debugging of individual anomalies through transparent explanation. |
+| Plot | Purpose |
+|------|----------|
+| **Local SHAP Force Plots (Top Anomalies 1–6)** | Per-feature contributions to each anomaly's score relative to baseline. Enables case-by-case debugging. |
 
 ---
 
 ### 📗 Cluster-Level Diagnostic Plots
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Clusters – Overall** | Shows all clusters since they all fit into one plot. | Gaining a holistic view of cluster characteristics in the dataset. | An overall summary of how all clusters are distributed and their key metrics. | Understanding the general structure and properties of clusters can help identify patterns and potential anomalies in the data. |
-| **Clusters – Largest Average Radius** | Ranks clusters by mean distance of members from their centroid. | Getting an overview of clusters that are more dispersed. | Identifies clusters with internal variability. | Large average radius suggests less cohesion and potential outliers. |
-| **Clusters – Largest Max Radius** | Shows clusters with the farthest outlying member. | Identifying clusters that have members farthest from cluster center. | Highlights clusters containing extreme outliers. | Indicates clusters that may contain hidden anomalies. |
-| **Clusters – Largest Size** | Displays cluster membership counts. | Understanding which clusters contain the most code units. | Provides sense of frequency of code structures. | Large clusters may represent common design patterns; small clusters are specialized. |
-| **Cluster Probabilities** | Distribution of HDBSCAN membership probabilities. | Detecting code units that don’t strongly belong to any cluster. | Measures how well-defined clusters are. | Highlights noisy or weakly defined clusters. |
+| Plot | Purpose |
+|------|----------|
+| **Clusters – Overall** | All clusters in one view. Holistic summary of distribution & key metrics. |
+| **Clusters – Largest Radius (Avg)** | Ranks by mean member distance from centroid. Identifies dispersed clusters. |
+| **Clusters – Largest Radius (Max)** | Shows farthest outlying member per cluster. Highlights extreme members. |
+| **Clusters – Largest Size** | Membership counts per cluster. Reveals common design patterns vs. specialized groups. |
+| **Cluster Probabilities** | HDBSCAN membership strength distribution. Detects weakly-defined or noisy clusters. |
+
 
 ---
 
 ### 📒 Cluster Noise & Bridge Diagnostics
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Cluster Noise – Highly Central and Popular** | Central nodes that don’t fit any cluster. | Detecting code units that are highly connected but anomalous. | Reveals influential but misfit nodes. | Such nodes may be key but unstable integration points. |
-| **Cluster Noise – Poorly Integrated Bridges** | Nodes connecting clusters but weakly integrated. | Detecting code units that bridge modules unusually. | Identifies cross-cutting or leaking dependencies. | May reveal architectural boundary violations. |
-| **Cluster Noise – Role Inverted Bridges** | Bridges with reversed structural roles compared to expected topology. | Detecting code units connecting clusters in unexpected ways. | Highlights anomalous coupling roles. | Indicates architectural inversion or misuse of interfaces. |
+| Plot | Purpose |
+|------|----------|
+| **Cluster Noise – Highly Central and Popular** | Central nodes that don't fit any cluster. May be key but unstable integration points. |
+| **Cluster Noise – Poorly Integrated Bridges** | Nodes connecting clusters but weakly integrated. May reveal boundary violations. |
+| **Cluster Noise – Role Inverted Bridges** | Bridges with reversed structural roles. Indicates architectural inversion. |
 
 ---
 
 ### 📙 Feature Distribution & Relationship Plots
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Betweenness Centrality Distribution** | Histogram of betweenness values. | Identifying code units that act as structural bridges. | Insight into flow of dependency control. | Detects potential bottlenecks or single points of failure. |
-| **Clustering Coefficient Distribution** | Histogram of local clustering coefficients. | Identifying modularity and local cohesion. | Insight into how tightly code units cluster. | Reveals how cohesive or isolated different regions of the graph are. |
-| **PageRank – ArticleRank Difference Distribution** | Distribution of `PageRank - ArticleRank`. | Identifying influential nodes beyond local connectivity. | Shows imbalance between influence and popularity. | Highlights components with disproportionate architectural impact. |
-| **Clustering Coefficient vs PageRank** | Scatterplot comparing local clustering to global influence. | Identifying relationships between cohesion and centrality. | Visualizes trade-offs between modularity and reach. | Helps spot code units that are both locally and globally critical. |
+| Plot | Purpose |
+|------|----------|
+| **Betweenness Centrality Distribution** | Histogram of betweenness values. Detects bottlenecks & single points of failure. |
+| **Clustering Coefficient Distribution** | Histogram of local clustering coefficients. Reveals cohesion in different graph regions. |
+| **PageRank – ArticleRank Difference Distribution** | Distribution of influence vs popularity. Highlights disproportionate architectural impact. |
+| **Clustering Coefficient vs PageRank** | Scatterplot: local vs global influence trade-offs. Finds units both locally & globally critical. |
 
 ---
 
 ### 📕 Graph Visualizations (Archetype-Level Network Views)
 
-| Plot | Description | Best For | Adds | Why |
-|------|--------------|----------|------|-----|
-| **Top Hub Graph Visualization** | Displays the most connected node (e.g., **#1 Hub**) at the center, surrounded by its direct dependencies. Incoming nodes show who is dependent on the hub. | Understanding highly connected code units or components that serve as central integrators. | Highlights nodes that act as major dependency aggregators. | Helps detect over-centralized modules or potential architectural bottlenecks. |
-| **Top Bottleneck Graph Visualization** | Shows the node with the highest betweenness centrality (e.g., **#1 Bottleneck**) and its local neighborhood. | Identifying code units that control information or dependency flow. | Emphasizes nodes that mediate critical paths between modules. | Reveals single points of failure or routing constraints in dependency flow. |
-| **Top Authority Graph Visualization** | Centers the most authoritative node (e.g., **#1 Authority**) with incoming and outgoing links from dependent nodes with high PageRank and emphasized PageRank to ArticleRank difference. | Detecting key knowledge or functionality providers. | Highlights components with high centrality. | Indicates structural or semantic “sources of truth” in the system. |
-| **Top Bridge Graph Visualization** | Displays a node acting as a structural bridge between clusters (e.g., **#1 Bridge**) and its cross-cluster connections based on node embeddings encoding the Graph structure. | Understanding cross-cutting dependencies between modules. | Reveals links connecting distinct architectural domains. | Useful for spotting boundary leaks or undesired coupling between subsystems. |
-| **Top Outlier Graph Visualization** | Centers an unusual or isolated node (e.g., **#1 Outlier**) that can hardly be assigned to a cluster and visualizes its sparse or unexpected dependency patterns. | Identifying structurally or behaviorally anomalous nodes. | Highlights nodes with rare or unexpected connection patterns. | Helps pinpoint code units that deviate from established dependency norms. |
+| Plot | Purpose |
+|------|----------|
+| **Top Hub** | Most-connected node with dependencies. Detects over-centralization & bottlenecks. |
+| **Top Bottleneck** | Highest betweenness: controls information flow. Reveals single points of failure. |
+| **Top Authority** | Most authoritative (high PageRank). Indicates "sources of truth" in system. |
+| **Top Bridge** | Cross-cluster connector. Identifies boundary leaks & undesired coupling. |
+| **Top Outlier** | Anomalous isolated node. Highlights deviations from dependency norms. |
 
 > **Note:**
 > - In all Graph Visualizations, the **central node** represents the selected *Top Archetype* (e.g., *Top 1 Hub*).  
@@ -155,50 +151,6 @@ Each abstraction level includes anomaly statistics, SHAP feature importance, arc
 
 ---
 
-### 📄 Structured Form (YAML Summary)
-
-You can include this in your appendix for machine-readable mapping:
-
-```yaml
-plots:
-  main:
-    - name: Anomalies
-      purpose: Distribution of anomalies and clusters
-    - name: Global Feature Importance (SHAP)
-      purpose: Global feature ranking
-    - name: Feature Dependence
-      purpose: Feature–score relationship
-  local:
-    - name: Local SHAP Force Plots
-      purpose: Local explanations for top anomalies
-  cluster:
-    - name: Clusters Largest Average Radius
-      purpose: Identify dispersed clusters
-    - name: Clusters Largest Max Radius
-      purpose: Identify extreme outlier clusters
-    - name: Clusters Largest Size
-      purpose: Identify dominant cluster types
-    - name: Cluster Probabilities
-      purpose: Assess cluster definition strength
-  cluster_noise:
-    - name: Cluster Noise – Highly Central and Popular
-      purpose: Central anomalies without cluster fit
-    - name: Cluster Noise – Poorly Integrated Bridges
-      purpose: Weakly integrated bridges
-    - name: Cluster Noise – Role Inverted Bridges
-      purpose: Inverted bridge roles
-  feature_distributions:
-    - name: Betweenness Centrality Distribution
-      purpose: Bridge and bottleneck detection
-    - name: Clustering Coefficient Distribution
-      purpose: Cohesion and modularity measurement
-    - name: PageRank – ArticleRank Difference Distribution
-      purpose: Influence vs popularity analysis
-  feature_relationships:
-    - name: Clustering Coefficient vs PageRank
-      purpose: Local vs global influence comparison
-```
-
 ## 4. Taxonomy of Anomaly Archetypes
 
 | Archetype | Feature Profile | Architectural Risk |
@@ -208,27 +160,6 @@ plots:
 | **Outlier** | High cluster distance, small cluster size | Misfit or irregular dependency pattern |
 | **Authority** | High PageRank, low ArticleRank | Over-relied utility; low local stability |
 | **Bridge** | Cross-cluster connection | Risky coupling; weak modular boundaries |
-
-**Structured form (for LLM parsing):**
-
-```yaml
-archetypes:
-  - name: Hub
-    profile: High degree, low clustering coefficient
-    risk: Central dependency, fragile hotspot
-  - name: Bottleneck
-    profile: High betweenness, low redundancy
-    risk: Single point of failure
-  - name: Outlier
-    profile: High cluster distance, small cluster size
-    risk: Misfit component
-  - name: Authority
-    profile: High PageRank, low ArticleRank
-    risk: Over-relied utility
-  - name: Bridge
-    profile: Cross-cluster connector
-    risk: Risky coupling
-```
 
 ---
 

--- a/domains/anomaly-detection/summary/report_deep_dive.template.md
+++ b/domains/anomaly-detection/summary/report_deep_dive.template.md
@@ -20,8 +20,6 @@
 
 #### Visualizations
 
-See [Plot Interpretation Guide](#3-plot-interpretation-guide) on how to read the plots in detail.
-
 <!-- include:report_deep_dive_anomaly_plots.md|empty.md -->
 
 <!-- include:report_deep_dive_cluster_overall_plot.md|empty.md -->

--- a/domains/external-dependencies/summary/report.template.md
+++ b/domains/external-dependencies/summary/report.template.md
@@ -4,11 +4,10 @@
 
 ## 1. Executive Overview
 
-This report analyses which **external packages, modules, and namespaces** the codebase depends on, how widely those dependencies are spread across internal modules, and how dependency usage breaks down per artifact.
+Analyzes which external packages, modules, and namespaces the codebase depends on, their spread, and per-artifact usage.
 
-> **Who imports whom?**  
-> External dependencies reveal coupling to third-party libraries, infrastructure frameworks, and platform APIs.  
-> High spread (many internal modules referencing the same external package) indicates a candidate for a **facade** or **anti-corruption layer**.
+> **Who imports whom?**
+> High spread (many internal modules referencing the same external package) = candidate for a **facade** or **anti-corruption layer**.
 
 ## 📚 Table of Contents
 
@@ -24,8 +23,7 @@ This report analyses which **external packages, modules, and namespaces** the co
 
 ### 2.1 Most Used External Packages
 
-The table below lists external Java packages ranked by how many *internal types* call into them.  
-High `numberOfExternalCallerTypes` values indicate packages that are deeply embedded in the codebase.
+External Java packages by internal caller type count. High `numberOfExternalCallerTypes` = deeply embedded.
 
 <!-- include:External_package_usage_overall.md|empty.md -->
 
@@ -44,14 +42,13 @@ High spread indicates a pervasive cross-cutting dependency that is hard to repla
 
 ### 2.4 External Package Usage per Artifact (Top)
 
-Which artifacts are most exposed to external packages?  
-Ranked by total number of internal packages with external dependencies.
+Artifacts ranked by number of internal packages with external dependencies.
 
 <!-- include:External_package_usage_per_artifact_sorted_top.md|empty.md -->
 
 ### 2.5 Aggregated External Package Usage per Artifact
 
-Statistical summary: for each artifact, how many internal packages use external ones, and what percentage is that?
+Per-artifact: how many internal packages use external ones and their percentage.
 
 <!-- include:External_package_usage_per_artifact_package_aggregated.md|empty.md -->
 
@@ -71,8 +68,7 @@ External npm modules ranked by how many internal TypeScript elements import them
 
 ### 3.2 Most Used External Namespaces
 
-Some npm packages expose multiple namespaces. This view groups by namespace to show  
-declaration-level coupling within a package.
+Groups by namespace to reveal declaration-level coupling within npm packages.
 
 <!-- include:External_namespace_usage_overall_for_Typescript.md|empty.md -->
 
@@ -98,14 +94,13 @@ Which internal TypeScript modules depend on the most external modules?
 
 ### 4.1 Maven POM Declared Dependencies
 
-Java dependencies declared in Maven `pom.xml` files — declared vs. analysed.
+Java dependencies declared in Maven `pom.xml` files.
 
 <!-- include:Maven_POM_dependencies.md|empty.md -->
 
 ### 4.2 package.json Declared Dependencies
 
-TypeScript / Node.js dependencies declared in `package.json` files, ranked by occurrence
-across repository packages.
+Node.js dependencies declared in `package.json` files, ranked by occurrence across repository packages.
 
 <!-- include:Package_json_dependencies_occurrence.md|empty.md -->
 
@@ -115,19 +110,15 @@ across repository packages.
 
 | Term | Definition |
 |------|-----------|
-| **External dependency** | A type, module, or namespace whose source code is *not* part of the scanned internal codebase. |
-| **External package** | A fully-qualified Java package belonging to an external library (e.g. `org.springframework.web`). |
-| **Second-level package** | The first two dot-separated segments of a package name (e.g. `org.springframework`). Used to group many variant packages under one framework name. |
-| **External module** | A TypeScript/JavaScript npm package imported via `import ... from 'module-name'`. |
-| **External namespace** | A named export group within an external TypeScript module (e.g. `node:fs`, `@angular/core`). |
+| **Second-level package** | First two dot-separated segments of a package name (e.g. `org.springframework`). Used to group variant packages under one framework name. |
 | **numberOfExternalCallerTypes** | Count of *internal Java types* that directly reference the external package. |
-| **numberOfExternalCallerPackages** | Count of *internal Java packages* that contain at least one type referencing the external package. |
-| **numberOfExternalCallerElements** | Count of *internal TypeScript elements* (functions, classes, variables) that import from the external module. |
+| **numberOfExternalCallerPackages** | Count of *internal Java packages* containing at least one type referencing the external package. |
+| **numberOfExternalCallerElements** | Count of *internal TypeScript elements* that import from the external module. |
 | **numberOfExternalCallerModules** | Count of *internal TypeScript modules* that import from the external module. |
 | **sumNumberOfTypes / sumNumberOfPackages** | Sum across all artifacts of internal types/packages dependent on the external package. Measures total spread. |
-| **sumNumberOfUsedExternalDeclarations** | Total distinct external declarations (functions, types) imported from the module across all internal modules. |
+| **sumNumberOfUsedExternalDeclarations** | Total distinct external declarations imported from the module across all internal modules. |
 | **packagesCallingExternalRate** | Ratio of internal packages with external references to total artifact packages. |
 | **typesCallingExternalRate** | Ratio of internal types with external references to total artifact types. |
-| **Anti-Corruption Layer (ACL)** | An architectural pattern that isolates the internal domain from external library APIs by wrapping them behind an internal interface. Recommended when a high-spread dependency must be replaced or abstracted. |
-| **Façade** | A simplified interface that hides the complexity of one or more external libraries. Useful when many internal modules call the same external package. |
-| **Hexagonal Architecture** | An architectural style (Ports & Adapters) that pushes all external dependencies to the outer ring, preventing them from leaking into the core domain. |
+| **Anti-Corruption Layer (ACL)** | Isolates the internal domain from external library APIs by wrapping them behind an internal interface. |
+| **Façade** | Simplified interface hiding external library complexity. Useful when many internal modules call the same external package. |
+| **Hexagonal Architecture** | Ports & Adapters style that pushes all external dependencies to the outer ring, preventing them from leaking into the core domain. |

--- a/domains/git-history/summary/report.template.md
+++ b/domains/git-history/summary/report.template.md
@@ -13,9 +13,7 @@ This report analyses the **git commit history** of the codebase. It covers:
 - **Data quality** — ambiguous or unresolved file references in the git log
 - **Git author wordcloud** — visual overview of contributor activity
 
-> **Reading the tables**: Rows are sorted by priority — the **first rows are the most critical**.  
-> High commit frequency in a directory can indicate hotspots that benefit from refactoring attention.  
-> Files that always change together may be candidates for co-location or module consolidation.
+> High commit frequency in a directory = refactoring hotspot. Files that always change together = co-location or module consolidation candidates.
 
 ## 📚 Table of Contents
 
@@ -33,7 +31,7 @@ This report analyses the **git commit history** of the codebase. It covers:
 
 ## 2. Directory Commit Statistics
 
-Shows how often each directory has been changed in git history and how many distinct authors contributed to it. High values in `commits` and `authors` point to active, potentially complex directories.
+Commit frequency and author count per directory. High values = active, potentially complex.
 
 ### 2.1 Directory Commit Statistics (Table)
 
@@ -47,7 +45,7 @@ Shows how often each directory has been changed in git history and how many dist
 
 ## 3. Co-Changed Files
 
-Files that are frequently committed together are said to be _co-changed_. High co-change frequency between two files is a signal of logical coupling — they may belong to the same conceptual unit or have a shared concern that could be refactored.
+Files committed together = logical coupling signal. May belong to the same conceptual unit or share a concern.
 
 ### 3.1 Co-Changed File Pairs
 
@@ -77,7 +75,7 @@ Shows all files that were changed together with another particular file.
 
 ## 4. File Change Distribution
 
-Shows the distribution of how many files are changed per commit. A high proportion of large commits (many files changed at once) can indicate low commit granularity.
+Files changed per commit. High proportion of large commits = low commit granularity.
 
 ### 4.1 Files per Commit Distribution
 
@@ -91,7 +89,7 @@ Shows the distribution of how many files are changed per commit. A high proporti
 
 ## 5. Pairwise Changed Files
 
-Direct pairwise co-change analysis between individual files, showing commit overlap counts and related dependency information.
+Commit overlap counts and dependency info between file pairs.
 
 ### 5.1 Pairwise Changed Files
 
@@ -99,7 +97,7 @@ Direct pairwise co-change analysis between individual files, showing commit over
 
 ### 5.2 Pairwise Changed Files (Top by Lift)
 
-Filing pairs with the highest _commit lift_ — pairs that co-change more often than random chance (lift > 1).
+File pairs that co-change more often than random chance (lift > 1).
 
 <!-- include:List_pairwise_changed_files_top_selected_metric.md|report_no_git_data.template.md -->
 
@@ -117,7 +115,7 @@ Files that are co-changed and also have a structural dependency relationship bet
 
 ## 6. Files by Author
 
-Shows the files each author has contributed to, including per-author commit statistics per file. Useful for identifying knowledge boundaries and bus-factor risks.
+Per-author file commit stats. Useful for knowledge boundaries and bus-factor risk.
 
 ### 6.1 Files with Commit Statistics by Author
 
@@ -127,23 +125,23 @@ Shows the files each author has contributed to, including per-author commit stat
 
 ## 7. Data Quality
 
-Identifies potential issues in the git log data: files referenced in commits that cannot be resolved to a known codebase file (unresolved), or that match more than one candidate (ambiguous). These affect the reliability of all co-change metrics.
+Files in git log that are unresolved (not found in codebase) or ambiguous (multiple matches). Affects reliability of co-change metrics.
 
 ### 7.1 File Resolution Summary
 
-Overview of file resolution by extension: how many files are resolved vs. ambiguous vs. unresolved per file type.
+Resolved vs. ambiguous vs. unresolved files by extension.
 
 <!-- include:List_git_files_by_resolved_label_and_extension.md|report_no_git_data.template.md -->
 
 ### 7.2 Ambiguous Git Files
 
-Files in the git log that match multiple candidates in the scanned codebase. These are excluded from co-change analysis.
+Match multiple codebase files — excluded from co-change analysis.
 
 <!-- include:List_ambiguous_git_files.md|report_no_git_data.template.md -->
 
 ### 7.3 Unresolved Git Files
 
-Files referenced in git commits but not found in the scanned codebase. May indicate deleted files, renames, or files outside the scan scope.
+Not found in scanned codebase. May indicate deleted files, renames, or out-of-scope paths.
 
 <!-- include:List_unresolved_git_files.md|report_no_git_data.template.md -->
 

--- a/domains/graph-algorithms/summary/report.template.md
+++ b/domains/graph-algorithms/summary/report.template.md
@@ -4,12 +4,11 @@
 
 ## 1. Overview
 
-This report summarises graph algorithm results computed from the code graph stored in Neo4j.
-It covers centrality scores, community detection assignments, and node similarity.
+Graph algorithm results from the code graph: centrality, community detection, and node similarity.
 
-- **Centrality** — which nodes (packages, types, artifacts) are most influential in the dependency graph
-- **Community Detection** — how code units cluster into communities based on their dependencies
-- **Similarity** — which code units are structurally most similar to each other (Jaccard)
+- **Centrality** — which nodes (packages, types, artifacts) are most influential
+- **Community Detection** — how code units cluster based on dependencies
+- **Similarity** — which code units share the most common dependencies (Jaccard)
 
 > **Reading the tables**: Rows are sorted by algorithm score — the **first rows are the most significant**.
 
@@ -24,9 +23,7 @@ It covers centrality scores, community detection assignments, and node similarit
 
 ## 2. Centrality
 
-Centrality scores indicate how important a node is in the dependency graph.
-High PageRank scores indicate nodes that are depended on by many other important nodes.
-High betweenness scores indicate nodes that act as bridges between different parts of the graph.
+High PageRank = depended on by many important nodes. High betweenness = bridge between graph parts.
 
 ### 2.1 Top Nodes by PageRank
 
@@ -44,9 +41,7 @@ High betweenness scores indicate nodes that act as bridges between different par
 
 ## 3. Community Detection
 
-Community detection algorithms group code units that are tightly connected to each other.
-High community sizes may indicate large, monolithic modules.
-Many small communities may indicate well-modularised code.
+High community sizes may indicate monolithic modules; many small = well-modularised.
 
 ### 3.1 Leiden Communities Overview
 
@@ -54,8 +49,7 @@ Many small communities may indicate well-modularised code.
 
 ### 3.2 Strongly Connected Components (SCC)
 
-Strongly connected components identify cycles in directed dependency graphs.
-Components with more than one member indicate circular dependencies.
+Components with more than one member = circular dependencies.
 
 <!-- include:StronglyConnectedComponentsOverview.md|report_no_graph_data.template.md -->
 
@@ -67,8 +61,7 @@ Weakly connected components identify isolated clusters of code units.
 
 ### 3.4 Local Clustering Coefficient
 
-The local clustering coefficient measures how tightly interconnected a node's neighbours are.
-High values indicate a node whose dependencies are also heavily dependent on each other.
+How tightly interconnected a node's neighbours are. High = dependencies are also mutually dependent.
 
 <!-- include:LCCNodesByCoefficient.md|report_no_graph_data.template.md -->
 
@@ -76,8 +69,7 @@ High values indicate a node whose dependencies are also heavily dependent on eac
 
 ## 4. Similarity
 
-Node similarity (Jaccard) identifies code units that share many common dependencies.
-High similarity scores may indicate duplicated or closely related functionality.
+Jaccard similarity: code units sharing common dependencies. High = potential duplication or related functionality.
 
 ### 4.1 Top Jaccard Similarity Pairs
 

--- a/domains/internal-dependencies/summary/report.template.md
+++ b/domains/internal-dependencies/summary/report.template.md
@@ -39,11 +39,9 @@ Artifacts by size and connectivity. High incoming = shared library; high outgoin
 
 ### 2.2 Interface Segregation Principle Candidates
 
-Based on Robert C. Martin's **Interface Segregation Principle** — _"Clients should not be forced to depend upon interfaces that they do not use."_
+ISP (Robert C. Martin): Interfaces declaring many methods but callers use only a subset — extract focused sub-interfaces.
 
-Interfaces with many declared methods but callers use only a subset. Extract focused sub-interfaces.
-
-`usageRatio` (lower = stronger candidate), `callerCount` (high + low ratio = high priority). `exampleCalledMethods` shows methods to extract.
+`usageRatio` (lower = stronger candidate), `callerCount` (high + low ratio = higher priority). `exampleCalledMethods` shows methods to extract.
 
 <!-- include:Candidates_for_Interface_Segregation.md|empty.md -->
 
@@ -56,8 +54,6 @@ Types used by most packages (high ripple risk on changes). Sorted by usage count
 ### 2.4 Overly Broad Artifact Dependencies
 
 Artifact dependencies where dependents use only a small `usedPackagesPercent`. Low % = optimization/removal candidate.
-
-A low `usedPackagesPercent` indicates that a dependent artifact imports only a small fraction of the artifact's packages.
 
 <!-- include:How_many_packages_used_by_dependent_artifacts.md|empty.md -->
 
@@ -109,7 +105,7 @@ Reveals dependency chain **depth and complexity**.
 
 ### 4.1 Java Package Path Finding
 
-Dependency path analysis at the Java package level. Intra-artifact pairs (both source and target in the same artifact) are highlighted; intermediate paths may cross artifact boundaries, reflecting real-world transitive coupling.
+Intra-artifact pairs highlighted; intermediate paths may cross artifact boundaries.
 
 #### 4.1.1 All Pairs Shortest Path
 

--- a/domains/java/summary/report.template.md
+++ b/domains/java/summary/report.template.md
@@ -4,14 +4,13 @@
 
 ## 1. Overview
 
-This report analyses the **Java codebase** loaded in the graph database. It covers:
+Analyzes the Java codebase:
 
-- **Artifact dependencies** — which artifacts depend on which, and how widely internal dependencies are spread
-- **Method metrics** — effective lines of method code per type and package, and the overall line count distribution
-- **Java code quality** — annotation usage, deprecated element usages, and reflection usage
-- **Web framework annotations** — Spring Web and Jakarta EE REST endpoint annotations
+- **Artifact dependencies** — which artifacts depend on which, and spread across modules
+- **Method metrics** — effective LOC per type and package
+- **Java code quality** — annotation usage, deprecated element usages, and reflection
+- **Web framework annotations** — Spring Web and Jakarta EE REST endpoints
 
-> **Reading the tables**: Rows are sorted by priority — the **first rows are the most critical**.  
 > High dependency counts may indicate coupling hotspots.  
 > Deprecated element usages should be migrated to their replacements.
 
@@ -30,7 +29,7 @@ This report analyses the **Java codebase** loaded in the graph database. It cove
 
 ## 2. Artifact Dependencies
 
-Shows direct dependency relationships between Maven artifacts (JARs). High incoming dependency counts indicate central, widely-used modules. High outgoing dependency counts indicate modules that depend on many others.
+Maven artifact dependencies. High incoming = central/shared; high outgoing = depends on many others.
 
 ### 2.1 Incoming Artifact Dependencies
 
@@ -56,7 +55,7 @@ Shows direct dependency relationships between Maven artifacts (JARs). High incom
 
 ## 3. Method Metrics
 
-Summarises the effective lines of method code (LOC) across types and packages. High values highlight the most complex or largest parts of the codebase.
+Effective Lines Of Code (LOC) per type and package. High values = complex or large.
 
 ### 3.1 Effective Method Line Count Distribution
 
@@ -78,7 +77,7 @@ Summarises the effective lines of method code (LOC) across types and packages. H
 
 ## 4. Java Code Quality
 
-Highlights annotations used across the codebase, deprecated API usages, and reflection calls that may be fragile or hard to analyse statically.
+Annotations, deprecated API usages, and reflection calls.
 
 ### 4.1 Annotated Code Elements
 
@@ -104,7 +103,7 @@ Highlights annotations used across the codebase, deprecated API usages, and refl
 
 ## 5. Web Framework Annotations
 
-Lists methods annotated with HTTP mapping annotations from Spring Web and Jakarta EE REST. These are the declared REST endpoints of the application.
+HTTP mapping annotations from Spring Web and Jakarta EE REST — declared REST endpoints.
 
 ### 5.1 Spring Web Request Annotations
 
@@ -122,7 +121,7 @@ Lists methods annotated with HTTP mapping annotations from Spring Web and Jakart
 
 ## 6. Duplicate Package Names
 
-Package names that appear in more than one artifact. Duplicate packages can cause split-package issues on the module path and often indicate unintended copying of code.
+Package names in multiple artifacts. Can cause split-package issues on the module path.
 
 <!-- include:DuplicatePackageNamesAcrossArtifacts.md|empty.md -->
 
@@ -130,7 +129,7 @@ Package names that appear in more than one artifact. Duplicate packages can caus
 
 ## 7. Dependency Spread
 
-Shows how many distinct artifacts each internal module is depended on by (spread), and vice versa. Highly spread dependencies are critical infrastructure modules.
+How many distinct artifacts each internal module is depended on by (spread) and vice versa. Highly spread = critical infrastructure.
 
 ### 7.1 Spread per Dependency (most used by others)
 
@@ -154,17 +153,16 @@ Shows how many distinct artifacts each internal module is depended on by (spread
 | `dependencyArtifactName` | Name of the dependency artifact in a spread analysis |
 | `usedInArtifacts` | Number of distinct artifacts using this dependency (spread) |
 | `artifactDependencies` | Number of distinct dependency artifacts used by this artifact (spread) |
-| `effectiveLineCount` | Effective line count of a method (non-blank, non-comment lines) |
-| `methods` | Number of methods at a given effective line count |
-| `typeName` | Simple name of a Java class, interface, enum, or annotation type |
-| `packageName` | Simple (last-segment) name of a Java package |
+| `typeName` | Simple name of a Java type (class, interface, enum, annotation type) |
+| `packageName` | Simple name of a Java package |
 | `fullPackageName` | Fully qualified name of a Java package |
+| `artifactName` | Name of the artifact (JAR/module) containing the element |
+| `methods` | Number of methods with a given effective line count |
+| `effectiveLineCount` | Non-blank, non-comment lines in a method |
 | `sumEffectiveLinesOfMethodCode` | Sum of effective lines of method code in a type |
-| `linesInPackage` | Sum of effective lines of method code across all methods in a package |
+| `linesInPackage` | Sum of effective lines across all methods in a package |
 | `annotationName` | Fully qualified name of a Java annotation type |
 | `languageElement` | Kind of code element annotated (Class, Method, Field, Type, Parameter, etc.) |
 | `numberOfAnnotatedElements` | Count of distinct elements annotated with a particular annotation |
-| `artifactName` | Name of the Maven artifact (JAR/WAR/EAR) |
 | `deprecatedElement` | Kind of deprecated code element (Class, Method, Field, etc.) |
 | `numberOfElementsUsingDeprecatedElements` | Count of distinct non-deprecated elements using a deprecated element |
-| `httpMethod` | HTTP method or mapping annotation (e.g., GET, POST, RequestMapping) |

--- a/domains/overview/summary/report.template.md
+++ b/domains/overview/summary/report.template.md
@@ -4,9 +4,7 @@
 
 ## 1. Overview
 
-This report provides a high-level summary of the graph database contents after scanning code artifacts.
-
-It covers the **general graph structure** (node label combinations, individual node labels, and relationship type distributions), followed by a **Java overview** (artifact sizes, type composition, and package counts), and a **TypeScript overview** (module element counts and element type composition).
+High-level summary of graph database contents: general graph structure (node labels, relationships), Java artifacts, and TypeScript modules.
 
 ## 📚 Table of Contents
 


### PR DESCRIPTION
### 🚀 Feature

- [Make markdown summaries LLM context friendly](https://github.com/JohT/code-graph-analysis-pipeline/pull/585/commits/f1d97f8f9d132743b1c33d7ba265ed07fa5f8ada): Condensed plot description tables to a compact 2-column LLM-friendly format, removed redundant YAML, and updated templates and glossaries across domains.

### ⚙️ Optimization

- 

### 🛠 Fix

- 

### 📖 Documentation

- 