### PR TITLE
Add project name to code unit nodes during enrichment

### DIFF
--- a/.github/prompts/plan-addProjectNameEnrichment.prompt.md
+++ b/.github/prompts/plan-addProjectNameEnrichment.prompt.md
@@ -1,0 +1,306 @@
+# Plan: Add `projectName` Enrichment to Code Unit Nodes
+
+## Problem Statement
+
+**Massive duplication pattern:** 20+ Cypher queries across `anomaly-detection`, `archetypes`, and `node-embeddings` domains repeat 4–6 identical lines of `OPTIONAL MATCH` traversal logic to compute project/artifact names at query runtime:
+
+```cypher
+OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
+    WITH *, artifact.name AS artifactName
+OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
+    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
+    WITH *, coalesce(artifactName, projectName) AS projectName
+```
+
+**Consequence:** 
+- Each downstream query pays traversal cost (extra I/O) every time it runs
+- Code duplication makes maintenance fragile (logic spread across 20+ files)
+- New queries must replicate boilerplate or lack project context
+
+**Solution:** Persist `projectName` as a node property once during pipeline setup, eliminating runtime traversal from all downstream queries.
+
+---
+
+## Solution Overview
+
+### Phase 1: Create 2 Enrichment Queries
+
+Two new queries in `cypher/General_Enrichment/` will set the `projectName` property on code unit nodes exactly once, during `prepareAnalysis.sh`:
+
+#### **1. `Set_projectName_for_Java_code_units.cypher`**
+
+```cypher
+// Set "projectName" property on Java Package and Type nodes contained in an Artifact. Requires "Add_file_name_and_extension.cypher".
+
+MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
+WHERE (codeUnit:Java:Package OR codeUnit:Java:Type)
+  AND codeUnit.projectName IS NULL
+ SET codeUnit.projectName = artifact.name
+RETURN count(*) AS updatedCodeUnits
+```
+
+**Why this pattern:**
+- `Java:Artifact` is the jQAssistant container for all Java code units (Package, Type, Method)
+- `artifact.name` is already set and stable (Maven artifact/JAR identifier)
+- Scope to Package + Type because they are projection targets; Method is nested under Type
+- `IS NULL` guard makes this query idempotent (safe to re-run without side effects)
+
+---
+
+#### **2. `Set_projectName_for_Typescript_modules.cypher`**
+
+```cypher
+// Set "projectName" property on TypeScript Module nodes using the containing Project name. Requires "Add_name_to_property_on_projects.cypher".
+
+MATCH (proj:TS:Project)-[:CONTAINS]->(module:TS:Module)
+WHERE proj.name IS NOT NULL
+  AND module.projectName IS NULL
+ SET module.projectName = proj.name
+RETURN count(*) AS updatedModules
+```
+
+**Why this pattern:**
+- `TS:Project.name` is already enriched by `Add_name_to_property_on_projects.cypher` (accounts for nested config-dir layout)
+- More accurate than parsing raw `projectRoot.absoluteFileName` at query time
+- Scope to Module (leaf code units are projection targets; their parent Project name is the container context)
+- `IS NULL` guard ensures idempotency
+
+---
+
+### Phase 2: Wire Into Pipeline
+
+Edit `scripts/prepareAnalysis.sh` at **line ~70** (immediately after the line):
+```bash
+execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_projects.cypher"
+```
+
+Add:
+```bash
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Java_code_units.cypher"
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Typescript_modules.cypher"
+```
+
+**Rationale for placement:**
+- After `Add_name_to_property_on_projects.cypher` ensures TS:Project names are set before enriching modules
+- Before any domain-specific queries (anomaly-detection, archetypes, etc.) so they can rely on the property
+
+---
+
+### Phase 3: Simplify Downstream Queries (20+ files)
+
+Replace the 2–3 `OPTIONAL MATCH` blocks with a single line reading the enriched property.
+
+#### **Before (example from `AnomalyDetectionFeatures.cypher`):**
+```cypher
+OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
+    WITH *, artifact.name AS artifactName
+OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
+    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
+  RETURN DISTINCT 
+         coalesce(codeUnit.fqn, ...) AS codeUnitName
+        ,codeUnit.name AS shortCodeUnitName
+        ,coalesce(artifactName, projectName, "") AS projectName
+        ,...
+```
+
+#### **After:**
+```cypher
+  RETURN DISTINCT 
+         coalesce(codeUnit.fqn, ...) AS codeUnitName
+        ,codeUnit.name AS shortCodeUnitName
+        ,coalesce(codeUnit.projectName, "") AS projectName
+        ,...
+```
+
+**Impact:** ~6 lines removed per file, 1 line replaces them.
+
+---
+
+## Files to Update
+
+### Anomaly Detection (9 files)
+
+Query files (5):
+- `domains/anomaly-detection/features/AnomalyDetectionFeatures.cypher`
+- `domains/anomaly-detection/summary/AnomalyDeepDiveTopAnomalies.cypher` ⚠️ **Note:** Has a 3rd fallback for `File:Directory` (SCIP nodes) — see Special Cases below
+- `domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_0a_Query_Calculated.cypher`
+- `domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher`
+- `domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher`
+- `domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher`
+
+Label files (3):
+- `domains/anomaly-detection/labels/AnomalyDetectionArchetypeOutlier.cypher`
+- `domains/anomaly-detection/labels/AnomalyDetectionArchetypeBridge.cypher`
+- `domains/anomaly-detection/labels/AnomalyDetectionTopAnomalies.cypher`
+
+### Archetypes (11 files)
+
+Query files (8):
+- `domains/archetypes/queries/AnomalyDetectionFragileStructuralBridges.cypher`
+- `domains/archetypes/queries/AnomalyDetectionOverReferencesUtilities.cypher`
+- `domains/archetypes/queries/AnomalyDetectionPotentialImbalancedRoles.cypher`
+- `domains/archetypes/queries/AnomalyDetectionSilentCoordinators.cypher`
+- `domains/archetypes/queries/AnomalyDetectionPopularBottlenecks.cypher`
+- `domains/archetypes/queries/AnomalyDetectionUnexpectedCentralNodes.cypher`
+- `domains/archetypes/queries/AnomalyDetectionHiddenBridgeNodes.cypher`
+- `domains/archetypes/queries/AnomalyDetectionDependencyHungryOrchestrators.cypher`
+
+Label files (3):
+- `domains/archetypes/labels/ArchetypeHub.cypher`
+- `domains/archetypes/labels/ArchetypeAuthority.cypher`
+- `domains/archetypes/labels/ArchetypeBottleneck.cypher`
+
+⚠️ **Special case:** `domains/archetypes/queries/AnomalyDetectionPotentialOverEngineerOrIsolated.cypher` (not in Phase 3 list yet — needs verification)
+
+### Node-Embeddings (8 files)
+
+Stream files (4):
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_4d_GraphSAGE_Stream.cypher`
+
+Tuneable-stream files (4):
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher`
+- `domains/node-embeddings/queries/node-embeddings/Node_Embeddings_4d_GraphSAGE_Tuneable_Stream.cypher`
+
+---
+
+## Special Cases & Decisions
+
+### 1. `AnomalyDeepDiveTopAnomalies.cypher` — 3rd Fallback for SCIP Nodes
+
+This file currently has a **third** `OPTIONAL MATCH` for `File:Directory`:
+```cypher
+OPTIONAL MATCH (codeDirectory:File:Directory)-[:CONTAINS]->(codeUnit)
+    WITH *, split(replace(codeDirectory.fileName, './', ''), '/')[-2] AS directoryName
+    WITH *, coalesce(artifactName, projectName, directoryName, "") AS projectName
+```
+
+**Options:**
+- **Option A (Recommended):** Simplify to `coalesce(codeUnit.projectName, '')` — gracefully returns empty string for unmapped SCIP nodes; no third enrichment needed yet
+- **Option B:** Add a third enrichment for SCIP nodes using directory-based fallback; revisit when SCIP integration requirements are clarified
+
+**Recommendation:** Option A for now. SCIP node enrichment can be deferred to a future phase if business requirements demand it.
+
+---
+
+### 2. Notebook Embedded Queries
+
+Two Jupyter notebooks contain embedded Cypher queries with the same pattern:
+- [domains/anomaly-detection/explore/AnomalyDetectionExploration.ipynb](domains/anomaly-detection/explore/AnomalyDetectionExploration.ipynb)
+- [domains/anomaly-detection/explore/AnomalyDetectionIsolationForestExploration.ipynb](domains/anomaly-detection/explore/AnomalyDetectionIsolationForestExploration.ipynb)
+
+**Action:** Update notebook cells to use `coalesce(codeUnit.projectName, "")` instead of the duplicated traversal logic. Notebooks are exploratory/interactive, so updates are not blocking but good hygiene.
+
+---
+
+### 3. Existing Enrichment Precedents
+
+- **`Set_artifactName_property_on_every_Package_node.cypher`:** Existing query (Java Package only, sets `artifactName` property). Our queries are complementary, use `projectName` property, and cover more node types (Package + Type, and all TS:Module).
+- **`Set_localRootPath_for_modules.cypher`:** Sets `module.rootProjectName` via local-path parsing. Our `module.projectName` is independent and uses the enriched `proj.name` value. Both can coexist.
+
+---
+
+## Verification & Testing
+
+### Unit Tests (Per-Query)
+
+1. **Test `Set_projectName_for_Java_code_units.cypher`:**
+   ```bash
+   ./scripts/executeQuery.sh cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher
+   # Expected: updatedCodeUnits > 0 (or 0 if no Java code in database)
+   ```
+
+2. **Test `Set_projectName_for_Typescript_modules.cypher`:**
+   ```bash
+   ./scripts/executeQuery.sh cypher/General_Enrichment/Set_projectName_for_Typescript_modules.cypher
+   # Expected: updatedModules > 0 (or 0 if no TypeScript code in database)
+   ```
+
+### Integration Test
+
+3. **Spot-check property coverage:**
+   ```cypher
+   MATCH (n) WHERE n.projectName IS NOT NULL 
+   RETURN labels(n)[0..3] AS nodeLabels, count(*) AS count 
+   ORDER BY count DESC
+   # Expected: Java:Package, Java:Type, TS:Module with non-zero counts
+   ```
+
+4. **Run domain analysis:**
+   ```bash
+   analyze.sh --domain anomaly-detection --report Csv --keep-running
+   analyze.sh --domain archetypes --report Csv --keep-running
+   # Expected: CSV outputs have non-empty `projectName` column in result rows
+   ```
+
+5. **Idempotency check:** Run enrichment twice, verify same result count
+   ```bash
+   # Run Step 2 enrichments
+   ./scripts/executeQuery.sh cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher
+   # Record: X updated
+   # Run again
+   ./scripts/executeQuery.sh cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher
+   # Expected: 0 updated (all nodes already have projectName set from first run)
+   ```
+
+---
+
+## Implementation Checklist
+
+- [ ] **Phase 1.1:** Create `cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher`
+- [ ] **Phase 1.2:** Create `cypher/General_Enrichment/Set_projectName_for_Typescript_modules.cypher`
+- [ ] **Phase 1 Verify:** Run both queries standalone; spot-check property coverage
+- [ ] **Phase 2:** Edit `scripts/prepareAnalysis.sh` to call both enrichments after `Add_name_to_property_on_projects.cypher`
+- [ ] **Phase 2 Verify:** Run `analyze.sh` for a test project; confirm no errors during enrichment phase
+- [ ] **Phase 3.1–3.6:** Simplify anomaly-detection queries (6 files)
+- [ ] **Phase 3.7–3.17:** Simplify archetypes queries (11 files)
+- [ ] **Phase 3.18–3.25:** Simplify node-embeddings queries (8 files)
+- [ ] **Phase 3 Verify:** Regression test — run `analyze.sh --domain anomaly-detection --report Csv` and compare CSV outputs to baseline (projectName column should match before/after)
+- [ ] **Phase 4 (Optional):** Update notebook queries for consistency
+- [ ] **Phase 5 (Optional):** Consider adding third enrichment for SCIP nodes if future requirements demand it
+
+---
+
+## Benefits
+
+| Metric | Before | After |
+|--------|--------|-------|
+| **Code duplication** | 20+ query files repeat 4–6 lines each (~100+ duplicated lines total) | 2 centralized enrichment queries |
+| **Query runtime** | Each query traverses Artifact/Project→codeUnit relationships at runtime | Single traversal during preparation; queries read cached property |
+| **Maintainability** | Change to project name logic = update 20+ files | Change = update 2 enrichment files + update 1 return alias pattern |
+| **New query onboarding** | Must replicate traversal boilerplate or miss context | Simply use `coalesce(codeUnit.projectName, '')` |
+| **Pipeline performance** | No improvement (traversal cost is relatively small) | Modest improvement (O(1) property read vs O(N) traversal per query) |
+
+---
+
+## Design Principles Applied
+
+- **DRY (Don't Repeat Yourself):** Eliminate duplicated logic across 20+ files
+- **Single Responsibility:** Enrichment queries own the project-name resolution; business queries only read the result
+- **Idempotency:** `IS NULL` guard allows safe re-runs without side effects
+- **Separation of Concerns:** Preparation phase handles all enrichment; domain queries remain focused on their logic
+- **Minimal Breaking Changes:** Downstream queries change only return clauses, not WHERE/MATCH logic
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Enrichment queries miss edge cases (e.g., SCIP nodes) | Some code units lack projectName; queries fall back to empty string | Phase 3 uses `coalesce()` fallback; test with real SCIP data before committing |
+| Stale projectName if node structure changes mid-pipeline | Incorrect project association after re-analysis | Guard with `IS NULL` ensures fresh property on re-run; add validation query to prepareAnalysis if needed |
+| Performance regression if enrichment queries are slow | Pipeline startup time increases | Test enrichment performance on large databases (>1M nodes); optimize if needed |
+| Notebooks diverge from main queries | Maintenance burden; documentation inconsistency | Update notebooks as part of Phase 3 (or defer to Phase 4 if time-constrained) |
+
+---
+
+## Future Enhancements
+
+1. **SCIP Node Enrichment:** Add `Set_projectName_for_SCIP_nodes.cypher` when SCIP integration requirements are clarified
+2. **Other Labels:** Extend enrichment to `File:Directory`, `Method`, or domain-specific labels if needed
+3. **Validation Query:** Add a data-quality check to `prepareAnalysis.sh` that verifies `projectName` coverage for expected node types
+4. **Documentation:** Update [CYPHER.md](../../CYPHER.md) reference (auto-generated from file headers) to document new enrichments

--- a/cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher
+++ b/cypher/General_Enrichment/Set_projectName_for_Java_code_units.cypher
@@ -1,0 +1,8 @@
+// Set "projectName" property on Java Package and Type nodes contained in an Artifact.
+
+MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
+WHERE (codeUnit:Java:Package OR codeUnit:Java:Type)
+  AND artifact.name IS NOT NULL
+  AND codeUnit.projectName IS NULL // Don't override an already existing "projectName" property
+  SET codeUnit.projectName = artifact.name
+RETURN count(*) AS updatedCodeUnits

--- a/cypher/General_Enrichment/Set_projectName_for_Java_methods.cypher
+++ b/cypher/General_Enrichment/Set_projectName_for_Java_methods.cypher
@@ -1,0 +1,7 @@
+// Set "projectName" property on Java Method nodes by inheriting it from their declaring Type. Requires "Set_projectName_for_Java_code_units.cypher".
+
+MATCH (type:Java:Type)-[:DECLARES]->(method:Java:Method)
+WHERE type.projectName IS NOT NULL
+  AND method.projectName IS NULL // Don't override an already existing "projectName" property
+  SET method.projectName = type.projectName
+RETURN count(*) AS updatedMethods

--- a/cypher/General_Enrichment/Set_projectName_for_Typescript_modules.cypher
+++ b/cypher/General_Enrichment/Set_projectName_for_Typescript_modules.cypher
@@ -1,0 +1,7 @@
+// Set "projectName" property on TypeScript Module nodes using the containing Project name. Requires "Add_name_to_property_on_projects.cypher".
+
+MATCH (proj:TS:Project)-[:CONTAINS]->(module:TS:Module)
+WHERE proj.name IS NOT NULL
+  AND module.projectName IS NULL // Don't override an already existing "projectName" property
+  SET module.projectName = proj.name
+RETURN count(*) AS updatedModules

--- a/domains/anomaly-detection/README.md
+++ b/domains/anomaly-detection/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the implementation and resources related to the Anomaly Detection domain within the Code Graph Analysis Pipeline project.
 
-The Anomaly Detection domain uses machine learning (Graph Neural Networks + XGBoost) to detect structural anomalies. It identifies **Bridge** nodes (structural vulnerability points) and **Outlier** nodes (structurally unusual code units).
+The Anomaly Detection domain uses machine learning (Graph Neural Networks + Isolation Forest) to detect structural anomalies. It identifies **Bridge** nodes (structural vulnerability points) and **Outlier** nodes (structurally unusual code units).
 
 **Note:** Structural archetypes like Authority, Bottleneck, and Hub are managed by the separate [archetypes domain](../archetypes/). This domain focuses exclusively on ML-detected anomalies.
 
@@ -32,7 +32,8 @@ The following scripts serve as entry points for various anomaly detection tasks 
 - **Archetypes Domain** owns: Authority, Bottleneck, Hub (structural patterns)
 
 For structural insights at different code levels (Package, Type, Module), run both domains via:
-```
+
+```shell
 analyze.sh --domain archetypes,anomaly-detection
 ```
 

--- a/domains/anomaly-detection/features/AnomalyDetectionFeatures.cypher
+++ b/domains/anomaly-detection/features/AnomalyDetectionFeatures.cypher
@@ -28,15 +28,11 @@
 //     AND codeUnit.anomalyTopFeatureSHAPValue3                 IS NOT NULL
      AND codeUnit.embeddingsFastRandomProjectionTunedForClusteringVisualizationX IS NOT NULL
      AND codeUnit.embeddingsFastRandomProjectionTunedForClusteringVisualizationY IS NOT NULL
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                        AS shortCodeUnitName
         ,elementId(codeUnit)                                  AS nodeElementId
-        ,coalesce(artifactName, projectName, "")              AS projectName
+        ,coalesce(codeUnit.projectName, '')                   AS projectName
         ,codeUnit.incomingDependencies                        AS incomingDependencies
         ,codeUnit.outgoingDependencies                        AS outgoingDependencies
         ,codeUnit[$community_property]                        AS communityId

--- a/domains/anomaly-detection/labels/AnomalyDetectionArchetypeBridge.cypher
+++ b/domains/anomaly-detection/labels/AnomalyDetectionArchetypeBridge.cypher
@@ -4,11 +4,7 @@
    MATCH (codeUnit)
    WHERE $projection_node_label IN labels(codeUnit)
      AND codeUnit.anomalyNodeEmbeddingSHAPSum < 0
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name                                  AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName 
-    WITH *, coalesce(artifactName, projectName)            AS projectName  
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
    ORDER BY codeUnit.anomalyNodeEmbeddingSHAPSum ASC
    LIMIT 10
     WITH collect([codeUnit, projectName]) AS results

--- a/domains/anomaly-detection/labels/AnomalyDetectionArchetypeOutlier.cypher
+++ b/domains/anomaly-detection/labels/AnomalyDetectionArchetypeOutlier.cypher
@@ -12,11 +12,7 @@
     WITH *
    WHERE codeUnit.clusteringHDBSCANNormalizedDistanceToMedoid  >= distanceToMedoidThreshold
      AND codeUnit.clusteringHDBSCANProbability                 <= clusteringProbabilityThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
-    WITH *, coalesce(artifactName, projectName)            AS projectName
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
    ORDER BY codeUnit.clusteringHDBSCANNormalizedDistanceToMedoid DESC, codeUnit.clusteringHDBSCANProbability ASC
    LIMIT 10
     WITH collect([codeUnit, projectName]) AS results

--- a/domains/anomaly-detection/labels/AnomalyDetectionTopAnomalies.cypher
+++ b/domains/anomaly-detection/labels/AnomalyDetectionTopAnomalies.cypher
@@ -6,11 +6,7 @@
      AND codeUnit.anomalyLabel = 1
    ORDER BY codeUnit.anomalyScore DESC
    LIMIT 50
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
-    WITH *, coalesce(artifactName, projectName)            AS projectName
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
   RETURN projectName
         ,codeUnit.name                                     AS shortCodeUnitName
         ,coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName

--- a/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_0a_Query_Calculated.cypher
+++ b/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_0a_Query_Calculated.cypher
@@ -4,14 +4,10 @@
  WHERE $dependencies_projection_node IN LABELS(codeUnit)
    AND codeUnit[$dependencies_projection_write_property] IS NOT NULL
    // AND codeUnit.notExistingToForceRecalculation IS NOT NULL // uncomment this line to force recalculation
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                AS shortCodeUnitName
-       ,coalesce(artifactName, projectName)                                                              AS projectName
+       ,coalesce(codeUnit.projectName, '')                                                               AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)           AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01)       AS centrality
        ,codeUnit[$dependencies_projection_write_property] AS embedding

--- a/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher
+++ b/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher
@@ -12,15 +12,11 @@ CALL gds.fastRP.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher
+++ b/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher
@@ -16,15 +16,11 @@ CALL gds.beta.hashgnn.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher
+++ b/domains/anomaly-detection/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher
@@ -18,15 +18,11 @@ CALL gds.node2vec.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/anomaly-detection/summary/AnomalyDeepDiveTopAnomalies.cypher
+++ b/domains/anomaly-detection/summary/AnomalyDeepDiveTopAnomalies.cypher
@@ -15,13 +15,7 @@ ORDER BY codeUnit.anomalyScore DESC, archetypeRank ASC
   WITH codeUnit
       ,coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
       ,apoc.text.join(collect(DISTINCT archetype), ', ') AS archetypes
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name                                             AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/'))            AS projectName
-OPTIONAL MATCH (codeDirectory:File:Directory)-[:CONTAINS]->(codeUnit)
-    WITH *, split(replace(codeDirectory.fileName, './', ''), '/')[-2] AS directoryName
-    WITH *, coalesce(artifactName, projectName, directoryName, "")    AS projectName
+    WITH *, coalesce(codeUnit.projectName, '')                        AS projectName
 RETURN codeUnitName                                                           AS `Name`
       ,projectName                                                            AS `Contained in`
       ,round(codeUnit.anomalyScore, 4, 'HALF_UP')                             AS `Anomaly Score`

--- a/domains/archetypes/labels/ArchetypeAuthority.cypher
+++ b/domains/archetypes/labels/ArchetypeAuthority.cypher
@@ -15,11 +15,7 @@
   UNWIND codeUnits AS codeUnit
     WITH *
    WHERE codeUnit.centralityPageRankToArticleRankDifference  >= pageToArticleRankDifferenceThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
-    WITH *, coalesce(artifactName, projectName)            AS projectName
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
    ORDER BY codeUnit.centralityPageRank DESC, codeUnit.centralityArticleRank ASC
    LIMIT 10
     WITH collect([codeUnit, projectName]) AS results

--- a/domains/archetypes/labels/ArchetypeBottleneck.cypher
+++ b/domains/archetypes/labels/ArchetypeBottleneck.cypher
@@ -10,11 +10,7 @@
   UNWIND codeUnits AS codeUnit
     WITH *
    WHERE codeUnit.centralityBetweenness >= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
-    WITH *, coalesce(artifactName, projectName)            AS projectName
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
    ORDER BY codeUnit.centralityBetweenness DESC
    LIMIT 10
     WITH collect([codeUnit, projectName]) AS results

--- a/domains/archetypes/labels/ArchetypeHub.cypher
+++ b/domains/archetypes/labels/ArchetypeHub.cypher
@@ -14,11 +14,7 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE degree                                       >= degreeThreshold
      AND codeUnit.communityLocalClusteringCoefficient <= localClusteringCoefficientThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
-    WITH *, coalesce(artifactName, projectName)            AS projectName
+    WITH *, coalesce(codeUnit.projectName, '') AS projectName
    ORDER BY codeUnit.communityLocalClusteringCoefficient ASC, degree DESC
    LIMIT 10
     WITH collect([codeUnit, projectName]) AS results

--- a/domains/archetypes/queries/AnomalyDetectionDependencyHungryOrchestrators.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionDependencyHungryOrchestrators.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.centralityArticleRank    >= articleRankThreshold
      AND codeUnit.centralityBetweenness    >= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,codeUnit.centralityArticleRank                  AS articleRank
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionFragileStructuralBridges.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionFragileStructuralBridges.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies   AS degree
    WHERE codeUnit.communityLocalClusteringCoefficient <= localClusteringCoefficientThreshold
      AND codeUnit.centralityBetweenness               >= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,codeUnit.communityLocalClusteringCoefficient AS localClusteringCoefficient
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionHiddenBridgeNodes.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionHiddenBridgeNodes.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.centralityPageRank    <= pageRankThreshold
      AND codeUnit.centralityBetweenness >= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,codeUnit.centralityPageRank                  AS pageRank
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionOverReferencesUtilities.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionOverReferencesUtilities.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.communityLocalClusteringCoefficient <= localClusteringCoefficientThreshold
      AND codeUnit.centralityPageRank                  >= pageRankThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.communityLocalClusteringCoefficient AS localClusteringCoefficient
         ,codeUnit.centralityPageRank                  AS pageRank
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionPopularBottlenecks.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionPopularBottlenecks.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.centralityPageRank    >= pageRankThreshold
      AND codeUnit.centralityBetweenness >= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,codeUnit.centralityPageRank                  AS pageRank
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionPotentialImbalancedRoles.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionPotentialImbalancedRoles.cypher
@@ -14,14 +14,10 @@
              pageToArticleRankDifferenceStandardDeviation                    AS pageToArticleRankDifferenceZScore
 // Only include code units with a PageRank vs ArticleRank difference more than 2 (z-score) standard deviations from the mean
 WHERE abs(pageToArticleRankDifferenceZScore) > 2.0
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                       AS shortCodeUnitName
-        ,coalesce(artifactName, projectName) AS projectName
+        ,coalesce(codeUnit.projectName, '')  AS projectName
         ,sign(pageToArticleRankDifference)   AS pageToArticleRankSign
         ,pageToArticleRankDifferenceZScore
         ,pageToArticleRankDifference

--- a/domains/archetypes/queries/AnomalyDetectionPotentialOverEngineerOrIsolated.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionPotentialOverEngineerOrIsolated.cypher
@@ -13,14 +13,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.centralityPageRank                  <= pageRankThreshold
      AND codeUnit.communityLocalClusteringCoefficient >= localClusteringCoefficientThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.communityLocalClusteringCoefficient AS localClusteringCoefficient
         ,codeUnit.centralityPageRank                  AS pageRank
         ,degree

--- a/domains/archetypes/queries/AnomalyDetectionSilentCoordinators.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionSilentCoordinators.cypher
@@ -13,14 +13,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE codeUnit.incomingDependencies  <= incomingDependenciesThreshold
      AND codeUnit.centralityBetweenness <= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,degree
         ,codeUnit.incomingDependencies                AS incomingDependencies

--- a/domains/archetypes/queries/AnomalyDetectionUnexpectedCentralNodes.cypher
+++ b/domains/archetypes/queries/AnomalyDetectionUnexpectedCentralNodes.cypher
@@ -14,14 +14,10 @@
     WITH *, codeUnit.incomingDependencies + codeUnit.outgoingDependencies AS degree
    WHERE degree                         <= degreeThreshold
      AND codeUnit.centralityBetweenness <= betweennessThreshold
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-    WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-    WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
   RETURN DISTINCT 
          coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
         ,codeUnit.name                                AS shortCodeUnitName
-        ,coalesce(artifactName, projectName)          AS projectName
+        ,coalesce(codeUnit.projectName, '')           AS projectName
         ,codeUnit.centralityBetweenness               AS betweenness
         ,degree
         ,codeUnit.incomingDependencies                AS incomingDependencies

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_0a_Query_Calculated.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_0a_Query_Calculated.cypher
@@ -4,14 +4,10 @@
  WHERE $dependencies_projection_node IN LABELS(codeUnit)
    AND codeUnit[$dependencies_projection_write_property] IS NOT NULL
    // AND codeUnit.notExistingToForceRecalculation IS NOT NULL // uncomment this line to force recalculation
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                AS shortCodeUnitName
-       ,coalesce(artifactName, projectName)                                                              AS projectName
+       ,coalesce(codeUnit.projectName, '')                                                               AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)           AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01)       AS centrality
        ,codeUnit[$dependencies_projection_write_property] AS embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Stream.cypher
@@ -10,15 +10,11 @@ CALL gds.fastRP.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)     AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_1d_Fast_Random_Projection_Tuneable_Stream.cypher
@@ -12,15 +12,11 @@ CALL gds.fastRP.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Stream.cypher
@@ -16,15 +16,11 @@ CALL gds.beta.hashgnn.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)     AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_2d_Hash_GNN_Tuneable_Stream.cypher
@@ -16,15 +16,11 @@ CALL gds.beta.hashgnn.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Stream.cypher
@@ -11,15 +11,11 @@ CALL gds.node2vec.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)     AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_3d_Node2Vec_Tuneable_Stream.cypher
@@ -18,15 +18,11 @@ CALL gds.node2vec.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenIdTuned, codeUnit.communityLeidenId, 0) AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_4d_GraphSAGE_Stream.cypher
+++ b/domains/node-embeddings/queries/node-embeddings/Node_Embeddings_4d_GraphSAGE_Stream.cypher
@@ -8,15 +8,11 @@ CALL gds.beta.graphSage.stream(
 YIELD nodeId, embedding
  WITH gds.util.asNode(nodeId) AS codeUnit
      ,embedding
-OPTIONAL MATCH (artifact:Java:Artifact)-[:CONTAINS]->(codeUnit)
-   WITH *, artifact.name AS artifactName
-OPTIONAL MATCH (projectRoot:Directory)<-[:HAS_ROOT]-(proj:TS:Project)-[:CONTAINS]->(codeUnit)
-   WITH *, last(split(projectRoot.absoluteFileName, '/')) AS projectName   
  RETURN DISTINCT 
         coalesce(codeUnit.fqn, codeUnit.globalFqn, codeUnit.fileName, codeUnit.signature, codeUnit.name) AS codeUnitName
        ,codeUnit.name                               AS shortCodeUnitName
        ,elementId(codeUnit)                         AS nodeElementId
-       ,coalesce(artifactName, projectName)         AS projectName
+       ,coalesce(codeUnit.projectName, '')          AS projectName
        ,coalesce(codeUnit.communityLeidenId, 0)     AS communityId
        ,coalesce(codeUnit.centralityPageRank, 0.01) AS centrality
        ,embedding

--- a/scripts/prepareAnalysis.sh
+++ b/scripts/prepareAnalysis.sh
@@ -70,6 +70,11 @@ execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Mark_test_modules.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_projects.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_scan_nodes.cypher"
 
+# Preparation - Set "projectName" property on Java and Typescript code unit nodes for uniform access without label traversal
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Java_code_units.cypher"
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Java_methods.cypher"
+execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Typescript_modules.cypher"
+
 # Preparation - Cleanup Graph for Typescript by removing duplicate relationships
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Remove_duplicate_CONTAINS_relations_between_files.cypher"
 

--- a/scripts/prepareAnalysis.sh
+++ b/scripts/prepareAnalysis.sh
@@ -60,25 +60,25 @@ execute_cypher "${CYPHER_DIR}/Create_Typescript_index_for_name.cypher"
 # Preparation - General Enrichment - Add properties "name" and "extension" to all File nodes
 execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Add_file_name_and_extension.cypher"
 
-# Preparation - Enrich Graph for Typescript by adding "module" and "name" properties
+# Preparation - Enrich Graph for TypeScript by adding "module" and "name" properties
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Index_module_name.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_module_properties.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Set_localRootPath_for_modules.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Mark_test_modules.cypher"
 
-# Preparation - Enrich Graph for Typescript by adding a name properties
+# Preparation - Enrich Graph for TypeScript by adding a name properties
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_projects.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_name_to_property_on_scan_nodes.cypher"
 
-# Preparation - Set "projectName" property on Java and Typescript code unit nodes for uniform access without label traversal
+# Preparation - Set "projectName" property on Java and TypeScript code unit nodes for uniform access without label traversal
 execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Java_code_units.cypher"
 execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Java_methods.cypher"
 execute_cypher "${GENERAL_ENRICHMENT_CYPHER_DIR}/Set_projectName_for_Typescript_modules.cypher"
 
-# Preparation - Cleanup Graph for Typescript by removing duplicate relationships
+# Preparation - Cleanup Graph for TypeScript by removing duplicate relationships
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Remove_duplicate_CONTAINS_relations_between_files.cypher"
 
-# Preparation - Enrich Graph for Typescript NPM data (link dependencies to packages, add package-to-package DEPENDS_ON relationships, enrich dependency counts, and link TS:Project nodes to NPM:Package nodes)
+# Preparation - Enrich Graph for TypeScript NPM data (link dependencies to packages, add package-to-package DEPENDS_ON relationships, enrich dependency counts, and link TS:Project nodes to NPM:Package nodes)
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_npm_dependencies_to_npm_packages.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_npm_packages_with_depends_on_relationships.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Enrich_npm_packages_with_dependency_counts.cypher"
@@ -87,25 +87,25 @@ execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Label_npm_packages_by_dep_type.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_projects_to_npm_packages.cypher"
 dataVerificationResult=$( execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Verify_projects_linked_to_npm_packages.cypher" "${@}")
 if is_result_and_csv_column_greater_zero "${dataVerificationResult}" "unresolvedProjectsCount"; then
-    # Warning: There are Typescript projects that are not linked to NPM Packages (unresolvedProjectsCount is greater than zero).
+    # Warning: There are TypeScript projects that are not linked to NPM Packages (unresolvedProjectsCount is greater than zero).
     #          It is possible to have projects with a tsconfig.json file but without a package.json e.g. for testing purposes.
-    echo -e "${COLOR_YELLOW}prepareAnalysis: Data verification warning: There are Typescript projects that are not linked to a npm package:${COLOR_DEFAULT}"
+    echo -e "${COLOR_YELLOW}prepareAnalysis: Data verification warning: There are TypeScript projects that are not linked to a npm package:${COLOR_DEFAULT}"
     echo -e "${COLOR_YELLOW}${dataVerificationResult}${COLOR_DEFAULT}"
     # Since this is now only a warning, execution will be continued.
 fi
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Link_external_modules_to_corresponding_npm_dependency.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_namespace_property_on_nodes_from_linked_npm_packages.cypher"
 
-# Preparation - Enrich Graph for Typescript by adding relationships between Modules with the same globalFqn
+# Preparation - Enrich Graph for TypeScript by adding relationships between Modules with the same globalFqn
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_IS_IMPLEMENTED_IN_relationship_for_matching_modules.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_IS_IMPLEMENTED_IN_relationship_for_matching_declarations.cypher"
 execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Add_DEPENDS_ON_relationship_to_resolved_modules.cypher"
 
 dataVerificationResult=$( execute_cypher "${TYPESCRIPT_CYPHER_DIR}/Verify_module_dependencies.cypher" "${@}")
 if ! is_csv_column_greater_zero "${dataVerificationResult}" "typescriptModuleDependenciesValid"; then
-    # Warning: Very small Typescript projects might not have dependencies between their modules.
+    # Warning: Very small TypeScript projects might not have dependencies between their modules.
     #          Therefore, it will only be a warning even though for example anomaly detection will not lead to any useable results.
-    echo -e "${COLOR_YELLOW}prepareAnalysis: Data verification warning: Typescript module dependencies are missing! Results based on those will be missing or empty:${COLOR_DEFAULT}"
+    echo -e "${COLOR_YELLOW}prepareAnalysis: Data verification warning: TypeScript module dependencies are missing! Results based on those will be missing or empty:${COLOR_DEFAULT}"
     echo -e "${COLOR_YELLOW}${dataVerificationResult}${COLOR_DEFAULT}"
     # Since this is now only a warning, execution will be continued.
 fi
@@ -116,11 +116,11 @@ execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Add_weight_proper
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Add_weight25PercentInterfaces_to_Java_Package_DEPENDS_ON_relationships.cypher" 
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Add_weight10PercentInterfaces_to_Java_Package_DEPENDS_ON_relationships.cypher"
 
-# Preparation - Add weights to Typescript Module DEPENDS_ON relationships
+# Preparation - Add weights to TypeScript Module DEPENDS_ON relationships
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Add_fine_grained_weights_for_Typescript_external_module_dependencies.cypher"
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Add_fine_grained_weights_for_Typescript_internal_module_dependencies.cypher"
 
-# Preparation - Add Typescript Module node properties "incomingDependencies" and "outgoingDependencies"
+# Preparation - Add TypeScript Module node properties "incomingDependencies" and "outgoingDependencies"
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Set_Incoming_Typescript_Module_Dependencies.cypher"
 execute_cypher_summarized "${DEPENDENCY_ENRICHMENT_CYPHER_DIR}/Set_Outgoing_Typescript_Module_Dependencies.cypher"
 


### PR DESCRIPTION
### 🚀 Feature

- [Add projectName enrichment for Java and TypeScript code units](https://github.com/JohT/code-graph-analysis-pipeline/pull/622/commits/f586d06e9c32956125ad7a4021050e03e762286b)

### ⚙️ Optimization

- [Refactor Cypher queries to utilize codeUnit.projectName instead of artifact and projectName variables](https://github.com/JohT/code-graph-analysis-pipeline/pull/622/commits/d3ab24e223c772ed58e9470088986a2ff76636d5)

### 🛠 Fix

- [Fix minor spelling issue in comments](https://github.com/JohT/code-graph-analysis-pipeline/pull/622/commits/7ac22a82406073992c616d0422529aa6678365ee)

### 📖 Documentation

- [Fix anomaly detection description](https://github.com/JohT/code-graph-analysis-pipeline/pull/622/commits/8ec75428c238521390a1b071cd6c084b6b8ede9a)