### PR TITLE
SCIP indices support for internal dependencies

### DIFF
--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -54,4 +54,4 @@ npx --yes markdownlint-cli2 \
 ```
 
 Checks syntax, link validity, heading consistency, spacing. Fix
-warnings. Errors block merge.
+warnings. Errors block merge. Ignore line length.

--- a/.github/prompts/plan-scipSupportFullyInInternalDependencies.prompt.md
+++ b/.github/prompts/plan-scipSupportFullyInInternalDependencies.prompt.md
@@ -1,0 +1,157 @@
+# Plan: Full SCIP Support in `domains/internal-dependencies`
+
+**TL;DR**: Extend all report types — Python charts, GraphViz build levels, Markdown summary, report template, explore notebooks — to include SCIP Semantic Index nodes. New files for new behavior (OCP); existing files modified only for additive, low-risk changes. Module-level OO Design Metrics added for SCIP; Visibility Metrics skipped for SCIP.
+
+---
+
+## Phase 1 — New Cypher Queries *(all independent, parallel)*
+
+1. Create `queries/internal-dependencies/List_all_SCIP_modules.cypher` — SCIP modules with in/out dependency counts and `isTest` flag
+2. Create `queries/internal-dependencies/List_all_SCIP_artifacts.cypher` — SCIP artifacts with in/out dependency counts and `isExternal`
+3. Create `queries/internal-dependencies/SCIP_SCC_Module_build_levels_for_graphviz.cypher` — SCC component nodes (`memberType = 'SemanticCodeIndexModule'`) with level coloring; edge weight = `referenceCount`; LIMIT 440; cycle labels (same pattern as `SCC_Longest_paths_for_graphviz.cypher`)
+4. Create `queries/internal-dependencies/SCIP_SCC_Artifact_build_levels_for_graphviz.cypher` — same pattern for `SemanticCodeIndexArtifact`
+5. Modify `queries/topological-sort/Topological_Sort_Critical_Path_Length.cypher` — add two `UNION ALL` blocks for `SemanticCodeIndexModule` and `SemanticCodeIndexArtifact`
+6. Create `queries/object-oriented-design-metrics/Count_and_set_abstract_types_for_SCIP.cypher` — count abstract types (where `isAbstract=true`) per SCIP module
+7. Create `queries/object-oriented-design-metrics/Calculate_and_set_Abstractness_for_SCIP.cypher` — calculate `abstractness = abstract_types / total_types` for each SCIP module
+8. Create `queries/object-oriented-design-metrics/Set_Incoming_SCIP_Module_Dependencies.cypher` — count distinct types/modules from which this module receives incoming `DEPENDS_ON`
+9. Create `queries/object-oriented-design-metrics/Set_Outgoing_SCIP_Module_Dependencies.cypher` — count distinct types/modules to which this module sends outgoing `DEPENDS_ON`
+10. Create `queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher` — calculate `instability = outgoing / (outgoing + incoming)` for each SCIP module
+11. Create `queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher` — calculate distance to main sequence: `abs(abstractness + instability - 1)`
+
+---
+
+## Phase 2 — Python Chart Extensions *(parallel with Phase 1)*
+
+### 2a. `pathFindingCharts.py` Extension
+12. Add `SCIP_ABSTRACTION_LEVELS` constant (two entries: Module + Artifact). Add `generate_scip_charts_for_level()` — same chart types as `generate_charts_for_level()` but reads `_StronglyConnectedComponents_longest_paths_distribution.csv` for the longest path charts. Call from `main()` after the existing loop. Existing `ABSTRACTION_LEVELS` and `generate_charts_for_level()` **untouched**.
+
+### 2b. `objectOrientedDesignMetricsCharts.py` Extension
+13. Add `SCIP_ABSTRACTION_LEVELS` constant (one entry: Module). Add `generate_scip_oo_design_metrics_charts()` — generates Main Sequence scatter plot (`Abstractness_vs_Instability.svg`) and distance distribution chart for SCIP modules using the new CSV files created by queries in Phase 1 items 6–11. Call from `main()` after the existing Java/TypeScript blocks. Existing code **untouched**.
+
+---
+
+## Phase 3 — Shell Script Extensions *(depends on Phase 1 queries 3+4)*
+
+14. Modify `graphs/internalDependenciesGraphs.sh` — add SCIP SCC build levels blocks for Module and Artifact; reuse the existing `setupStronglyConnectedComponentsForSccVisualization()` helper already defined in the file
+15. Modify `internalDependenciesCsv.sh` — add the **missing** `cleanupAfterReportGeneration.sh` call for `SCIP_Semantic_Index_Type` (currently absent from cleanup)
+
+---
+
+## Phase 4 — Markdown Summary + Report Template *(depends on Phases 1–3)*
+
+16. Modify `summary/internalDependenciesSummary.sh`:
+   - SCIP internal structure: `execute_limited_table` for both new list queries + new listing for Internal Types
+   - SCIP APSP tables: `projectionExists "dependencies_projection=scip-module-path-finding"` guard + `Path_Finding_5_All_pairs_shortest_path_distribution_overall.cypher`; same for Artifact
+   - SCIP SCC longest path: CSV-only links (no live query — avoids dependency on ephemeral `-components` projection)
+   - SCIP OO Design Metrics: Execute the new queries for abstractness/instability/distance; generate CSV tables
+   - SVG chart references for SCIP Module + Artifact (all-pairs + SCC longest path + OO Design Metrics charts)
+   - Graph visualization SVG references: `ScipModuleBuildLevels.svg`, `ScipArtifactBuildLevels.svg`, existing longest path SVGs
+
+17. Modify `summary/report.template.md` — add four new top-level sections:
+    - **Section 3.4 SCIP Semantic Index Structure** (list modules, artifacts, internal types; `empty.md` fallback)
+    - **Section 4.4 SCIP Semantic Index Path Finding** (APSP + SCC longest path; `empty.md` fallback)
+    - **Section 6.4 SCIP Semantic Index Graphs** (build levels + longest path SVGs; `empty.md` fallback)
+    - **Section 8.4 SCIP Semantic Index OO Design Metrics** (main sequence scatter + distance tables + chart SVGs; `empty.md` fallback)
+
+---
+
+## Phase 5 — Explore Notebooks *(parallel with Phases 2–4)*
+
+18. Create `explore/InternalDependenciesScip.ipynb` — mirrors `InternalDependenciesJava.ipynb`; uses the new `List_all_SCIP_modules.cypher` and `List_all_SCIP_artifacts.cypher`; tables sorted by various dependency metrics
+19. Create `explore/PathFindingScip.ipynb` — mirrors `PathFindingTypescript.ipynb`; APSP via `create_directed_unweighted_projection`; SCC longest path via explicit SCC setup + `SCC_Longest_paths_distribution_per_project.cypher`; clearly documents the cycle-handling SCC approach
+20. Create `explore/ObjectOrientedDesignMetricsScip.ipynb` — mirrors `ObjectOrientedDesignMetricsJava.ipynb` and `ObjectOrientedDesignMetricsTypescript.ipynb`; displays Main Sequence scatter plot for SCIP modules; shows instability, abstractness, and distance metrics; allows filtering and exploration by module properties
+
+---
+
+## Phase 6 — Documentation
+
+21. Update [domains/internal-dependencies/README.md](domains/internal-dependencies/README.md) — output listing, SVG charts description, Markdown summary section mentions, OO Design Metrics section
+
+---
+
+## Relevant Files
+
+| Type | File |
+|------|------|
+| New | `queries/internal-dependencies/List_all_SCIP_modules.cypher` |
+| New | `queries/internal-dependencies/List_all_SCIP_artifacts.cypher` |
+| New | `queries/internal-dependencies/SCIP_SCC_Module_build_levels_for_graphviz.cypher` |
+| New | `queries/internal-dependencies/SCIP_SCC_Artifact_build_levels_for_graphviz.cypher` |
+| New | `queries/object-oriented-design-metrics/Count_and_set_abstract_types_for_SCIP.cypher` |
+| New | `queries/object-oriented-design-metrics/Calculate_and_set_Abstractness_for_SCIP.cypher` |
+| New | `queries/object-oriented-design-metrics/Set_Incoming_SCIP_Module_Dependencies.cypher` |
+| New | `queries/object-oriented-design-metrics/Set_Outgoing_SCIP_Module_Dependencies.cypher` |
+| New | `queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher` |
+| New | `queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher` |
+| New | `explore/InternalDependenciesScip.ipynb` |
+| New | `explore/PathFindingScip.ipynb` |
+| New | `explore/ObjectOrientedDesignMetricsScip.ipynb` |
+| Modify | `pathFindingCharts.py` |
+| Modify | `objectOrientedDesignMetricsCharts.py` |
+| Modify | `graphs/internalDependenciesGraphs.sh` |
+| Modify | `internalDependenciesCsv.sh` |
+| Modify | `summary/internalDependenciesSummary.sh` |
+| Modify | `summary/report.template.md` |
+| Modify | `queries/topological-sort/Topological_Sort_Critical_Path_Length.cypher` |
+| Modify | `README.md` |
+
+---
+
+## Verification
+
+Against `temp/react-router-17.13.2-scip-without-jqassistant` with `NEO4J_INITIAL_PASSWORD=neo4jinitial`:
+
+1. `analyze.sh --domain internal-dependencies --report Csv --keep-running` — SCIP CSVs present, no SCIP_Semantic_Index_Type directory left behind; OO Design Metrics CSVs present (`*_Abstractness*.csv`, `*_Instability*.csv`, `*_distance*.csv`)
+2. `analyze.sh --domain internal-dependencies --report Python --keep-running` — SCIP SVG charts generated in `SCIP_Semantic_Index_Module/` and `SCIP_Semantic_Index_Artifact/`; OO Design Metrics charts present (Main Sequence scatter plots, distance distributions)
+3. `analyze.sh --domain internal-dependencies --report Visualization --keep-running` — `ScipModuleBuildLevels.svg` and `ScipArtifactBuildLevels.svg` present
+4. `analyze.sh --domain internal-dependencies --report Markdown --keep-running` — sections 3.4, 4.4, 6.4, 8.4 appear in `internal_dependencies_report.md`
+5. `shellcheck` on all modified shell scripts
+6. Open and run `PathFindingScip.ipynb`, `InternalDependenciesScip.ipynb`, and `ObjectOrientedDesignMetricsScip.ipynb` against running Neo4j
+
+---
+
+## Decisions
+
+- **OO Design Metrics for SCIP**: **Implemented at Module scope** — modules are treated like Java packages, containing internal types some of which are abstract. Abstractness calculated as `(abstract_types_in_module) / (total_types_in_module)`. Instability calculated as `(outgoing_module_dependencies) / (incoming + outgoing_module_dependencies)`. Visibility Metrics skipped (less meaningful for SCIP modules).
+- **Longest path CSV for SCIP charts**: **`_StronglyConnectedComponents_longest_paths_distribution.csv`**
+- **Build levels visualization**: **SCC component graph** (consistent with existing SCIP longest-path viz)
+- **SCIP placement in report**: **new top-level sections** (3.4, 4.4, 6.4, 8.4)
+- **Missing SCIP data**: **silently omit** (`empty.md` fallback)
+- **SCC longest path in Markdown table**: **CSV link only** (projection ephemeral)
+- **SCIP Internal Types**: Listed in section 3.4.3 with separate subsection; topological sort CSV provided; no visualization (too large/messy)
+
+---
+
+## Open Questions for Refinement
+
+**Q1: Notebook complexity trade-off**
+> The `PathFindingScip.ipynb` will be notably more complex than `PathFindingTypescript.ipynb` because it needs to set up SCC components manually before running the longest path. Are you OK with that complexity in the notebook, or should the notebook defer to pre-computed CSV files (like the Python charts do)?
+**A1: Ok with the additional complexity**. Split it up into granular well named and documented functions.
+
+**Q2: Error handling in Python charts**
+> When `_StronglyConnectedComponents_longest_paths_distribution.csv` is missing (e.g., no SCIP data at all), should the SCIP chart generation fail explicitly or silently skip? Current design: silently skip (consistent with missing Java/TS CSVs).
+**A2: Silent skip on missing data, otherwise fail fast**. If there are no SCIP nodes, then silently skip. If there should have been a file, consider running the csv generation or fail fast. In doubt, failing is better than hiding.
+
+**Q3: SCIP Type nodes in internal structure section**
+> Should SCIP Internal Types appear in a separate subsection (e.g., 3.4.3 SCIP Internal Types) with a listing query, or is topological sort + SCC longest path enough coverage?
+**A3: Yes, SCIP Internal Types should appear in a separate subsection**
+
+**Q4: Build levels for SCIP Type nodes**
+> SCIP Internal Types also have topological sort results (CSV already generated). Should we add `ScipModuleBuildLevels.svg` visualization for Type nodes (similar to Java Type but uncommented)? Current design: only Module and Artifact SCC visualizations; Type handling via CSV only.
+**A4: No Visualization of Types nodes**: They could get large, messy and confusing. Write a short hint why they are skipped and link the topological sort results
+
+**Q5: Module-level OO Design Metrics**
+> With the new `isAbstract` property on SCIP Internal Type nodes, should we implement OO Design Metrics (abstractness/instability/distance-to-main-sequence) at the SCIP Module scope?
+**A5: YES, implement at Module scope**: Treat SCIP modules like Java packages. Calculate module-level abstractness from contained abstract types, instability from inter-module dependencies. This enables Main Sequence analysis and visualization for SCIP modules, completing the parity with Java/TypeScript OO metrics.
+---
+
+## Implementation Order Recommendation
+
+1. **Start Phase 1** (Cypher queries 1–11) — parallel, foundational
+   - Items 1–5 (path finding, visualization queries) independent
+   - Items 6–11 (OO metrics queries) independent of 1–5 but depend on same SCIP Type/Module structure
+2. **Then Phase 2** (pathFindingCharts.py + objectOrientedDesignMetricsCharts.py extensions) — depends on Phase 1 CSVs
+3. **Then Phase 3** (shell scripts) — depends on Phase 1 queries 3–4
+4. **Then Phase 4** (Markdown + report template) — depends on Phases 1–3 CSVs and images
+5. **Parallel: Phase 5** (notebooks) — mirrors existing patterns; low dependency risk
+6. **Final: Phase 6** (README update) — after all else

--- a/domains/internal-dependencies/README.md
+++ b/domains/internal-dependencies/README.md
@@ -37,21 +37,29 @@ domains/internal-dependencies/
 │   ├── PathFindingJava.ipynb
 │   └── PathFindingTypescript.ipynb
 ├── queries/
-│   ├── internal-dependencies/             # 14 Cypher queries (internal structure)
+│   ├── internal-dependencies/             # 16 Cypher queries (internal structure, including SCIP)
 │   ├── path-finding/                      # 15 Cypher queries (path algorithms)
 │   │   ├── Set_Parameters*.cypher         # Parameter templates for all path-finding node types
 │   │   └── Path_Finding_*.cypher          # Path-finding algorithms (shortest path, longest path)
 │   ├── topological-sort/                  # 6 core Cypher queries (build ordering)
+│   ├── object-oriented-design-metrics/    # 28 queries: Java, TypeScript, SCIP abstractness/instability
 │   └── strongly-connected-components/     # 9 queries: SCC detection → component sort → propagation
 │       ├── SCC_*.cypher                   # Strongly Connected Component queries
 │       └── SCC_TopologicalSort_*.cypher   # Component-level topological sort
 │   └── exploration/                       # 2 Cypher queries (explore notebooks only)
-├── graphs/
-│   └── internalDependenciesGraphs.sh      # Graph visualization orchestration
-└── summary/
-    ├── internalDependenciesSummary.sh     # Markdown assembly logic
-    └── report.template.md                 # Main report template
-```
+├── explore/                               # Jupyter notebooks for interactive exploration
+│   ├── InternalDependenciesJava.ipynb
+│   ├── InternalDependenciesTypescript.ipynb
+│   ├── InternalDependenciesScip.ipynb     # SCIP module + artifact listing tables
+│   ├── PathFindingJava.ipynb
+│   ├── PathFindingTypescript.ipynb
+│   ├── PathFindingScip.ipynb              # SCIP APSP + SCC-based longest path
+│   ├── ObjectOrientedDesignMetricsJava.ipynb
+│   ├── ObjectOrientedDesignMetricsTypescript.ipynb
+│   ├── ObjectOrientedDesignMetricsScip.ipynb  # SCIP Main Sequence analysis
+│   ├── VisibilityMetricsJava.ipynb
+│   ├── VisibilityMetricsTypescript.ipynb
+│   └── Wordcloud.ipynb
 
 ## Prerequisites
 
@@ -155,17 +163,26 @@ reports/internal-dependencies/
 │   ├── SemanticCodeIndexInternalType_Topological_Sort.csv
 │   └── SemanticCodeIndexInternalType_StronglyConnectedComponents_longest_paths_distribution.csv
 ├── SCIP_Semantic_Index_Module/
+│   ├── List_all_SCIP_modules.csv
 │   ├── SemanticCodeIndexModule_all_pairs_shortest_paths_distribution_per_project.csv
 │   ├── SemanticCodeIndexModule_Topological_Sort.csv
 │   ├── SemanticCodeIndexModule_StronglyConnectedComponents_longest_paths_distribution.csv
+│   ├── AbstractnessScip.csv
+│   ├── InstabilityScip.csv
+│   ├── MainSequenceAbstractnessInstabilityDistanceScip.csv
+│   ├── IncomingPackageDependenciesScip.csv
+│   ├── OutgoingPackageDependenciesScip.csv
 │   └── Graph_Visualizations/
+│       ├── ScipModuleBuildLevels.{csv,dot,svg}   # SCC-based build level graph
 │       ├── ScipModuleLongestPathsIsolated.{csv,dot,svg}
 │       └── ScipModuleLongestPaths.{csv,dot,svg}
 └── SCIP_Semantic_Index_Artifact/
+    ├── List_all_SCIP_artifacts.csv
     ├── SemanticCodeIndexArtifact_all_pairs_shortest_paths_distribution_per_project.csv
     ├── SemanticCodeIndexArtifact_Topological_Sort.csv
     ├── SemanticCodeIndexArtifact_StronglyConnectedComponents_longest_paths_distribution.csv
     └── Graph_Visualizations/
+        ├── ScipArtifactBuildLevels.{csv,dot,svg}   # SCC-based build level graph
         ├── ScipArtifactLongestPathsIsolated.{csv,dot,svg}
         └── ScipArtifactLongestPaths.{csv,dot,svg}
 ```
@@ -178,10 +195,33 @@ Python-generated charts from [pathFindingCharts.py](./pathFindingCharts.py):
 - **Java Artifact**: all-pairs shortest path (bar, pie) + longest path (bar, pie)
 - **TypeScript Module**: all-pairs shortest path and longest path charts (same set as Java Package)
 - **NPM packages**: same chart pattern where data exists
+- **SCIP Module**: all-pairs shortest path charts + SCC-based longest path charts (bar, pie, stacked log, stacked normalised, max per project)
+- **SCIP Artifact**: all-pairs shortest path (bar, pie) + SCC-based longest path (bar, pie)
+
+Python-generated charts from [objectOrientedDesignMetricsCharts.py](./objectOrientedDesignMetricsCharts.py):
+
+- **Java Package**: Main Sequence scatter plot + incoming/outgoing dependency bar charts (with and without sub-packages)
+- **TypeScript Module**: Main Sequence scatter plot + incoming/outgoing dependency bar charts
+- **SCIP Module**: Main Sequence scatter plot (`SCIP_Module_MainSequence.svg`) + incoming/outgoing dependency bar charts
 
 ### Markdown Summary (`reports/internal-dependencies/internal_dependencies_report.md`)
 
-A structured report covering cyclic dependencies, internal structure analysis, path finding insights, topological build levels, graph visualizations, and a glossary.
+A structured report covering internal structure, path finding insights, topological build levels, graph visualizations, OO design metrics, visibility metrics, and a glossary.
+
+Sections:
+- **Section 2**: Java internal structure (artifact listing, ISP candidates, widely used types)
+- **Section 3**: TypeScript internal structure (module listing, widely used elements)
+- **Section 3.4**: SCIP Semantic Index structure (module listing, artifact listing, internal types topological sort CSV link)
+- **Section 4**: Path finding (APSP + longest path for Java, TypeScript, NPM)
+- **Section 4.4**: SCIP Semantic Index path finding (APSP + SCC-based longest path for modules and artifacts)
+- **Section 5**: Topological sort critical path lengths (all abstraction levels including SCIP)
+- **Section 6**: Graph visualizations (Java, TypeScript, NPM)
+- **Section 6.4**: SCIP Semantic Index graphs (SCC build level graphs + longest path visualizations; types excluded - too large)
+- **Section 7**: Glossary and column definitions
+- **Section 8**: OO Design Metrics (Java packages, TypeScript modules)
+- **Section 8.4**: SCIP Semantic Index OO Design Metrics (Main Sequence scatter + dependency bar charts for modules)
+- **Section 9**: Visibility metrics (Java, TypeScript)
+- **Section 10**: Code vocabulary word cloud
 
 ## Breaking Change Note
 

--- a/domains/internal-dependencies/explore/InternalDependenciesScip.ipynb
+++ b/domains/internal-dependencies/explore/InternalDependenciesScip.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b87fa8d2",
+   "metadata": {},
+   "source": [
+    "# Internal Dependencies — SCIP Semantic Index\n",
+    "<br>\n",
+    "\n",
+    "Explores SCIP (Semantic Code Intelligence Protocol) module and artifact dependency structure.\n",
+    "SCIP indexes are language-agnostic and support TypeScript, Go, Rust, and other languages.\n",
+    "\n",
+    "### References\n",
+    "- [SCIP — Semantic Code Intelligence Protocol](https://github.com/sourcegraph/scip)\n",
+    "- [code-graph-analysis-pipeline — SCIP support](../../SCIP.md)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63557e62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5267d28d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\".\n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f15407",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(cypher_file_name: str) -> str:\n",
+    "    with open(cypher_file_name) as file:\n",
+    "        return ' '.join(file.readlines())\n",
+    "\n",
+    "\n",
+    "def query_cypher_to_data_frame(filename: str, limit: int = -1) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Execute the Cypher query of the given file and returns the result as a DataFrame.\n",
+    "\n",
+    "    Args:\n",
+    "        filename: Path to the file containing the Cypher query.\n",
+    "        limit: Optional row limit appended to the query. Default -1 = no limit.\n",
+    "    \"\"\"\n",
+    "    cypher_query = get_cypher_query_from_file(filename)\n",
+    "    if limit > 0:\n",
+    "        cypher_query = f\"{cypher_query}\\nLIMIT {limit}\"\n",
+    "    records, summary, keys = driver.execute_query(cypher_query)\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed08b4d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf42aceb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "325629b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pandas DataFrame Display Configuration\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22a9020f",
+   "metadata": {},
+   "source": [
+    "## 1 — SCIP Modules\n",
+    "\n",
+    "SCIP modules correspond to source directories. The following tables sort modules by different metrics to highlight central or leaf modules.\n",
+    "\n",
+    "The full list is in the CSV report: `reports/internal-dependencies/SCIP_Semantic_Index_Module/List_all_SCIP_modules.csv`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "350875d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules = query_cypher_to_data_frame(\"../queries/internal-dependencies/List_all_SCIP_modules.cypher\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7cf4741",
+   "metadata": {},
+   "source": [
+    "### Table 1a — Top 30 modules with the highest type count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "548eeedc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['numberOfTypes', 'moduleName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87e9e396",
+   "metadata": {},
+   "source": [
+    "### Table 1b — Top 30 modules with the highest number of incoming dependencies\n",
+    "\n",
+    "High incoming = widely imported by other modules (high in-degree)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33a45362",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['incomingDependencies', 'moduleName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d76ae0af",
+   "metadata": {},
+   "source": [
+    "### Table 1c — Top 30 modules with the highest number of outgoing dependencies\n",
+    "\n",
+    "High outgoing = broad consumer depending on many other modules (high out-degree)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59acc3b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['outgoingDependencies', 'moduleName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7823f635",
+   "metadata": {},
+   "source": [
+    "### Table 1d — Top 30 modules with the lowest type count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34e301ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['numberOfTypes', 'moduleName'], ascending=[True, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d61102c4",
+   "metadata": {},
+   "source": [
+    "### Table 1e — Top 30 modules with the lowest number of incoming dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be9aed89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['incomingDependencies', 'moduleName'], ascending=[True, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8ee761e",
+   "metadata": {},
+   "source": [
+    "### Table 1f — Top 30 modules with the lowest number of outgoing dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a370d47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules.sort_values(by=['outgoingDependencies', 'moduleName'], ascending=[True, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd945318",
+   "metadata": {},
+   "source": [
+    "### Table 1g — Test modules only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e46438f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_modules[scip_modules['isTest'] == True].sort_values(by=['numberOfTypes', 'moduleName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd077702",
+   "metadata": {},
+   "source": [
+    "## 2 — SCIP Artifacts\n",
+    "\n",
+    "SCIP artifacts correspond to packages (npm, go module, cargo crate, etc.).\n",
+    "\n",
+    "The full list is in the CSV report: `reports/internal-dependencies/SCIP_Semantic_Index_Artifact/List_all_SCIP_artifacts.csv`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b85700a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifacts = query_cypher_to_data_frame(\"../queries/internal-dependencies/List_all_SCIP_artifacts.cypher\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "129bcf0c",
+   "metadata": {},
+   "source": [
+    "### Table 2a — Top 30 artifacts with the highest number of incoming dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36ae5f6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifacts.sort_values(by=['incomingDependencies', 'artifactName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa06c980",
+   "metadata": {},
+   "source": [
+    "### Table 2b — Top 30 artifacts with the highest number of outgoing dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "237a0644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifacts.sort_values(by=['outgoingDependencies', 'artifactName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abd1abf0",
+   "metadata": {},
+   "source": [
+    "### Table 2c — Internal artifacts only (not external libraries)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59054d60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifacts[scip_artifacts['isExternal'] == False].sort_values(by=['incomingDependencies', 'artifactName'], ascending=[False, True]).reset_index(drop=True).head(30)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "code-graph-analysis-pipeline (3.12.8.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/domains/internal-dependencies/explore/ObjectOrientedDesignMetricsScip.ipynb
+++ b/domains/internal-dependencies/explore/ObjectOrientedDesignMetricsScip.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "952109d2",
+   "metadata": {},
+   "source": [
+    "# Object Oriented Design Metrics — SCIP Semantic Index\n",
+    "<br>\n",
+    "\n",
+    "Applies OO Design Metrics (Robert C. Martin's Stable Abstractions Principle) to SCIP Semantic Index modules.\n",
+    "\n",
+    "**Abstractness**: ratio of abstract types to total types per module. `isAbstract = true` on `SemanticCodeIndexInternalType` nodes.\n",
+    "\n",
+    "**Instability**: ratio of outgoing to total (outgoing + incoming) module-level `DEPENDS_ON` relationships.\n",
+    "\n",
+    "**Main Sequence**: ideal balance line where `Abstractness + Instability = 1`.\n",
+    "\n",
+    "**Zone of Pain**: concrete + stable = hard to change without breaking dependents.  \n",
+    "**Zone of Uselessness**: abstract + unstable = over-designed, unlikely to be used.\n",
+    "\n",
+    "Visibility metrics are not applicable for SCIP modules and are omitted.\n",
+    "\n",
+    "### References\n",
+    "- [Analyze java package metrics in a graph database](https://joht.github.io/johtizen/data/2023/04/21/java-package-metrics-analysis.html)\n",
+    "- [Calculate metrics](https://101.jqassistant.org/calculate-metrics/index.html)\n",
+    "- [Neo4j Python Driver](https://neo4j.com/docs/api/python-driver/current)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64606f35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5190f715",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\".\n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d0c0185",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(cypher_file_name: str) -> str:\n",
+    "    with open(cypher_file_name) as file:\n",
+    "        return ' '.join(file.readlines())\n",
+    "\n",
+    "\n",
+    "def query_cypher_to_data_frame(filename: str, limit: int = -1) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Execute the Cypher query of the given file and return the result as a DataFrame.\n",
+    "\n",
+    "    Args:\n",
+    "        filename: Path to the file containing the Cypher query.\n",
+    "        limit: Optional row limit appended to the query. Default -1 = no limit.\n",
+    "    \"\"\"\n",
+    "    cypher_query = get_cypher_query_from_file(filename)\n",
+    "    if limit > 0:\n",
+    "        cypher_query = f\"{cypher_query}\\nLIMIT {limit}\"\n",
+    "    records, summary, keys = driver.execute_query(cypher_query)\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)\n",
+    "\n",
+    "\n",
+    "def query_first_non_empty_cypher_to_data_frame(*filenames: str, limit: int = -1) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Execute the Cypher queries of the given files and return the first non-empty result.\n",
+    "\n",
+    "    If all queries return empty results, the last (empty) result is returned.\n",
+    "    The second file is typically a SET query that writes and returns data when the\n",
+    "    GET query (first file) returns nothing (property not yet set).\n",
+    "    \"\"\"\n",
+    "    result = pd.DataFrame()\n",
+    "    for filename in filenames:\n",
+    "        result = query_cypher_to_data_frame(filename, limit)\n",
+    "        if not result.empty:\n",
+    "            return result\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2472e114",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a38f5ca5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9b098c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colormap for Main Sequence scatter: green (near main sequence) → red (far away)\n",
+    "MAIN_SEQUENCE_COLORMAP = LinearSegmentedColormap.from_list(\n",
+    "    \"main_sequence\", [\"green\", \"gold\", \"orangered\", \"red\"], N=256\n",
+    ")\n",
+    "\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "550878e0",
+   "metadata": {},
+   "source": [
+    "## 1 — Incoming Dependencies\n",
+    "\n",
+    "Incoming dependencies are also denoted as \"Fan-in\", \"Afferent Coupling\", or \"in-degree\".\n",
+    "These are modules that depend on the listed module. High incoming = widely used, hard to change safely.\n",
+    "\n",
+    "The `incomingDependencies` property is set during SCIP enrichment in the scip-index-import domain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cb666d5",
+   "metadata": {},
+   "source": [
+    "#### Table 1a — Top 20 SCIP modules with the most incoming dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb8a73d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher\",\n",
+    "    limit=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c679fe12",
+   "metadata": {},
+   "source": [
+    "## 2 — Outgoing Dependencies\n",
+    "\n",
+    "Outgoing dependencies are also denoted as \"Fan-out\", \"Efferent Coupling\", or \"out-degree\".\n",
+    "These are modules that this module depends on. High outgoing = broad consumer; sensitive to upstream changes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0659b58",
+   "metadata": {},
+   "source": [
+    "#### Table 2a — Top 20 SCIP modules with the most outgoing dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3a60ab2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Get_Outgoing_SCIP_Module_Dependencies.cypher\",\n",
+    "    limit=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47831aea",
+   "metadata": {},
+   "source": [
+    "## 3 — Instability\n",
+    "\n",
+    "$$Instability = \\frac{Outgoing\\:Dependencies}{Outgoing\\:Dependencies + Incoming\\:Dependencies}$$\n",
+    "\n",
+    "*Instability* measures how many changes in other modules could force this module to change.\n",
+    "- `0` = fully stable (only incoming, no outgoing) — risky to change, others depend on it.\n",
+    "- `1` = fully unstable (only outgoing, no incoming) — free to change, nothing depends on it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d839716",
+   "metadata": {},
+   "source": [
+    "#### Table 3a — Top 20 SCIP modules with the lowest Instability\n",
+    "\n",
+    "Sets the `instability` property on module nodes if not already done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0db16b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_first_non_empty_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher\",\n",
+    "    \"../queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher\",\n",
+    "    limit=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fde0b36c",
+   "metadata": {},
+   "source": [
+    "## 4 — Abstractness\n",
+    "\n",
+    "$$Abstractness = \\frac{Abstract\\:Types}{Total\\:Types}$$\n",
+    "\n",
+    "*Abstractness* = ratio of abstract types to total types per module.\n",
+    "A `SemanticCodeIndexInternalType` is abstract when `isAbstract = true`.\n",
+    "\n",
+    "- `0` = fully concrete — easy to use, but hard to extend without modification.\n",
+    "- `1` = fully abstract — all types are abstract/interface; flexible but requires concrete implementations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1603fbc6",
+   "metadata": {},
+   "source": [
+    "#### Table 4a — Top 20 SCIP modules with the lowest Abstractness\n",
+    "\n",
+    "Sets `numberOfAbstractTypes`, `numberOfTypes`, and `abstractness` on module nodes if not already done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e483027a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Count_and_set_abstract_types_for_SCIP must run before Calculate_and_set_Abstractness_for_SCIP\n",
+    "query_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Count_and_set_abstract_types_for_SCIP.cypher\"\n",
+    ")\n",
+    "\n",
+    "query_first_non_empty_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Get_Abstractness_for_SCIP.cypher\",\n",
+    "    \"../queries/object-oriented-design-metrics/Calculate_and_set_Abstractness_for_SCIP.cypher\",\n",
+    "    limit=20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92a71f33",
+   "metadata": {},
+   "source": [
+    "## 5 — Distance from Main Sequence\n",
+    "\n",
+    "$$Distance = |Abstractness + Instability - 1|$$\n",
+    "\n",
+    "The **Main Sequence** is the ideal diagonal where `A + I = 1`. Distance measures how far a module deviates.\n",
+    "\n",
+    "- **Zone of Pain** (`A ≈ 0, I ≈ 0`): concrete + stable = risky, hard to change.\n",
+    "- **Zone of Uselessness** (`A ≈ 1, I ≈ 1`): abstract + unstable = over-designed, likely unused."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3e5ac7b",
+   "metadata": {},
+   "source": [
+    "#### Table 5a — Top 20 SCIP modules furthest from Main Sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea850094",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "main_sequence_data = query_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher\",\n",
+    "    limit=20,\n",
+    ")\n",
+    "main_sequence_data.head(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a9ffd04",
+   "metadata": {},
+   "source": [
+    "#### Chart 5b — Main Sequence scatter plot\n",
+    "\n",
+    "- X-axis: Abstractness (0 = concrete, 1 = abstract)\n",
+    "- Y-axis: Instability (0 = stable, 1 = unstable)\n",
+    "- Point size: number of types (larger = more types in module)\n",
+    "- Color: distance from Main Sequence (green = near, red = far)\n",
+    "- Green dashed diagonal = Main Sequence ideal line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8dc74c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_main_sequence_data = query_cypher_to_data_frame(\n",
+    "    \"../queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher\"\n",
+    ")\n",
+    "\n",
+    "if not all_main_sequence_data.empty and {'abstractness', 'instability', 'elementsCount', 'distance'}.issubset(all_main_sequence_data.columns):\n",
+    "    marker_scales = all_main_sequence_data['elementsCount'].clip(lower=2, upper=300) * 0.7\n",
+    "\n",
+    "    figure, axis = plot.subplots(figsize=(10, 8))\n",
+    "    scatter = axis.scatter(\n",
+    "        all_main_sequence_data['abstractness'],\n",
+    "        all_main_sequence_data['instability'],\n",
+    "        s=marker_scales,\n",
+    "        c=all_main_sequence_data['distance'],\n",
+    "        cmap=MAIN_SEQUENCE_COLORMAP,\n",
+    "        alpha=0.5,\n",
+    "    )\n",
+    "    axis.plot([0, 1], [1, 0], color='lightgreen', linestyle='dashed', label='Main Sequence')\n",
+    "    figure.colorbar(scatter, ax=axis, label='Distance from Main Sequence')\n",
+    "    axis.set_title('SCIP Modules — Abstractness vs. Instability (Main Sequence)')\n",
+    "    axis.set_xlabel('Abstractness')\n",
+    "    axis.set_ylabel('Instability')\n",
+    "    axis.set_xlim(-0.05, 1.05)\n",
+    "    axis.set_ylim(-0.05, 1.05)\n",
+    "    axis.legend(loc='upper right')\n",
+    "    plot.tight_layout()\n",
+    "    plot.show()\n",
+    "else:\n",
+    "    print(\"No data available for Main Sequence scatter plot.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "464b4ecb",
+   "metadata": {},
+   "source": [
+    "#### Table 5c — Modules in Zone of Pain (concrete + stable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e6eb3af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not all_main_sequence_data.empty:\n",
+    "    zone_of_pain = all_main_sequence_data.query('abstractness <= 0.3 and instability <= 0.3').head(20)\n",
+    "    print(f\"Zone of Pain modules: {len(zone_of_pain)}\")\n",
+    "    zone_of_pain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60aac4f",
+   "metadata": {},
+   "source": [
+    "#### Table 5d — Modules in Zone of Uselessness (abstract + unstable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbac5236",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not all_main_sequence_data.empty:\n",
+    "    zone_of_uselessness = all_main_sequence_data.query('abstractness >= 0.7 and instability >= 0.7').head(20)\n",
+    "    print(f\"Zone of Uselessness modules: {len(zone_of_uselessness)}\")\n",
+    "    zone_of_uselessness"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "code-graph-analysis-pipeline (3.12.8.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/domains/internal-dependencies/explore/PathFindingScip.ipynb
+++ b/domains/internal-dependencies/explore/PathFindingScip.ipynb
@@ -1,0 +1,866 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3f3c0c79",
+   "metadata": {},
+   "source": [
+    "# Path Finding — SCIP Semantic Index\n",
+    "\n",
+    "Demonstrates path finding algorithms applied to SCIP Semantic Index module and artifact dependency graphs.\n",
+    "\n",
+    "**Key difference from TypeScript/Java path finding:**  \n",
+    "SCIP dependency graphs may contain cycles (circular module dependencies). The longest path algorithm requires a Directed Acyclic Graph (DAG). To handle cycles, Strongly Connected Components (SCC) are computed first — each cycle is condensed into a single SCC component node. Path finding then runs on the acyclic component graph (DAG).\n",
+    "\n",
+    "**All Pairs Shortest Path (APSP)** works on the original graph (handles cycles naturally).  \n",
+    "**Longest Path** runs on the SCC component DAG.\n",
+    "\n",
+    "### References\n",
+    "- [SCIP — Semantic Code Intelligence Protocol](https://github.com/sourcegraph/scip)\n",
+    "- [Neo4j GDS — All Pairs Shortest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/all-pairs-shortest-path)\n",
+    "- [Neo4j GDS — Longest Path](https://neo4j.com/docs/graph-data-science/current/algorithms/dag/longest-path)\n",
+    "- [Neo4j GDS — Strongly Connected Components](https://neo4j.com/docs/graph-data-science/current/algorithms/strongly-connected-components)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffff5e4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import typing\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plot\n",
+    "import numpy as np\n",
+    "from neo4j import GraphDatabase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b42d94f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please set the environment variable \"NEO4J_INITIAL_PASSWORD\" in your shell \n",
+    "# before starting jupyter notebook to provide the password for the user \"neo4j\".\n",
+    "# It is not recommended to hardcode the password into jupyter notebook for security reasons.\n",
+    "\n",
+    "driver = GraphDatabase.driver(uri=\"bolt://localhost:7687\", auth=(\"neo4j\", os.environ.get(\"NEO4J_INITIAL_PASSWORD\")))\n",
+    "driver.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dab21526",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#The following cell uses the build-in %html \"magic\" to override the CSS style for tables to a much smaller size.\n",
+    "#This is especially needed for PDF export of tables with multiple columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14e90f7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "/* CSS style for smaller dataframe tables. */\n",
+    ".dataframe th {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    ".dataframe td {\n",
+    "    font-size: 8px;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05c879df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAIN_COLOR_MAP = 'nipy_spectral'\n",
+    "\n",
+    "pd.set_option('display.max_colwidth', 300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f2e68f9",
+   "metadata": {},
+   "source": [
+    "## Helper functions\n",
+    "\n",
+    "### Query helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5253f286",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cypher_query_from_file(filename: str) -> str:\n",
+    "    \"\"\"Read and join all lines of a Cypher file into a single query string.\"\"\"\n",
+    "    with open(filename) as file:\n",
+    "        return ' '.join(file.readlines())\n",
+    "\n",
+    "\n",
+    "def query_cypher_to_data_frame(\n",
+    "    filename: str,\n",
+    "    parameters: typing.Optional[typing.Dict[str, typing.Any]] = None,\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Execute the Cypher query from a file and return the result as a DataFrame.\n",
+    "\n",
+    "    Args:\n",
+    "        filename: Path to the file containing the Cypher query.\n",
+    "        parameters: Optional dict of Cypher parameters.\n",
+    "    \"\"\"\n",
+    "    records, summary, keys = driver.execute_query(\n",
+    "        get_cypher_query_from_file(filename),\n",
+    "        parameters_=parameters or {},\n",
+    "    )\n",
+    "    return pd.DataFrame([r.values() for r in records], columns=keys)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3868d25c",
+   "metadata": {},
+   "source": [
+    "### Projection helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19f00083",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_directed_unweighted_projection(parameters: dict) -> bool:\n",
+    "    \"\"\"\n",
+    "    Create a directed unweighted in-memory GDS projection with filtered subgraph.\n",
+    "\n",
+    "    Returns True when data exists for the given node label, False when the graph has no matching nodes.\n",
+    "    The projection name is derived from `parameters['dependencies_projection']`.\n",
+    "    Creates both the projection and a \"-cleaned\" subgraph (filtering out zero-degree nodes).\n",
+    "    \"\"\"\n",
+    "    data_projectable = query_cypher_to_data_frame(\n",
+    "        \"../../../cypher/Dependencies_Projection/Dependencies_0_Check_Projectable.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    if data_projectable.empty:\n",
+    "        print(f\"No data for node label '{parameters.get('dependencies_projection_node')}'.\")\n",
+    "        return False\n",
+    "    \n",
+    "    # Prepare projection (fill in default values for missing properties)\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../../../cypher/Dependencies_Projection/Dependencies_0_Prepare_Projection.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    \n",
+    "    # Delete existing projections and subgraphs\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../../../cypher/Dependencies_Projection/Dependencies_1_Delete_Projection.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../../../cypher/Dependencies_Projection/Dependencies_2_Delete_Subgraph.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    \n",
+    "    # Create the projection\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/path-finding/Path_Finding_1_Create_Projection.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    \n",
+    "    # Create filtered subgraph without zero-degree nodes (generic approach)\n",
+    "    # This uses GDS degree centrality to identify nodes with at least one relationship\n",
+    "    projection_name = parameters.get(\"dependencies_projection\")\n",
+    "    cleaned_name = projection_name + \"-cleaned\"\n",
+    "    \n",
+    "    filter_query = f\"\"\"\n",
+    "    CALL gds.graph.filter(\n",
+    "        '{cleaned_name}',\n",
+    "        '{projection_name}',\n",
+    "        'true',\n",
+    "        '*'\n",
+    "    )\n",
+    "    YIELD graphName, nodeCount, relationshipCount\n",
+    "    RETURN graphName, nodeCount, relationshipCount\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    subgraph_result = driver.execute_query(filter_query)\n",
+    "    records, summary, keys = subgraph_result\n",
+    "    \n",
+    "    # Check if subgraph was created with relationships\n",
+    "    if records and len(records) > 0:\n",
+    "        result_dict = {k: v for k, v in zip(keys, records[0].values())}\n",
+    "        relationship_count = result_dict.get(\"relationshipCount\", 0)\n",
+    "        if relationship_count > 0:\n",
+    "            return True\n",
+    "    \n",
+    "    print(f\"No relationships in subgraph for projection '{projection_name}'.\")\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec01642",
+   "metadata": {},
+   "source": [
+    "### SCC helpers\n",
+    "\n",
+    "The following functions implement the cycle-handling pipeline used for SCIP path finding.\n",
+    "Each step is idempotent: it checks whether its output already exists before re-running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f126054",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ensure_scc_computed(parameters: dict) -> None:\n",
+    "    \"\"\"\n",
+    "    Detect and write Strongly Connected Component IDs to member nodes (idempotent).\n",
+    "\n",
+    "    Skips SCC detection when communityStronglyConnectedComponentId is already set.\n",
+    "    Always re-creates StronglyConnectedComponent nodes and their DEPENDS_ON edges\n",
+    "    using MERGE, so repeated calls are safe.\n",
+    "    \"\"\"\n",
+    "    scc_exists = query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_Exists.cypher\", parameters\n",
+    "    )\n",
+    "    if scc_exists.empty:\n",
+    "        print(\"Writing SCC component IDs to nodes...\")\n",
+    "        query_cypher_to_data_frame(\n",
+    "            \"../queries/strongly-connected-components/SCC_Write.cypher\", parameters\n",
+    "        )\n",
+    "    else:\n",
+    "        print(\"SCC component IDs already present, skipping detection.\")\n",
+    "\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_CreateNode.cypher\", parameters\n",
+    "    )\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_CreateDependency.cypher\", parameters\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def recreate_scc_components_projection(parameters: dict) -> None:\n",
+    "    \"\"\"\n",
+    "    Drop and recreate the ephemeral in-memory -components GDS projection.\n",
+    "\n",
+    "    The -components projection is not persisted across Neo4j restarts. It is always\n",
+    "    recreated here so downstream algorithms have a fresh, consistent view.\n",
+    "    Prerequisites: ensure_scc_computed() must have run at least once.\n",
+    "    \"\"\"\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_TopologicalSort_Delete_Projection.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_TopologicalSort_Projection.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def ensure_scc_topology_sorted(parameters: dict) -> None:\n",
+    "    \"\"\"\n",
+    "    Compute topological sort on the SCC component DAG and propagate levels to member nodes (idempotent).\n",
+    "\n",
+    "    Skips writing when topologicalSortMaxDistanceFromSource is already set on component nodes.\n",
+    "    Topological sort values are required for level labels in GraphViz visualizations and\n",
+    "    for the build level groupings in the longest path charts.\n",
+    "    Prerequisites: recreate_scc_components_projection() must have run in this session.\n",
+    "    \"\"\"\n",
+    "    topology_exists = query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_TopologicalSort_Exists.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "    if topology_exists.empty:\n",
+    "        print(\"Writing topological sort to SCC components...\")\n",
+    "        query_cypher_to_data_frame(\n",
+    "            \"../queries/strongly-connected-components/SCC_TopologicalSort_Write.cypher\",\n",
+    "            parameters,\n",
+    "        )\n",
+    "    else:\n",
+    "        print(\"Topological sort already present on SCC components, skipping.\")\n",
+    "\n",
+    "    query_cypher_to_data_frame(\n",
+    "        \"../queries/strongly-connected-components/SCC_TopologicalSort_Propagate.cypher\",\n",
+    "        parameters,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def setup_scc_for_longest_path(parameters: dict) -> None:\n",
+    "    \"\"\"\n",
+    "    Full SCC pipeline required before running the SCC-based longest path algorithm.\n",
+    "\n",
+    "    Runs in order:\n",
+    "    1. Detect and write SCC component IDs (idempotent).\n",
+    "    2. Recreate the in-memory -components projection (always fresh).\n",
+    "    3. Compute topological sort on the component DAG (idempotent).\n",
+    "\n",
+    "    Args:\n",
+    "        parameters: Dict with keys dependencies_projection, dependencies_projection_node,\n",
+    "                    dependencies_projection_weight_property.\n",
+    "    \"\"\"\n",
+    "    ensure_scc_computed(parameters)\n",
+    "    recreate_scc_components_projection(parameters)\n",
+    "    ensure_scc_topology_sorted(parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3341aaf8",
+   "metadata": {},
+   "source": [
+    "### Distribution analysis helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd836900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_total_distance_distribution(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"Aggregate path count per distance across all projects.\"\"\"\n",
+    "    return (\n",
+    "        data_frame\n",
+    "        .groupby('distance')[['pairCount', 'distanceTotalPairCount']]\n",
+    "        .agg({'pairCount': 'sum', 'distanceTotalPairCount': 'max'})\n",
+    "        .reset_index()\n",
+    "        .sort_values('distance')\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def get_max_distance_per_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"Return the maximum distance (diameter) per source project, sorted descending.\"\"\"\n",
+    "    return (\n",
+    "        data_frame\n",
+    "        .groupby('sourceProject')['distance']\n",
+    "        .max()\n",
+    "        .reset_index()\n",
+    "        .rename(columns={'distance': 'maxDistance'})\n",
+    "        .sort_values('maxDistance', ascending=False)\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def pivot_distribution_by_project(data_frame: pd.DataFrame) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Pivot the per-project distribution into wide format (rows=distance, columns=project).\n",
+    "\n",
+    "    Only includes intra-project pairs (isDifferentTargetProject == False).\n",
+    "    \"\"\"\n",
+    "    intra = data_frame[data_frame['isDifferentTargetProject'] == False].copy()\n",
+    "    if intra.empty:\n",
+    "        return pd.DataFrame()\n",
+    "    return intra.pivot_table(\n",
+    "        index='distance',\n",
+    "        columns='sourceProject',\n",
+    "        values='pairCount',\n",
+    "        aggfunc='sum',\n",
+    "        fill_value=0,\n",
+    "    ).sort_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b553183",
+   "metadata": {},
+   "source": [
+    "### Chart helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f42c942f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_distance_bar(data_frame: pd.DataFrame, title: str, ylabel: str = 'Number of paths') -> None:\n",
+    "    \"\"\"Bar chart of path count per distance.\"\"\"\n",
+    "    if data_frame.empty:\n",
+    "        print(f\"No data for: {title}\")\n",
+    "        return\n",
+    "    figure, axis = plot.subplots(figsize=(10, 5))\n",
+    "    data_frame.plot(kind='bar', x='distance', y='pairCount', ax=axis,\n",
+    "                    legend=False, grid=True, fontsize=8, cmap=MAIN_COLOR_MAP,\n",
+    "                    xlabel='Distance (number of hops)', ylabel=ylabel, title=title)\n",
+    "    axis.tick_params(axis='x', labelrotation=45)\n",
+    "    figure.tight_layout()\n",
+    "    plot.show()\n",
+    "\n",
+    "\n",
+    "def plot_distance_pie(data_frame: pd.DataFrame, title: str) -> None:\n",
+    "    \"\"\"Pie chart of path count by distance.\"\"\"\n",
+    "    if data_frame.empty:\n",
+    "        print(f\"No data for: {title}\")\n",
+    "        return\n",
+    "    total = data_frame['pairCount'].sum()\n",
+    "\n",
+    "    def autopct(pct: float) -> str:\n",
+    "        return f'{pct:1.2f}% ({int(round(total * pct / 100))})'\n",
+    "\n",
+    "    figure, axis = plot.subplots(figsize=(8, 8))\n",
+    "    data_frame.plot(kind='pie', y='pairCount', labels=data_frame['distance'],\n",
+    "                    labeldistance=None, legend=True, autopct=autopct,\n",
+    "                    explode=np.full(len(data_frame), 0.01),\n",
+    "                    textprops={'fontsize': 8}, pctdistance=1.2,\n",
+    "                    cmap=MAIN_COLOR_MAP, ax=axis, title=title)\n",
+    "    axis.set_ylabel('')\n",
+    "    axis.legend(bbox_to_anchor=(1.05, 1), loc='upper left', title='distance')\n",
+    "    figure.tight_layout()\n",
+    "    plot.show()\n",
+    "\n",
+    "\n",
+    "def plot_diameter_bar(data_frame: pd.DataFrame, title: str) -> None:\n",
+    "    \"\"\"Bar chart of max distance (diameter) per project, descending.\"\"\"\n",
+    "    if data_frame.empty:\n",
+    "        print(f\"No data for: {title}\")\n",
+    "        return\n",
+    "    top = data_frame.head(20)\n",
+    "    figure, axis = plot.subplots(figsize=(max(10, len(top) * 0.8 + 2), 5))\n",
+    "    top.plot(kind='bar', x='sourceProject', y='maxDistance', ax=axis,\n",
+    "             legend=False, grid=True, fontsize=8, cmap=MAIN_COLOR_MAP,\n",
+    "             xlabel='Project', ylabel='Max distance', title=title)\n",
+    "    axis.tick_params(axis='x', labelrotation=45)\n",
+    "    figure.tight_layout()\n",
+    "    plot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4260a121",
+   "metadata": {},
+   "source": [
+    "## 1 — SCIP Module Path Finding\n",
+    "\n",
+    "### 1.1 All Pairs Shortest Path (APSP)\n",
+    "\n",
+    "Operates on the full SCIP module dependency graph. Cycles are handled naturally by the BFS-based algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd09cee2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_module_parameters = {\n",
+    "    \"dependencies_projection\": \"scip-module-path-finding-notebook\",\n",
+    "    \"dependencies_projection_node\": \"SemanticCodeIndexModule\",\n",
+    "    \"dependencies_projection_weight_property\": \"referenceCount\",\n",
+    "    \"dependencies_projection_language\": \"SCIP_Semantic_Index\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4f4862f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_scip_module_data_available = create_directed_unweighted_projection(scip_module_parameters)\n",
+    "print(f\"SCIP Module projection available: {is_scip_module_data_available}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cac586ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if is_scip_module_data_available:\n",
+    "    scip_module_apsp = query_cypher_to_data_frame(\n",
+    "        \"../queries/path-finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher\",\n",
+    "        scip_module_parameters,\n",
+    "    )\n",
+    "else:\n",
+    "    scip_module_apsp = pd.DataFrame()\n",
+    "\n",
+    "print(f\"APSP rows: {len(scip_module_apsp)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ffc4541",
+   "metadata": {},
+   "source": [
+    "#### 1.1.1 APSP total distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0ec99cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_module_apsp_total = get_total_distance_distribution(scip_module_apsp)\n",
+    "scip_module_apsp_total.head(30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff635731",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_distance_bar(scip_module_apsp_total, 'SCIP Module — All Pairs Shortest Path Distribution')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccc396aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_distance_pie(scip_module_apsp_total, 'SCIP Module — All Pairs Shortest Path by Distance')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1ed099e",
+   "metadata": {},
+   "source": [
+    "#### 1.1.2 APSP graph diameter per project\n",
+    "\n",
+    "The graph diameter is the longest shortest path. Higher = deeper transitive dependency chains."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57a420df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_module_apsp_diameter = get_max_distance_per_project(scip_module_apsp)\n",
+    "scip_module_apsp_diameter.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74423cf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_diameter_bar(scip_module_apsp_diameter, 'SCIP Module — Graph Diameter per Project')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6a4f255",
+   "metadata": {},
+   "source": [
+    "### 1.2 SCC-based Longest Path\n",
+    "\n",
+    "Because the SCIP module graph may contain cycles, the Longest Path algorithm cannot run directly on it (it requires a DAG). The cycle-handling pipeline:\n",
+    "\n",
+    "1. **Detect SCCs**: Find Strongly Connected Components. Each cycle becomes one component.\n",
+    "2. **Build component graph**: Create `StronglyConnectedComponent` nodes and `DEPENDS_ON` edges.\n",
+    "3. **Recreate -components projection**: The GDS in-memory projection is ephemeral — recreated every session.\n",
+    "4. **Topological sort**: Assign build levels to each component node.\n",
+    "5. **Longest path**: Run on the condensed DAG. Each cycle contributes 1 level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f776d76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SCC longest path uses a separate projection name to avoid conflicts with the APSP projection above\n",
+    "scip_module_topology_parameters = {\n",
+    "    \"dependencies_projection\": \"scip-module-topology-notebook\",\n",
+    "    \"dependencies_projection_node\": \"SemanticCodeIndexModule\",\n",
+    "    \"dependencies_projection_weight_property\": \"referenceCount\",\n",
+    "    \"dependencies_projection_language\": \"SCIP_Semantic_Index\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70963175",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_scip_module_topology_available = create_directed_unweighted_projection(scip_module_topology_parameters)\n",
+    "print(f\"SCIP Module topology projection available: {is_scip_module_topology_available}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60a95d93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if is_scip_module_topology_available:\n",
+    "    setup_scc_for_longest_path(scip_module_topology_parameters)\n",
+    "    print(\"SCC pipeline complete.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15eaa68a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if is_scip_module_topology_available:\n",
+    "    scip_module_longest = query_cypher_to_data_frame(\n",
+    "        \"../queries/path-finding/SCC_Longest_paths_distribution_per_project.cypher\",\n",
+    "        scip_module_topology_parameters,\n",
+    "    )\n",
+    "else:\n",
+    "    scip_module_longest = pd.DataFrame()\n",
+    "\n",
+    "print(f\"SCC Longest Path rows: {len(scip_module_longest)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63846a61",
+   "metadata": {},
+   "source": [
+    "#### 1.2.1 SCC Longest Path total distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bc6ba69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_module_longest_total = get_total_distance_distribution(scip_module_longest)\n",
+    "scip_module_longest_total.head(30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0657fdf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_distance_bar(scip_module_longest_total, 'SCIP Module — SCC Longest Path Distribution')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92807735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_distance_pie(scip_module_longest_total, 'SCIP Module — SCC Longest Path by Distance')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9c2db4",
+   "metadata": {},
+   "source": [
+    "#### 1.2.2 SCC Longest Path — max per project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa37ff81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_module_longest_diameter = get_max_distance_per_project(scip_module_longest)\n",
+    "scip_module_longest_diameter.head(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e634fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_diameter_bar(scip_module_longest_diameter, 'SCIP Module — Max SCC Longest Path per Project')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c686868a",
+   "metadata": {},
+   "source": [
+    "## 2 — SCIP Artifact Path Finding\n",
+    "\n",
+    "Same pipeline as SCIP modules, but at the package/artifact level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf07d911",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifact_parameters = {\n",
+    "    \"dependencies_projection\": \"scip-artifact-path-finding-notebook\",\n",
+    "    \"dependencies_projection_node\": \"SemanticCodeIndexArtifact\",\n",
+    "    \"dependencies_projection_weight_property\": \"referenceCount\",\n",
+    "    \"dependencies_projection_language\": \"SCIP_Semantic_Index\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6377af8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_scip_artifact_data_available = create_directed_unweighted_projection(scip_artifact_parameters)\n",
+    "print(f\"SCIP Artifact projection available: {is_scip_artifact_data_available}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75f71509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if is_scip_artifact_data_available:\n",
+    "    scip_artifact_apsp = query_cypher_to_data_frame(\n",
+    "        \"../queries/path-finding/Path_Finding_5_All_pairs_shortest_path_distribution_per_project.cypher\",\n",
+    "        scip_artifact_parameters,\n",
+    "    )\n",
+    "else:\n",
+    "    scip_artifact_apsp = pd.DataFrame()\n",
+    "\n",
+    "print(f\"SCIP Artifact APSP rows: {len(scip_artifact_apsp)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "227a29fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifact_apsp_total = get_total_distance_distribution(scip_artifact_apsp)\n",
+    "scip_artifact_apsp_total.head(30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d59fb3f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_distance_bar(scip_artifact_apsp_total, 'SCIP Artifact — All Pairs Shortest Path Distribution')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "709b2a62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifact_apsp_diameter = get_max_distance_per_project(scip_artifact_apsp)\n",
+    "plot_diameter_bar(scip_artifact_apsp_diameter, 'SCIP Artifact — Graph Diameter per Project')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60830f50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifact_topology_parameters = {\n",
+    "    \"dependencies_projection\": \"scip-artifact-topology-notebook\",\n",
+    "    \"dependencies_projection_node\": \"SemanticCodeIndexArtifact\",\n",
+    "    \"dependencies_projection_weight_property\": \"referenceCount\",\n",
+    "    \"dependencies_projection_language\": \"SCIP_Semantic_Index\",\n",
+    "}\n",
+    "\n",
+    "is_scip_artifact_topology_available = create_directed_unweighted_projection(scip_artifact_topology_parameters)\n",
+    "\n",
+    "if is_scip_artifact_topology_available:\n",
+    "    setup_scc_for_longest_path(scip_artifact_topology_parameters)\n",
+    "    scip_artifact_longest = query_cypher_to_data_frame(\n",
+    "        \"../queries/path-finding/SCC_Longest_paths_distribution_per_project.cypher\",\n",
+    "        scip_artifact_topology_parameters,\n",
+    "    )\n",
+    "else:\n",
+    "    scip_artifact_longest = pd.DataFrame()\n",
+    "\n",
+    "print(f\"SCIP Artifact SCC Longest Path rows: {len(scip_artifact_longest)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81f94130",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scip_artifact_longest_total = get_total_distance_distribution(scip_artifact_longest)\n",
+    "plot_distance_bar(scip_artifact_longest_total, 'SCIP Artifact — SCC Longest Path Distribution')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "code-graph-analysis-pipeline (3.12.8.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/domains/internal-dependencies/graphs/internalDependenciesGraphs.sh
+++ b/domains/internal-dependencies/graphs/internalDependenciesGraphs.sh
@@ -237,6 +237,12 @@ SCIP_MODULE_WEIGHT="dependencies_projection_weight_property=referenceCount"
 if createDirectedDependencyProjection "${SCIP_LANGUAGE}" "${SCIP_MODULE_PROJECTION}" "${SCIP_MODULE_NODE}" "${SCIP_MODULE_WEIGHT}"; then
     setupStronglyConnectedComponentsForSccVisualization "${SCIP_MODULE_PROJECTION}" "${SCIP_MODULE_NODE}" "${SCIP_MODULE_WEIGHT}"
 
+    echo "${SCRIPT_NAME}: Creating visualization ScipModuleBuildLevels..."
+    execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/SCIP_SCC_Module_build_levels_for_graphviz.cypher" \
+        "${SCIP_MODULE_PROJECTION}" "${SCIP_MODULE_NODE}" "${SCIP_MODULE_WEIGHT}" \
+        > "${SCIP_MODULE_GRAPH_VIZ_DIR}/ScipModuleBuildLevels.csv"
+    source "${VISUALIZATION_SCRIPTS_DIR}/visualizeQueryResults.sh" "${SCIP_MODULE_GRAPH_VIZ_DIR}/ScipModuleBuildLevels.csv"
+
     echo "${SCRIPT_NAME}: Creating visualization ScipModuleLongestPathsIsolated..."
     execute_cypher "${PATH_FINDING_CYPHER_DIR}/SCC_Longest_paths_for_graphviz.cypher" \
         "${SCIP_MODULE_PROJECTION}" "${SCIP_MODULE_NODE}" "${SCIP_MODULE_WEIGHT}" \
@@ -265,6 +271,12 @@ SCIP_ARTIFACT_WEIGHT="dependencies_projection_weight_property=referenceCount"
 
 if createDirectedDependencyProjection "${SCIP_LANGUAGE}" "${SCIP_ARTIFACT_PROJECTION}" "${SCIP_ARTIFACT_NODE}" "${SCIP_ARTIFACT_WEIGHT}"; then
     setupStronglyConnectedComponentsForSccVisualization "${SCIP_ARTIFACT_PROJECTION}" "${SCIP_ARTIFACT_NODE}" "${SCIP_ARTIFACT_WEIGHT}"
+
+    echo "${SCRIPT_NAME}: Creating visualization ScipArtifactBuildLevels..."
+    execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/SCIP_SCC_Artifact_build_levels_for_graphviz.cypher" \
+        "${SCIP_ARTIFACT_PROJECTION}" "${SCIP_ARTIFACT_NODE}" "${SCIP_ARTIFACT_WEIGHT}" \
+        > "${SCIP_ARTIFACT_GRAPH_VIZ_DIR}/ScipArtifactBuildLevels.csv"
+    source "${VISUALIZATION_SCRIPTS_DIR}/visualizeQueryResults.sh" "${SCIP_ARTIFACT_GRAPH_VIZ_DIR}/ScipArtifactBuildLevels.csv"
 
     echo "${SCRIPT_NAME}: Creating visualization ScipArtifactLongestPathsIsolated..."
     execute_cypher "${PATH_FINDING_CYPHER_DIR}/SCC_Longest_paths_for_graphviz.cypher" \

--- a/domains/internal-dependencies/internalDependenciesCsv.sh
+++ b/domains/internal-dependencies/internalDependenciesCsv.sh
@@ -83,6 +83,18 @@ execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/List_elements_that_are_used_by_many_
 execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/How_many_elements_compared_to_all_existing_are_used_by_dependent_modules_for_Typescript.cypher" \
     > "${FULL_REPORT_DIRECTORY}/Typescript_Module/ModuleElementsUsageTypescript.csv"
 
+echo "internalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing internal dependencies for SCIP..."
+
+SCIP_MODULE_DIR="${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module"
+mkdir -p "${SCIP_MODULE_DIR}"
+SCIP_ARTIFACT_DIR="${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact"
+mkdir -p "${SCIP_ARTIFACT_DIR}"
+
+execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/List_all_SCIP_modules.cypher" \
+    > "${SCIP_MODULE_DIR}/List_all_SCIP_modules.csv"
+execute_cypher "${INTERNAL_DEPS_CYPHER_DIR}/List_all_SCIP_artifacts.cypher" \
+    > "${SCIP_ARTIFACT_DIR}/List_all_SCIP_artifacts.csv"
+
 # ── Path Finding ──────────────────────────────────────────────────────────────
 
 echo "internalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Starting path finding..."
@@ -399,6 +411,22 @@ echo "internalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Processing Object-
 # Prerequisite: count and set abstract type flags before running abstractness queries.
 execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Count_and_set_abstract_types.cypher"
 
+# -- SCIP Semantic Index Modules ----------------------------------------------
+
+SCIP_MODULE_OO_DIR="${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module"
+
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Count_and_set_abstract_types_for_SCIP.cypher"
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Calculate_and_set_Abstractness_for_SCIP.cypher" \
+    > "${SCIP_MODULE_OO_DIR}/AbstractnessScip.csv"
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Calculate_and_set_Instability_for_SCIP.cypher" \
+    > "${SCIP_MODULE_OO_DIR}/InstabilityScip.csv"
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher" \
+    > "${SCIP_MODULE_OO_DIR}/MainSequenceAbstractnessInstabilityDistanceScip.csv"
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Get_Incoming_SCIP_Module_Dependencies.cypher" \
+    > "${SCIP_MODULE_OO_DIR}/IncomingPackageDependenciesScip.csv"
+execute_cypher "${OBJECT_ORIENTED_DESIGN_METRICS_CYPHER_DIR}/Get_Outgoing_SCIP_Module_Dependencies.cypher" \
+    > "${SCIP_MODULE_OO_DIR}/OutgoingPackageDependenciesScip.csv"
+
 # -- Java Packages without sub-packages --------------------------------------
 
 execute_cypher_queries_until_results \
@@ -476,6 +504,7 @@ source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}/NPM_DevPackage"
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module"
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact"
+source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Type"
 source "${SCRIPTS_DIR}/cleanupAfterReportGeneration.sh" "${FULL_REPORT_DIRECTORY}"
 
 echo "internalDependenciesCsv: $(date +'%Y-%m-%dT%H:%M:%S%z') Successfully finished."

--- a/domains/internal-dependencies/objectOrientedDesignMetricsCharts.py
+++ b/domains/internal-dependencies/objectOrientedDesignMetricsCharts.py
@@ -74,6 +74,18 @@ OUTGOING_CHART_PREFIX = {
 
 TOP_DEPENDENCIES_COUNT = 30
 
+# ── SCIP configuration ─────────────────────────────────────────────────────────
+# SCIP OO Design Metrics cover modules only (instability + abstractness via isAbstract flag).
+# CSV file names produced by internalDependenciesCsv.sh for the SCIP module level.
+SCIP_MODULE_SUBDIRECTORY = "SCIP_Semantic_Index_Module"
+SCIP_MODULE_DESCRIPTION = "SCIP Semantic Index Modules"
+SCIP_MODULE_MAIN_SEQUENCE_CSV = "MainSequenceAbstractnessInstabilityDistanceScip.csv"
+SCIP_MODULE_INCOMING_CSV = "IncomingPackageDependenciesScip.csv"
+SCIP_MODULE_OUTGOING_CSV = "OutgoingPackageDependenciesScip.csv"
+SCIP_CHART_MAIN_SEQUENCE_PREFIX = "SCIP_Module_MainSequence"
+SCIP_CHART_INCOMING_PREFIX = "SCIP_Module_IncomingDependencies_Bar"
+SCIP_CHART_OUTGOING_PREFIX = "SCIP_Module_OutgoingDependencies_Bar"
+
 
 class Parameters:
     def __init__(
@@ -434,6 +446,57 @@ def generate_charts_for_level(
     generate_outgoing_dependencies_chart(level_directory, description, outgoing_csv, verbose)
 
 
+def generate_scip_oo_design_metrics_charts(report_directory: str, verbose: bool) -> None:
+    """Generates all OO Design Metric charts for SCIP Semantic Index modules.
+
+    SCIP modules expose abstractness (via isAbstract flag on contained types) and instability
+    (via inter-module DEPENDS_ON counts). This covers Main Sequence analysis and
+    incoming/outgoing dependency bar charts. Silently skips when no SCIP data is present.
+    """
+    level_directory = os.path.join(report_directory, SCIP_MODULE_SUBDIRECTORY)
+    if not os.path.isdir(level_directory):
+        if verbose:
+            print(f"{SCRIPT_NAME}: Skipping SCIP OO metrics — directory not found: {level_directory}")
+        return
+
+    print(f"{SCRIPT_NAME}: Processing {SCIP_MODULE_DESCRIPTION}...")
+
+    main_sequence_csv = os.path.join(level_directory, SCIP_MODULE_MAIN_SEQUENCE_CSV)
+    incoming_csv = os.path.join(level_directory, SCIP_MODULE_INCOMING_CSV)
+    outgoing_csv = os.path.join(level_directory, SCIP_MODULE_OUTGOING_CSV)
+
+    main_sequence_data = load_csv(main_sequence_csv, verbose)
+    if main_sequence_data is not None and not main_sequence_data.empty:
+        plot_main_sequence_scatter(
+            data_frame=main_sequence_data,
+            title=f'Abstractness vs. Instability ("Main Sequence")\n{SCIP_MODULE_DESCRIPTION}',
+            file_path=chart_file_path(SCIP_CHART_MAIN_SEQUENCE_PREFIX, level_directory, verbose),
+            verbose=verbose,
+        )
+
+    incoming_data = load_csv(incoming_csv, verbose)
+    if incoming_data is not None and not incoming_data.empty:
+        numeric_cols = incoming_data.select_dtypes(include="number").columns.tolist()
+        count_column = numeric_cols[0] if numeric_cols else ""
+        plot_top_dependencies_bar(
+            data_frame=incoming_data,
+            title=f"Top {TOP_DEPENDENCIES_COUNT} by Incoming Dependencies\n{SCIP_MODULE_DESCRIPTION}",
+            file_path=chart_file_path(SCIP_CHART_INCOMING_PREFIX, level_directory, verbose),
+            count_column=count_column,
+        )
+
+    outgoing_data = load_csv(outgoing_csv, verbose)
+    if outgoing_data is not None and not outgoing_data.empty:
+        numeric_cols = outgoing_data.select_dtypes(include="number").columns.tolist()
+        count_column = numeric_cols[0] if numeric_cols else ""
+        plot_top_dependencies_bar(
+            data_frame=outgoing_data,
+            title=f"Top {TOP_DEPENDENCIES_COUNT} by Outgoing Dependencies\n{SCIP_MODULE_DESCRIPTION}",
+            file_path=chart_file_path(SCIP_CHART_OUTGOING_PREFIX, level_directory, verbose),
+            count_column=count_column,
+        )
+
+
 def main() -> None:
     """Generates all Object Oriented Design metrics charts for all abstraction levels."""
     parameters = parse_parameters()
@@ -455,6 +518,11 @@ def main() -> None:
             outgoing_csv_name=outgoing_csv_name,
             verbose=parameters.verbose,
         )
+
+    generate_scip_oo_design_metrics_charts(
+        report_directory=parameters.report_directory,
+        verbose=parameters.verbose,
+    )
 
     print(f"{SCRIPT_NAME}: Successfully finished.")
 

--- a/domains/internal-dependencies/pathFindingCharts.py
+++ b/domains/internal-dependencies/pathFindingCharts.py
@@ -40,6 +40,13 @@ ABSTRACTION_LEVELS = [
     ("NPM_DevPackage",   "NpmDevPackage",    "NPM Dev Package"),
 ]
 
+# SCIP Semantic Index abstraction levels: (subdirectory, nodeLabel, description)
+# Uses SCC-based longest path CSV (cycles condensed into components before path finding).
+SCIP_ABSTRACTION_LEVELS = [
+    ("SCIP_Semantic_Index_Module",   "SemanticCodeIndexModule",   "SCIP Semantic Index Module"),
+    ("SCIP_Semantic_Index_Artifact", "SemanticCodeIndexArtifact", "SCIP Semantic Index Artifact"),
+]
+
 # Colormap matching the original PathFindingJava.ipynb notebook
 MAIN_COLOR_MAP = "nipy_spectral"
 
@@ -431,6 +438,128 @@ def generate_charts_for_level(
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 
+def generate_scip_charts_for_level(
+    subdirectory: str,
+    node_label: str,
+    description: str,
+    report_directory: str,
+    verbose: bool,
+) -> None:
+    """Generates path finding charts for a single SCIP abstraction level.
+
+    Differs from generate_charts_for_level() in that the longest path CSV
+    uses the SCC-based file name (_StronglyConnectedComponents_longest_paths_distribution.csv)
+    because SCIP graphs may contain cycles — path finding runs on the condensed SCC component DAG.
+    APSP charts use the same pattern as the standard levels.
+
+    Silently skips if the level directory or any CSV file does not exist.
+    Fails fast on unexpected data structure issues.
+    """
+    level_directory = os.path.join(report_directory, subdirectory)
+    if not os.path.isdir(level_directory):
+        if verbose:
+            print(f"{SCRIPT_NAME}: Skipping {description} — directory not found: {level_directory}")
+        return
+
+    all_pairs_shortest_paths_csv = os.path.join(
+        level_directory,
+        f"{node_label}_all_pairs_shortest_paths_distribution_per_project.csv",
+    )
+    # SCIP longest path runs on the SCC component DAG, not directly on member nodes
+    scc_longest_csv = os.path.join(
+        level_directory,
+        f"{node_label}_StronglyConnectedComponents_longest_paths_distribution.csv",
+    )
+
+    # ── All pairs shortest path charts ────────────────────────────────────────
+    all_pairs_shortest_paths_data = load_csv(all_pairs_shortest_paths_csv, verbose)
+    if all_pairs_shortest_paths_data is not None and not all_pairs_shortest_paths_data.empty:
+        print(f"{SCRIPT_NAME}: Generating SCIP All Pairs Shortest Path charts for {description}...")
+
+        total_all_pairs_shortest_paths = aggregate_total_distribution(all_pairs_shortest_paths_data)
+
+        if not total_all_pairs_shortest_paths.empty:
+            plot_distribution_bar(
+                total_all_pairs_shortest_paths, DISTANCE_COLUMN, PAIR_COUNT_COLUMN,
+                f"{description} — All Pairs Shortest Path Distribution",
+                chart_file_path(f"{subdirectory}_AllPairsShortestPath_Bar", level_directory, verbose),
+            )
+            plot_distribution_pie(
+                total_all_pairs_shortest_paths, DISTANCE_COLUMN, PAIR_COUNT_COLUMN,
+                f"{description} — All Pairs Shortest Path by Distance",
+                chart_file_path(f"{subdirectory}_AllPairsShortestPath_Pie", level_directory, verbose),
+            )
+
+        pivoted = pivot_distribution_by_project(all_pairs_shortest_paths_data, DISTANCE_COLUMN, PAIR_COUNT_COLUMN, SOURCE_PROJECT_COLUMN)
+        if not pivoted.empty:
+            plot_per_project_stacked_bar(
+                pivoted,
+                f"{description} — All Pairs Shortest Path per Project (absolute, log scale)",
+                chart_file_path(f"{subdirectory}_AllPairsShortestPath_StackedBar_Log", level_directory, verbose),
+                use_log_scale=True,
+            )
+            normalized = normalize_distribution_by_project(pivoted)
+            plot_per_project_normalized_bar(
+                normalized,
+                f"{description} — All Pairs Shortest Path per Project (normalised)",
+                chart_file_path(f"{subdirectory}_AllPairsShortestPath_StackedBar_Normalised", level_directory, verbose),
+            )
+
+        diameter_data = max_distance_per_project(all_pairs_shortest_paths_data)
+        if not diameter_data.empty:
+            plot_diameter_bar(
+                diameter_data, SOURCE_PROJECT_COLUMN, "diameter",
+                f"{description} — Graph Diameter per Project",
+                chart_file_path(f"{subdirectory}_GraphDiameter_per_Project", level_directory, verbose),
+            )
+
+    # ── SCC-based longest path charts ─────────────────────────────────────────
+    # The SCC longest path CSV may be absent when no SCIP nodes exist — silently skip.
+    scc_longest_data = load_csv(scc_longest_csv, verbose)
+    if scc_longest_data is not None and not scc_longest_data.empty:
+        print(f"{SCRIPT_NAME}: Generating SCIP SCC Longest Path charts for {description}...")
+
+        total_longest = aggregate_total_distribution(scc_longest_data)
+
+        if not total_longest.empty:
+            plot_distribution_bar(
+                total_longest, DISTANCE_COLUMN, PAIR_COUNT_COLUMN,
+                f"{description} — SCC Longest Path Distribution",
+                chart_file_path(f"{subdirectory}_LongestPath_Bar", level_directory, verbose),
+            )
+            plot_distribution_pie(
+                total_longest, DISTANCE_COLUMN, PAIR_COUNT_COLUMN,
+                f"{description} — SCC Longest Path by Distance",
+                chart_file_path(f"{subdirectory}_LongestPath_Pie", level_directory, verbose),
+            )
+
+        pivoted_longest = pivot_distribution_by_project(scc_longest_data, DISTANCE_COLUMN, PAIR_COUNT_COLUMN, SOURCE_PROJECT_COLUMN)
+        if not pivoted_longest.empty:
+            plot_per_project_stacked_bar(
+                pivoted_longest,
+                f"{description} — SCC Longest Path per Project (absolute, log scale)",
+                chart_file_path(f"{subdirectory}_LongestPath_StackedBar_Log", level_directory, verbose),
+                use_log_scale=True,
+            )
+            normalized_longest = normalize_distribution_by_project(pivoted_longest)
+            plot_per_project_normalized_bar(
+                normalized_longest,
+                f"{description} — SCC Longest Path per Project (normalised)",
+                chart_file_path(f"{subdirectory}_LongestPath_StackedBar_Normalised", level_directory, verbose),
+            )
+
+        max_longest = max_distance_per_project(scc_longest_data)
+        if not max_longest.empty:
+            plot_diameter_bar(
+                max_longest, SOURCE_PROJECT_COLUMN, "diameter",
+                f"{description} — Max SCC Longest Path per Project",
+                chart_file_path(f"{subdirectory}_MaxLongestPath_per_Project", level_directory, verbose),
+            )
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
 def main() -> None:
     parameters = parse_parameters()
 
@@ -453,6 +582,15 @@ def main() -> None:
 
     for subdirectory, node_label, description in ABSTRACTION_LEVELS:
         generate_charts_for_level(
+            subdirectory=subdirectory,
+            node_label=node_label,
+            description=description,
+            report_directory=parameters.report_directory,
+            verbose=parameters.verbose,
+        )
+
+    for subdirectory, node_label, description in SCIP_ABSTRACTION_LEVELS:
+        generate_scip_charts_for_level(
             subdirectory=subdirectory,
             node_label=node_label,
             description=description,

--- a/domains/internal-dependencies/queries/internal-dependencies/List_all_SCIP_artifacts.cypher
+++ b/domains/internal-dependencies/queries/internal-dependencies/List_all_SCIP_artifacts.cypher
@@ -1,0 +1,10 @@
+// List all existing SCIP Semantic Index artifacts with dependency counts and external flag.
+
+MATCH (a:SemanticCodeIndexArtifact)
+RETURN a.projectName        AS projectName
+      ,a.name               AS artifactName
+      ,a.version            AS version
+      ,a.incomingDependencies AS incomingDependencies
+      ,a.outgoingDependencies AS outgoingDependencies
+      ,a.isExternal          AS isExternal
+ORDER BY incomingDependencies DESC, outgoingDependencies DESC, artifactName

--- a/domains/internal-dependencies/queries/internal-dependencies/List_all_SCIP_modules.cypher
+++ b/domains/internal-dependencies/queries/internal-dependencies/List_all_SCIP_modules.cypher
@@ -1,0 +1,14 @@
+// List all existing internal SCIP Semantic Index modules with dependency counts and test flag.
+
+MATCH (m:SemanticCodeIndexModule)
+OPTIONAL MATCH (m)-[:CONTAINS]->(t:SemanticCodeIndexInternalType)
+ WITH m
+     ,count(DISTINCT t.fqn) AS numberOfTypes
+RETURN m.projectName        AS projectName
+      ,m.fqn                AS moduleFqn
+      ,m.name               AS moduleName
+      ,numberOfTypes
+      ,m.incomingDependencies AS incomingDependencies
+      ,m.outgoingDependencies AS outgoingDependencies
+      ,m.isTest               AS isTest
+ORDER BY incomingDependencies DESC, outgoingDependencies DESC, moduleName

--- a/domains/internal-dependencies/queries/internal-dependencies/SCIP_SCC_Artifact_build_levels_for_graphviz.cypher
+++ b/domains/internal-dependencies/queries/internal-dependencies/SCIP_SCC_Artifact_build_levels_for_graphviz.cypher
@@ -1,0 +1,44 @@
+// List of all SCIP Semantic Index artifact SCC components and their dependencies with build levels for GraphViz Visualization.
+// Requires "SCC_TopologicalSort_Write.cypher".
+
+MATCH (sourceForStatistics:StronglyConnectedComponent)
+WHERE sourceForStatistics.memberType = $dependencies_projection_node
+  AND sourceForStatistics.topologicalSortMaxDistanceFromSource IS NOT NULL
+OPTIONAL MATCH (sourceForStatistics)-[dependencyForStatistics:DEPENDS_ON]->(targetForStatistics:StronglyConnectedComponent)
+WHERE targetForStatistics.memberType = $dependencies_projection_node
+  AND targetForStatistics.topologicalSortMaxDistanceFromSource IS NOT NULL
+ WITH min(dependencyForStatistics[$dependencies_projection_weight_property]) AS minWeight
+     ,max(dependencyForStatistics[$dependencies_projection_weight_property]) AS maxWeight
+     ,max(sourceForStatistics.topologicalSortMaxDistanceFromSource)          AS maxLevel
+// 1E-38 prevents division by zero when all weights are equal
+ WITH *, CASE WHEN minWeight = maxWeight THEN maxWeight + 1 ELSE maxWeight END AS maxWeight
+MATCH (source:StronglyConnectedComponent)-[dependency:DEPENDS_ON]->(target:StronglyConnectedComponent)
+WHERE source.memberType = $dependencies_projection_node
+  AND target.memberType = $dependencies_projection_node
+  AND source.topologicalSortMaxDistanceFromSource IS NOT NULL
+  AND target.topologicalSortMaxDistanceFromSource IS NOT NULL
+ WITH *, CASE WHEN maxWeight = minWeight THEN 0.0
+              ELSE toFloat(dependency[$dependencies_projection_weight_property] - minWeight) / toFloat(maxWeight - minWeight)
+         END AS normalizedWeight
+ WITH *, round((normalizedWeight * 5) + 1, 2) AS penWidth
+// Single-member nodes: show bare artifact name; cycle nodes: annotate with cycle size and representative name
+ WITH *, CASE WHEN source.size = 1
+              THEN replace(source.name, 'Component ', '')
+              ELSE 'Cycle (' + source.size + ')\\naround ' + replace(source.name, 'Cycle around ', '')
+         END AS sourceLabel
+ WITH *, CASE WHEN target.size = 1
+              THEN replace(target.name, 'Component ', '')
+              ELSE 'Cycle (' + target.size + ')\\naround ' + replace(target.name, 'Cycle around ', '')
+         END AS targetLabel
+ WITH *, "\\n(level " + coalesce(source.topologicalSortMaxDistanceFromSource + "/" + maxLevel, "?") + ")" AS sourceLevelInfo
+ WITH *, "\\n(level " + coalesce(target.topologicalSortMaxDistanceFromSource + "/" + maxLevel, "?") + ")" AS targetLevelInfo
+ WITH *, sourceLabel + sourceLevelInfo AS fullSourceName
+ WITH *, targetLabel + targetLevelInfo AS fullTargetName
+ WITH *, "\" -> \"" + fullTargetName
+                  + "\" [label = "  + dependency[$dependencies_projection_weight_property] + ";"
+                  + " penwidth = "  + penWidth + ";"
+                  + " ];"    AS graphVizDotNotationEdge
+ WITH *, "\"" + fullSourceName + coalesce(graphVizDotNotationEdge, "\" [];") AS graphVizDotNotationLine
+ORDER BY dependency[$dependencies_projection_weight_property] DESC, target.topologicalSortMaxDistanceFromSource DESC
+RETURN graphVizDotNotationLine
+LIMIT 440

--- a/domains/internal-dependencies/queries/internal-dependencies/SCIP_SCC_Module_build_levels_for_graphviz.cypher
+++ b/domains/internal-dependencies/queries/internal-dependencies/SCIP_SCC_Module_build_levels_for_graphviz.cypher
@@ -1,0 +1,44 @@
+// List of all SCIP Semantic Index module SCC components and their dependencies with build levels for GraphViz Visualization.
+// Requires "SCC_TopologicalSort_Write.cypher".
+
+MATCH (sourceForStatistics:StronglyConnectedComponent)
+WHERE sourceForStatistics.memberType = $dependencies_projection_node
+  AND sourceForStatistics.topologicalSortMaxDistanceFromSource IS NOT NULL
+OPTIONAL MATCH (sourceForStatistics)-[dependencyForStatistics:DEPENDS_ON]->(targetForStatistics:StronglyConnectedComponent)
+WHERE targetForStatistics.memberType = $dependencies_projection_node
+  AND targetForStatistics.topologicalSortMaxDistanceFromSource IS NOT NULL
+ WITH min(dependencyForStatistics[$dependencies_projection_weight_property]) AS minWeight
+     ,max(dependencyForStatistics[$dependencies_projection_weight_property]) AS maxWeight
+     ,max(sourceForStatistics.topologicalSortMaxDistanceFromSource)          AS maxLevel
+// 1E-38 prevents division by zero when all weights are equal
+ WITH *, CASE WHEN minWeight = maxWeight THEN maxWeight + 1 ELSE maxWeight END AS maxWeight
+MATCH (source:StronglyConnectedComponent)-[dependency:DEPENDS_ON]->(target:StronglyConnectedComponent)
+WHERE source.memberType = $dependencies_projection_node
+  AND target.memberType = $dependencies_projection_node
+  AND source.topologicalSortMaxDistanceFromSource IS NOT NULL
+  AND target.topologicalSortMaxDistanceFromSource IS NOT NULL
+ WITH *, CASE WHEN maxWeight = minWeight THEN 0.0
+              ELSE toFloat(dependency[$dependencies_projection_weight_property] - minWeight) / toFloat(maxWeight - minWeight)
+         END AS normalizedWeight
+ WITH *, round((normalizedWeight * 5) + 1, 2) AS penWidth
+// Single-member nodes: show bare module name; cycle nodes: annotate with cycle size and representative name
+ WITH *, CASE WHEN source.size = 1
+              THEN replace(source.name, 'Component ', '')
+              ELSE 'Cycle (' + source.size + ')\\naround ' + replace(source.name, 'Cycle around ', '')
+         END AS sourceLabel
+ WITH *, CASE WHEN target.size = 1
+              THEN replace(target.name, 'Component ', '')
+              ELSE 'Cycle (' + target.size + ')\\naround ' + replace(target.name, 'Cycle around ', '')
+         END AS targetLabel
+ WITH *, "\\n(level " + coalesce(source.topologicalSortMaxDistanceFromSource + "/" + maxLevel, "?") + ")" AS sourceLevelInfo
+ WITH *, "\\n(level " + coalesce(target.topologicalSortMaxDistanceFromSource + "/" + maxLevel, "?") + ")" AS targetLevelInfo
+ WITH *, sourceLabel + sourceLevelInfo AS fullSourceName
+ WITH *, targetLabel + targetLevelInfo AS fullTargetName
+ WITH *, "\" -> \"" + fullTargetName
+                  + "\" [label = "  + dependency[$dependencies_projection_weight_property] + ";"
+                  + " penwidth = "  + penWidth + ";"
+                  + " ];"    AS graphVizDotNotationEdge
+ WITH *, "\"" + fullSourceName + coalesce(graphVizDotNotationEdge, "\" [];") AS graphVizDotNotationLine
+ORDER BY dependency[$dependencies_projection_weight_property] DESC, target.topologicalSortMaxDistanceFromSource DESC
+RETURN graphVizDotNotationLine
+LIMIT 440

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Abstractness_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Abstractness_for_SCIP.cypher
@@ -1,0 +1,14 @@
+// Calculate and set Abstractness for SCIP Semantic Index modules. Requires "Count_and_set_abstract_types_for_SCIP.cypher".
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.numberOfTypes IS NOT NULL
+ WITH m
+     ,toFloat(m.numberOfAbstractTypes) / (m.numberOfTypes + 1E-38) AS abstractness
+  SET m.abstractness = abstractness
+RETURN m.projectName        AS projectName
+      ,m.fqn                AS fullQualifiedModuleName
+      ,m.name               AS moduleName
+      ,abstractness
+      ,m.numberOfAbstractTypes AS numberOfAbstractTypes
+      ,m.numberOfTypes         AS numberOfTypes
+ORDER BY abstractness ASC, numberOfTypes DESC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
@@ -1,0 +1,16 @@
+// Calculate and set Instability for SCIP Semantic Index modules. Requires "Set_Incoming_SCIP_Module_Dependencies.cypher" and "Set_Outgoing_SCIP_Module_Dependencies.cypher" from the scip-index-import enrichment phase.
+// Reuses existing incomingDependencies and outgoingDependencies already set during enrichment.
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.incomingDependencies IS NOT NULL
+  AND m.outgoingDependencies IS NOT NULL
+ WITH m
+     ,toFloat(m.outgoingDependencies) / (m.outgoingDependencies + m.incomingDependencies + 1E-38) AS instability
+  SET m.instability = instability
+RETURN m.projectName          AS projectName
+      ,m.fqn                  AS fullQualifiedModuleName
+      ,m.name                 AS moduleName
+      ,instability
+      ,m.outgoingDependencies AS outgoingDependencies
+      ,m.incomingDependencies AS incomingDependencies
+ORDER BY instability ASC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_distance_between_abstractness_and_instability_for_SCIP.cypher
@@ -1,0 +1,14 @@
+// Calculate distance between abstractness and instability for SCIP Semantic Index modules.
+// Requires "Calculate_and_set_Abstractness_for_SCIP.cypher" and "Calculate_and_set_Instability_for_SCIP.cypher".
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.abstractness IS NOT NULL
+  AND m.instability  IS NOT NULL
+RETURN m.projectName                                    AS artifactName
+      ,m.fqn                                           AS fullQualifiedName
+      ,m.name                                          AS name
+      ,abs(m.abstractness + m.instability - 1)         AS distance
+      ,m.abstractness                                  AS abstractness
+      ,m.instability                                   AS instability
+      ,m.numberOfTypes                                 AS elementsCount
+ORDER BY distance DESC, elementsCount DESC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Count_and_set_abstract_types_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Count_and_set_abstract_types_for_SCIP.cypher
@@ -1,0 +1,13 @@
+// Count and set abstract type counts for SCIP Semantic Index modules. Requires "Link_SCIP_Module_CONTAINS_SCIP_InternalType.cypher".
+
+MATCH (m:SemanticCodeIndexModule)
+ WITH m
+     ,count{(m)-[:CONTAINS]->(:SemanticCodeIndexInternalType)}                  AS numberOfTypes
+     ,count{(m)-[:CONTAINS]->(:SemanticCodeIndexInternalType {isAbstract: true})} AS numberOfAbstractTypes
+  SET m.numberOfTypes         = numberOfTypes
+     ,m.numberOfAbstractTypes = numberOfAbstractTypes
+RETURN m.fqn                AS moduleFqn
+      ,m.name               AS moduleName
+      ,numberOfTypes
+      ,numberOfAbstractTypes
+ORDER BY numberOfAbstractTypes DESC, numberOfTypes DESC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Abstractness_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Abstractness_for_SCIP.cypher
@@ -1,0 +1,11 @@
+// Get SCIP Semantic Index modules with the lowest Abstractness first (if already set).
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.abstractness IS NOT NULL
+RETURN m.projectName          AS projectName
+      ,m.fqn                  AS fullQualifiedModuleName
+      ,m.name                 AS moduleName
+      ,m.abstractness         AS abstractness
+      ,m.numberOfAbstractTypes AS numberOfAbstractTypes
+      ,m.numberOfTypes         AS numberOfTypes
+ORDER BY abstractness ASC, numberOfTypes DESC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
@@ -1,0 +1,10 @@
+// Get SCIP Semantic Index modules with the most incoming dependencies first (if already set by enrichment).
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.incomingDependencies IS NOT NULL
+RETURN m.projectName          AS projectName
+      ,m.fqn                  AS fullQualifiedModuleName
+      ,m.name                 AS moduleName
+      ,m.incomingDependencies AS incomingDependencies
+      ,m.outgoingDependencies AS outgoingDependencies
+ORDER BY incomingDependencies DESC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
@@ -1,0 +1,11 @@
+// Get SCIP Semantic Index modules with the lowest Instability first (if already set).
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.instability IS NOT NULL
+RETURN m.projectName          AS projectName
+      ,m.fqn                  AS fullQualifiedModuleName
+      ,m.name                 AS moduleName
+      ,m.instability          AS instability
+      ,m.outgoingDependencies AS outgoingDependencies
+      ,m.incomingDependencies AS incomingDependencies
+ORDER BY instability ASC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Outgoing_SCIP_Module_Dependencies.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Outgoing_SCIP_Module_Dependencies.cypher
@@ -1,0 +1,10 @@
+// Get SCIP Semantic Index modules with the most outgoing dependencies first (if already set by enrichment).
+
+MATCH (m:SemanticCodeIndexModule)
+WHERE m.outgoingDependencies IS NOT NULL
+RETURN m.projectName          AS projectName
+      ,m.fqn                  AS fullQualifiedModuleName
+      ,m.name                 AS moduleName
+      ,m.outgoingDependencies AS outgoingDependencies
+      ,m.incomingDependencies AS incomingDependencies
+ORDER BY outgoingDependencies DESC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/path-finding/Path_Finding_1_Create_Projection.cypher
+++ b/domains/internal-dependencies/queries/path-finding/Path_Finding_1_Create_Projection.cypher
@@ -1,2 +1,6 @@
 //Path Finding 1 Create Projection
-CALL gds.graph.project('package-dependencies', 'Package', 'DEPENDS_ON')
+CALL gds.graph.project(
+    $dependencies_projection,
+    $dependencies_projection_node,
+    'DEPENDS_ON'
+)

--- a/domains/internal-dependencies/queries/path-finding/SCC_Longest_paths_distribution_per_project.cypher
+++ b/domains/internal-dependencies/queries/path-finding/SCC_Longest_paths_distribution_per_project.cypher
@@ -22,15 +22,19 @@ UNWIND sourcesAndTargets AS sourceAndTarget
      ,sourceAndTarget.target AS target
 // Resolve project context via one representative member of the source component
 OPTIONAL MATCH (sourceMember)-[:IN_STRONGLY_CONNECTED_COMPONENT]->(source)
+OPTIONAL MATCH (targetMember)-[:IN_STRONGLY_CONNECTED_COMPONENT]->(target)
  WITH distance
      ,distanceTotalPairCount
      ,distanceTotalSourceCount
      ,distanceTotalTargetCount
      ,source
      ,target
-     ,head(collect(sourceMember)) AS representativeMember
-OPTIONAL MATCH (sourceProject:Project|Artifact|SemanticCodeIndexArtifact)-[:CONTAINS]->(representativeMember)
-RETURN coalesce(sourceProject.name, source.name) AS sourceProject
+     ,head(collect(DISTINCT sourceMember)) AS representativeSourceMember
+     ,head(collect(DISTINCT targetMember)) AS representativeTargetMember
+OPTIONAL MATCH (sourceProject:Project|Artifact|SemanticCodeIndexProject|SemanticCodeIndexArtifact)-[:CONTAINS]->(representativeSourceMember)
+OPTIONAL MATCH (targetProject:Project|Artifact|SemanticCodeIndexProject|SemanticCodeIndexArtifact)-[:CONTAINS]->(representativeTargetMember)
+RETURN coalesce(sourceProject.name, source.name)         AS sourceProject
+      ,coalesce((targetProject <> sourceProject), false) AS isDifferentTargetProject
       ,distance
       ,distanceTotalPairCount
       ,distanceTotalSourceCount
@@ -40,4 +44,4 @@ RETURN coalesce(sourceProject.name, source.name) AS sourceProject
       ,count(DISTINCT target) AS targetNodeCount
       ,collect(DISTINCT source.name + ' -> ' + target.name)[0..4] AS examples
       ,collect(DISTINCT sourceProject.name)[0..4] AS exampleProjects
-ORDER BY sourceProject, distance
+ORDER BY sourceProject, isDifferentTargetProject, distance

--- a/domains/internal-dependencies/queries/topological-sort/Topological_Sort_Critical_Path_Length.cypher
+++ b/domains/internal-dependencies/queries/topological-sort/Topological_Sort_Critical_Path_Length.cypher
@@ -19,6 +19,16 @@ CALL {
     RETURN 'TypeScript Module' AS abstractionLevel
           ,max(n.maxDistanceFromSource) AS maxBuildLevel
           ,count(n)                     AS nodeCount
+    UNION ALL
+    MATCH (n:SemanticCodeIndexModule) WHERE n.maxDistanceFromSource IS NOT NULL
+    RETURN 'SCIP Module'       AS abstractionLevel
+          ,max(n.maxDistanceFromSource) AS maxBuildLevel
+          ,count(n)                     AS nodeCount
+    UNION ALL
+    MATCH (n:SemanticCodeIndexArtifact) WHERE n.maxDistanceFromSource IS NOT NULL
+    RETURN 'SCIP Artifact'     AS abstractionLevel
+          ,max(n.maxDistanceFromSource) AS maxBuildLevel
+          ,count(n)                     AS nodeCount
 }
 RETURN abstractionLevel
       ,nodeCount

--- a/domains/internal-dependencies/summary/internalDependenciesSummary.sh
+++ b/domains/internal-dependencies/summary/internalDependenciesSummary.sh
@@ -174,6 +174,26 @@ assemble_internal_dependencies_report() {
         "Typescript_Module/ModuleElementsUsageTypescript.csv" \
         "${report_include_directory}/How_many_elements_used_by_dependent_modules.md"
 
+    # ── SCIP Semantic Index internal structure ─────────────────────────────
+
+    execute_limited_table \
+        "${INTERNAL_DEPS_QUERY_CYPHER_DIR}/List_all_SCIP_modules.cypher" \
+        "SCIP_Semantic_Index_Module/List_all_SCIP_modules.csv" \
+        "${report_include_directory}/List_all_SCIP_modules.md"
+
+    execute_limited_table \
+        "${INTERNAL_DEPS_QUERY_CYPHER_DIR}/List_all_SCIP_artifacts.cypher" \
+        "SCIP_Semantic_Index_Artifact/List_all_SCIP_artifacts.csv" \
+        "${report_include_directory}/List_all_SCIP_artifacts.md"
+
+    # SCIP Internal Types: topological sort CSV link only (no live query — too large for table)
+    {
+        if [ -f "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Type/SemanticCodeIndexInternalType_Topological_Sort.csv" ]; then
+            echo ""
+            echo "[Full topological sort data](./SCIP_Semantic_Index_Type/SemanticCodeIndexInternalType_Topological_Sort.csv)"
+        fi
+    } > "${report_include_directory}/ScipInternalTypesTopologicalSort.md"
+
     # ── Path finding tables (Java Artifact) ──────────────────────────────────
     # Guard: only run if Java Artifact path finding projection exists.
     ARTIFACT_PROJECTION="dependencies_projection=artifact-path-finding"
@@ -291,6 +311,80 @@ assemble_internal_dependencies_report() {
         include_svgs_matching "${FULL_REPORT_DIRECTORY}/Typescript_Module" "Typescript_Module_MaxLongestPath_per_Project.svg"
     } > "${report_include_directory}/TypescriptModuleLongestPathCharts.md"
 
+    # ── Path finding tables (SCIP Module) ─────────────────────────────────
+    # Guard: only run if SCIP module path-finding projection exists.
+    SCIP_MODULE_PROJECTION="dependencies_projection=scip-module-path-finding"
+    if projectionExists "${SCIP_MODULE_PROJECTION}"; then
+        {
+            execute_cypher "${PATH_FINDING_CYPHER_DIR}/Path_Finding_5_All_pairs_shortest_path_distribution_overall.cypher" \
+                "${SCIP_MODULE_PROJECTION}" \
+                --output-markdown-table | limit_markdown_table
+            if [ -f "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module/SemanticCodeIndexModule_all_pairs_shortest_paths_distribution_per_project.csv" ]; then
+                echo ""
+                echo "[Full data per project](./SCIP_Semantic_Index_Module/SemanticCodeIndexModule_all_pairs_shortest_paths_distribution_per_project.csv)"
+            fi
+        } > "${report_include_directory}/ScipModuleAllPairsShortestPathDistribution.md"
+    fi
+
+    # SCIP SCC longest path: CSV link only — projection is ephemeral and not available here
+    {
+        if [ -f "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module/SemanticCodeIndexModule_StronglyConnectedComponents_longest_paths_distribution.csv" ]; then
+            echo ""
+            echo "[Full SCC longest path data per project](./SCIP_Semantic_Index_Module/SemanticCodeIndexModule_StronglyConnectedComponents_longest_paths_distribution.csv)"
+        fi
+    } > "${report_include_directory}/ScipModuleSccLongestPathDistribution.md"
+
+    # ── Path finding SVG chart references (SCIP Module) ───────────────────
+    {
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_AllPairsShortestPath_Bar.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_AllPairsShortestPath_Pie.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_AllPairsShortestPath_StackedBar_Log.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_AllPairsShortestPath_StackedBar_Normalised.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_GraphDiameter_per_Project.svg"
+    } > "${report_include_directory}/ScipModuleAllPairsShortestPathCharts.md"
+
+    {
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_LongestPath_Bar.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_LongestPath_Pie.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_LongestPath_StackedBar_Log.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_LongestPath_StackedBar_Normalised.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Module" "SCIP_Semantic_Index_Module_MaxLongestPath_per_Project.svg"
+    } > "${report_include_directory}/ScipModuleSccLongestPathCharts.md"
+
+    # ── Path finding tables (SCIP Artifact) ───────────────────────────────
+    # Guard: only run if SCIP artifact path-finding projection exists.
+    SCIP_ARTIFACT_PROJECTION="dependencies_projection=scip-artifact-path-finding"
+    if projectionExists "${SCIP_ARTIFACT_PROJECTION}"; then
+        {
+            execute_cypher "${PATH_FINDING_CYPHER_DIR}/Path_Finding_5_All_pairs_shortest_path_distribution_overall.cypher" \
+                "${SCIP_ARTIFACT_PROJECTION}" \
+                --output-markdown-table | limit_markdown_table
+            if [ -f "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact/SemanticCodeIndexArtifact_all_pairs_shortest_paths_distribution_per_project.csv" ]; then
+                echo ""
+                echo "[Full data per project](./SCIP_Semantic_Index_Artifact/SemanticCodeIndexArtifact_all_pairs_shortest_paths_distribution_per_project.csv)"
+            fi
+        } > "${report_include_directory}/ScipArtifactAllPairsShortestPathDistribution.md"
+    fi
+
+    # SCIP Artifact SCC longest path: CSV link only
+    {
+        if [ -f "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact/SemanticCodeIndexArtifact_StronglyConnectedComponents_longest_paths_distribution.csv" ]; then
+            echo ""
+            echo "[Full SCC longest path data per project](./SCIP_Semantic_Index_Artifact/SemanticCodeIndexArtifact_StronglyConnectedComponents_longest_paths_distribution.csv)"
+        fi
+    } > "${report_include_directory}/ScipArtifactSccLongestPathDistribution.md"
+
+    # ── Path finding SVG chart references (SCIP Artifact) ─────────────────
+    {
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact" "SCIP_Semantic_Index_Artifact_AllPairsShortestPath_Bar.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact" "SCIP_Semantic_Index_Artifact_AllPairsShortestPath_Pie.svg"
+    } > "${report_include_directory}/ScipArtifactAllPairsShortestPathCharts.md"
+
+    {
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact" "SCIP_Semantic_Index_Artifact_LongestPath_Bar.svg"
+        include_svgs_matching "${FULL_REPORT_DIRECTORY}/SCIP_Semantic_Index_Artifact" "SCIP_Semantic_Index_Artifact_LongestPath_Pie.svg"
+    } > "${report_include_directory}/ScipArtifactSccLongestPathCharts.md"
+
     # ── Graph visualization SVG references (Java Artifact) ────────────────
     {
         include_svg_if_exists "Java_Artifact/Graph_Visualizations/JavaArtifactBuildLevels.svg" \
@@ -324,6 +418,22 @@ assemble_internal_dependencies_report() {
         include_svg_if_exists "NPM_DevPackage/Graph_Visualizations/NpmDevPackageLongestPaths.svg" \
             "NPM Dev Package Longest Paths (with contributors)"
     } > "${report_include_directory}/NpmPackageGraphVisualizations.md"
+
+    # ── Graph visualization SVG references (SCIP Semantic Index) ──────────
+    {
+        include_svg_if_exists "SCIP_Semantic_Index_Module/Graph_Visualizations/ScipModuleBuildLevels.svg" \
+            "SCIP Module Build Levels"
+        include_svg_if_exists "SCIP_Semantic_Index_Module/Graph_Visualizations/ScipModuleLongestPathsIsolated.svg" \
+            "SCIP Module Longest Paths (Isolated)"
+        include_svg_if_exists "SCIP_Semantic_Index_Module/Graph_Visualizations/ScipModuleLongestPaths.svg" \
+            "SCIP Module Longest Paths (with contributors)"
+        include_svg_if_exists "SCIP_Semantic_Index_Artifact/Graph_Visualizations/ScipArtifactBuildLevels.svg" \
+            "SCIP Artifact Build Levels"
+        include_svg_if_exists "SCIP_Semantic_Index_Artifact/Graph_Visualizations/ScipArtifactLongestPathsIsolated.svg" \
+            "SCIP Artifact Longest Paths (Isolated)"
+        include_svg_if_exists "SCIP_Semantic_Index_Artifact/Graph_Visualizations/ScipArtifactLongestPaths.svg" \
+            "SCIP Artifact Longest Paths (with contributors)"
+    } > "${report_include_directory}/ScipGraphVisualizations.md"
 
     # ── Topological sort critical path length KPI ─────────────────────────
 
@@ -366,6 +476,17 @@ assemble_internal_dependencies_report() {
     include_svg_if_exists "Typescript_Module/Typescript_Module_OutgoingDependencies_Bar.svg" \
         "TypeScript Module Outgoing Dependencies" \
         > "${report_include_directory}/Typescript_Module_OutgoingDependencies_Bar.md"
+
+    # SCIP Semantic Index Modules Object-Oriented Design
+    include_svg_if_exists "SCIP_Semantic_Index_Module/SCIP_Module_MainSequence.svg" \
+        "SCIP Module Main Sequence" \
+        > "${report_include_directory}/SCIP_Module_MainSequence.md"
+    include_svg_if_exists "SCIP_Semantic_Index_Module/SCIP_Module_IncomingDependencies_Bar.svg" \
+        "SCIP Module Incoming Dependencies" \
+        > "${report_include_directory}/SCIP_Module_IncomingDependencies_Bar.md"
+    include_svg_if_exists "SCIP_Semantic_Index_Module/SCIP_Module_OutgoingDependencies_Bar.svg" \
+        "SCIP Module Outgoing Dependencies" \
+        > "${report_include_directory}/SCIP_Module_OutgoingDependencies_Bar.md"
 
     # ── Visibility metrics SVG chart references ────────────────────────────
 

--- a/domains/internal-dependencies/summary/report.template.md
+++ b/domains/internal-dependencies/summary/report.template.md
@@ -19,11 +19,15 @@ Analyzes internal dependencies: packages, artifacts, modules, NPM packages withi
 1. [Executive Overview](#1-executive-overview)
 1. [Java Internal Structure](#2-java-internal-structure)
 1. [TypeScript Internal Structure](#3-typescript-internal-structure)
+1. [SCIP Semantic Index Structure](#34-scip-semantic-index-structure)
 1. [Path Finding](#4-path-finding)
+1. [SCIP Semantic Index Path Finding](#44-scip-semantic-index-path-finding)
 1. [Topological Sort](#5-topological-sort)
 1. [Graph Visualizations](#6-graph-visualizations)
+1. [SCIP Semantic Index Graphs](#64-scip-semantic-index-graphs)
 1. [Glossary and Column Definitions](#7-glossary-and-column-definitions)
 1. [Object Oriented Design Metrics](#8-object-oriented-design-metrics)
+1. [SCIP Semantic Index OO Design Metrics](#84-scip-semantic-index-oo-design-metrics)
 1. [Visibility Metrics](#9-visibility-metrics)
 1. [Code Vocabulary](#10-code-vocabulary)
 
@@ -92,6 +96,30 @@ Elements imported by most modules (high ripple risk). Shared utilities or core d
 Low `usedElementsPercent` = public API wider than needed. Candidates for narrower interface.
 
 <!-- include:How_many_elements_used_by_dependent_modules.md|report_no_typescript_data.template.md -->
+
+---
+
+## 3.4 SCIP Semantic Index Structure
+
+SCIP (Semantic Code Intelligence Protocol) indexes represent language-agnostic dependency graphs for TypeScript, Go, Rust, and other supported languages. Modules map to source directories; artifacts to package identifiers.
+
+### 3.4.1 SCIP Module Listing
+
+Modules by type count and dependency connectivity. High incoming = widely imported; high outgoing = broad consumer.
+
+<!-- include:List_all_SCIP_modules.md|empty.md -->
+
+### 3.4.2 SCIP Artifact Listing
+
+Artifacts (package + version) by dependency count. `isExternal = true` = no internal source types.
+
+<!-- include:List_all_SCIP_artifacts.md|empty.md -->
+
+### 3.4.3 SCIP Internal Types
+
+SCIP internal types are numerous and fine-grained — a live table would be impractical. Topological sort results (build order and level) are available in the CSV files below. Type-level visualization is intentionally omitted; use the module-level graphs for structural overview.
+
+<!-- include:ScipInternalTypesTopologicalSort.md|empty.md -->
 
 ---
 
@@ -165,6 +193,48 @@ Deepest sequential TypeScript import chain.
 
 ---
 
+## 4.4 SCIP Semantic Index Path Finding
+
+SCIP graphs may contain cycles; path finding runs on the SCC condensed DAG. Each SCC component represents either a single module or a cycle. Longest paths operate on the component graph.
+
+### 4.4.1 SCIP Module Path Finding
+
+#### 4.4.1.1 All Pairs Shortest Path
+
+Graph diameter over SCIP modules. Higher = deeper transitive dependency chains.
+
+<!-- include:ScipModuleAllPairsShortestPathDistribution.md|empty.md -->
+
+<!-- include:ScipModuleAllPairsShortestPathCharts.md|empty.md -->
+
+#### 4.4.1.2 SCC Longest Path
+
+Longest path through the condensed module DAG. Pre-computed from CSV — SCC projection is ephemeral.
+
+<!-- include:ScipModuleSccLongestPathDistribution.md|empty.md -->
+
+<!-- include:ScipModuleSccLongestPathCharts.md|empty.md -->
+
+### 4.4.2 SCIP Artifact Path Finding
+
+#### 4.4.2.1 All Pairs Shortest Path
+
+Artifact-level graph diameter.
+
+<!-- include:ScipArtifactAllPairsShortestPathDistribution.md|empty.md -->
+
+<!-- include:ScipArtifactAllPairsShortestPathCharts.md|empty.md -->
+
+#### 4.4.2.2 SCC Longest Path
+
+Longest path through the condensed artifact DAG.
+
+<!-- include:ScipArtifactSccLongestPathDistribution.md|empty.md -->
+
+<!-- include:ScipArtifactSccLongestPathCharts.md|empty.md -->
+
+---
+
 ## 5. Topological Sort
 
 Assigns **build level** to each node: Level 0 (no dependencies) → Level N (depends on level N−1).
@@ -202,6 +272,19 @@ Directed graphs: node color = build level (darker = higher level = more transiti
 Build levels and longest paths for NPM packages (prod + dev dependencies).
 
 <!-- include:NpmPackageGraphVisualizations.md|report_no_typescript_data.template.md -->
+
+---
+
+## 6.4 SCIP Semantic Index Graphs
+
+SCC-based build level graphs and longest path visualizations for SCIP modules and artifacts.
+Types are excluded: at the type granularity the graph becomes too large and detailed to be useful — use the module-level graphs for structural overview. Topological sort CSV data for types is available in the CSV report directories.
+
+### 6.4.1 SCIP Module Graphs
+
+**Build levels**: SCC component hierarchy. **Longest paths**: Isolated chain + contributor view (cycle nodes condensed).
+
+<!-- include:ScipGraphVisualizations.md|empty.md -->
 
 ---
 
@@ -257,6 +340,20 @@ Measures conformance to Stable Abstractions Principle(Robert C. Martin): stable 
 <!-- include:Typescript_Module_IncomingDependencies_Bar.md|report_no_typescript_data.template.md -->
 
 <!-- include:Typescript_Module_OutgoingDependencies_Bar.md|report_no_typescript_data.template.md -->
+
+---
+
+## 8.4 SCIP Semantic Index OO Design Metrics
+
+Same principle as Java/TypeScript. Abstractness = abstract types / total types per module. Instability = outgoing / (incoming + outgoing) module dependencies. Visibility metrics are omitted for SCIP (not applicable).
+
+### 8.4.1 SCIP Semantic Index Modules
+
+<!-- include:SCIP_Module_MainSequence.md|empty.md -->
+
+<!-- include:SCIP_Module_IncomingDependencies_Bar.md|empty.md -->
+
+<!-- include:SCIP_Module_OutgoingDependencies_Bar.md|empty.md -->
 
 ---
 

--- a/domains/scip-index-import/README.md
+++ b/domains/scip-index-import/README.md
@@ -167,7 +167,7 @@ domains/scip-index-import/
 ├── testConvertScipIndexToCsvForNeo4jAdminImport.sh # Tests for convertScipIndexToCsvForNeo4jAdminImport.sh
 └── queries/
     ├── import/                            # Phase 1: setup and import
-    │   ├── Cleanup_SCIP_Type_Nodes.cypher
+    │   ├── Cleanup_All_SCIP_Nodes.cypher
     │   ├── Create_SCIP_Internal_Type_Constraint.cypher
     │   ├── Create_SCIP_External_Type_Constraint.cypher
     │   ├── Import_SCIP_Type_Internal_Nodes.cypher
@@ -207,7 +207,7 @@ domains/scip-index-import/
 
 | Query | Purpose |
 |-------|---------|
-| [Cleanup_SCIP_Type_Nodes.cypher](./queries/import/Cleanup_SCIP_Type_Nodes.cypher) | Delete all existing SCIP nodes — clean slate before re-import |
+| [Cleanup_All_SCIP_Nodes.cypher](./queries/import/Cleanup_All_SCIP_Nodes.cypher) | Delete all existing SCIP-labeled nodes (types, modules, artifacts, projects) — ensures clean slate before re-import |
 | [Create_SCIP_Internal_Type_Constraint.cypher](./queries/import/Create_SCIP_Internal_Type_Constraint.cypher) | Create uniqueness constraint on `SemanticCodeIndexInternalType.symbol` |
 | [Create_SCIP_External_Type_Constraint.cypher](./queries/import/Create_SCIP_External_Type_Constraint.cypher) | Create uniqueness constraint on `SemanticCodeIndexExternalType.symbol` |
 | [Import_SCIP_Type_Internal_Nodes.cypher](./queries/import/Import_SCIP_Type_Internal_Nodes.cypher) | Import internal types (own source files); sets `isTest` from file path patterns |

--- a/domains/scip-index-import/README.md
+++ b/domains/scip-index-import/README.md
@@ -5,6 +5,8 @@ Converts SCIP JSON index files to Neo4j import CSVs, imports them into Neo4j, an
 
 Supported languages: Go, Java, TypeScript, Rust, C++, Ruby, Python, C#.
 
+Anonymous inner classes are detected automatically when the SCIP indexer sets `enclosing_symbol` and `relationships[].is_implementation` on local symbols. See [Anonymous Inner Class Support](#anonymous-inner-class-support) below.
+
 See [SCIP.md](../../SCIP.md) for how to generate `.scip.json` files outside the pipeline.
 
 ## How It Works
@@ -154,10 +156,40 @@ analyze.sh  # Updates artifacts/ → triggers resetAndScan → deletes hash → 
 - **Purpose:** Tracks SHA hash of all files in `indices/` directory
 - **Behavior:** Auto-deleted on graph reset; regenerated after successful import
 
-## Folder Structure
+## Anonymous Inner Class Support
 
-```text
-domains/scip-index-import/
+SCIP represents anonymous inner classes as `local` method symbols within their enclosing method, not as top-level type symbols. This pipeline detects and imports them as first-class nodes when the SCIP indexer provides sufficient metadata.
+
+### Requirements
+
+The SCIP indexer must populate two fields on each local symbol that is a method of an anonymous class:
+
+- `enclosing_symbol` — qualified symbol of the enclosing method (e.g. `semanticdb maven ... Manager#execute().`)
+- `relationships[].is_implementation: true` — symbol of the interface method being overridden (e.g. `... Callback#run().`)
+
+Java indexers that use `semanticdb` typically provide both fields. Support for other languages depends on the indexer.
+
+### What Gets Imported
+
+One anonymous class node is created per unique `enclosing_symbol` within a document. If a method contains more than one anonymous class, they share a single node (known limitation — SCIP does not distinguish multiple anonymous classes within the same method).
+
+| Field | Value |
+|-------|-------|
+| `typeName` | `AnonymousClass` |
+| `:LABEL` (admin import) | `SCIP;SemanticCodeIndexInternalType;SemanticCodeIndexAnonymousType` |
+| `isAbstract` | `false` |
+| `isTest` | Derived from file path (same as other internal types) |
+| Node ID format | `<pkg_id> <version> <EnclosingClass>#<method>()$anonymous<N>#` |
+
+Example node ID: `maven/com.example/app 1.0 com/example/Manager#execute()$anonymous3#`
+
+### Edges
+
+Each anonymous class node gets:
+- A `DEPENDS_ON` edge to every type it implements (derived from `relationships[].is_implementation`)
+- A `BELONGS_TO` edge to the project node (admin import only)
+
+## Folder Structure
 ├── README.md                              # This file
 ├── importScipIndexData.sh                 # Entry point: orchestrates CSV conversion + import
 ├── importScipIndexDataWithAdminImport.sh  # Pre-start fast import via neo4j-admin (sourced by analyze.sh)

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -242,7 +242,7 @@ function extract_type_nodes_admin() {
                 {
                     id:             short_symbol($symbol),
                     fqn:            short_symbol($symbol),
-                    name:           ($descriptor | gsub("#"; "") | split("/") | last | gsub("`"; "")),
+                    name:           ($descriptor | gsub("#$"; "") | split("/") | last | gsub("`"; "")),
                     language:       scheme_to_language(scheme($symbol)),
                     scheme:         scheme($symbol),
                     typeName:       $cu_type,
@@ -368,7 +368,7 @@ function extract_external_type_nodes_admin() {
             {
                 id:             short_symbol($symbol),
                 fqn:            short_symbol($symbol),
-                name:           ($descriptor | gsub("#"; "") | split("/") | last | gsub("`"; "")),
+                name:           ($descriptor | gsub("#$"; "") | split("/") | last | gsub("`"; "")),
                 language:       scheme_to_language(scheme($symbol)),
                 scheme:         scheme($symbol),
                 typeName:       $cu_type,

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -484,7 +484,7 @@ function extract_project_metadata_admin() {
             $project_root,
             ($meta.tool_info.name // "unknown"),
             ($meta.tool_info.version // "unknown"),
-            "SCIP:SemanticCodeIndexProject"
+            "SCIP;SemanticCodeIndexProject"
         ] | @csv
     ' "${input_file}"
 }

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -474,6 +474,7 @@ function extract_project_metadata_admin() {
             else
                 $meta.project_root
             end
+            | gsub("/$"; "")
         ) as $project_root |
         (
             # Create a stable FQN from the project root, suitable as node ID
@@ -509,6 +510,7 @@ function extract_type_project_links_admin() {
             else
                 .metadata.project_root
             end
+            | gsub("/$"; "")
             | gsub("[^A-Za-z0-9._-]"; "_")
         ) as $project_fqn |
 

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -65,10 +65,33 @@ JQ_ADMIN_FUNCTIONS='
         symbol | split(" ") | if length >= 5 then .[4] else "" end;
 
     def is_type_descriptor(symbol):
+        descriptor(symbol) | (contains("#") and (endswith("]") | not));
+
+    def is_base_type_descriptor(symbol):
         descriptor(symbol) | endswith("#");
 
     def is_type_parameter_descriptor(symbol):
         descriptor(symbol) | endswith("]");
+
+    def normalize_descriptor(symbol):
+        descriptor(symbol) | split("#")[0] + "#";
+
+    def normalize_symbol(symbol):
+        symbol | split(" ") | 
+        if length >= 5 then
+            .[0:4] as $prefix | 
+            (.[4] | split("#")[0] + "#") as $norm_desc |
+            ($prefix + [$norm_desc]) | join(" ")
+        else
+            symbol
+        end;
+
+    def short_symbol_normalized(s):
+        normalize_symbol(s) | split(" ") | if length >= 5 then
+            .[2:5] | join(" ")
+        else
+            .
+        end;
 
     def null_kind_fallback(signature_text; doc_first_line):
         if (signature_text // "" | test("^public final ")) then "Record"
@@ -200,7 +223,7 @@ function extract_type_nodes_admin() {
 
                 .symbol as $symbol |
 
-                select(is_type_descriptor($symbol)) |
+                select(is_base_type_descriptor($symbol)) |
                 select(is_type_parameter_descriptor($symbol) | not) |
 
                 ($symbol | split(" ")) as $tokens |
@@ -242,7 +265,7 @@ function extract_type_nodes_admin() {
                  select((.symbol_roles // 0) % 2 == 1) |
                  select(.symbol | startswith("local ") | not) |
                  select((.symbol | split(" ") | length) >= 5) |
-                 select(is_type_descriptor(.symbol)) |
+                 select(is_base_type_descriptor(.symbol)) |
                  select(is_type_parameter_descriptor(.symbol) | not) |
                  .symbol
                 ] as $defined_type_symbols |
@@ -323,7 +346,7 @@ function extract_external_type_nodes_admin() {
 
             .symbol as $symbol |
 
-            select(is_type_descriptor($symbol)) |
+            select(is_base_type_descriptor($symbol)) |
             select(is_type_parameter_descriptor($symbol) | not) |
 
             ($symbol | split(" ")) as $tokens |
@@ -378,71 +401,65 @@ function extract_depends_on_edges_admin() {
 
         ($index[0].symbol_to_file)       as $sym_to_file       |
         ($index[0].internal_package_ids) as $internal_pkg_ids  |
-        [
-            .documents[] |
-            .relative_path as $source_file |
 
-                [.occurrences[] |
-                 select((.symbol_roles // 0) % 2 == 1) |
-                 select(.symbol | startswith("local ") | not) |
-                 select((.symbol | split(" ") | length) >= 5) |
-                 select(is_type_descriptor(.symbol)) |
-                 select(is_type_parameter_descriptor(.symbol) | not) |
-                 .symbol
-                ] as $source_type_symbols |
+        .documents[] |
+        .relative_path as $source_file |
 
-                [.occurrences[] |
-                 select((.symbol_roles // 0) % 2 == 0) |
-                 select(.symbol | startswith("local ") | not) |
-                 select((.symbol | split(" ") | length) >= 5) |
-                 .symbol as $ref_symbol |
-                 select(is_type_descriptor($ref_symbol)) |
-                 select(is_type_parameter_descriptor($ref_symbol) | not) |
-                 $sym_to_file[$ref_symbol] as $target_file |
-                 ($ref_symbol | split(" ") | .[2]) as $ref_pkg_id |
-                 (($target_file != null and $target_file != $source_file)
-                  or ($target_file == null
-                        and ($internal_pkg_ids | index($ref_pkg_id)) == null
-                        and $ref_pkg_id != ".")) as $is_valid_target |
-                 select($is_valid_target) |
-                 $ref_symbol
-                ] as $valid_ref_symbols |
+            # Filter and categorize all valid occurrences first (single pass)
+            [.occurrences[] |
+             select(.symbol | startswith("local ") | not) |
+             select((.symbol | split(" ") | length) >= 5) |
+             select(is_type_descriptor(.symbol)) |
+             select(is_type_parameter_descriptor(.symbol) | not) |
+             {symbol: .symbol, role: ((.symbol_roles // 0) % 2)}
+            ] as $valid_occurrences |
 
-                ([.occurrences[] |
-                  select(.symbol | startswith("local ") | not) |
-                  select((.symbol | split(" ") | length) >= 5) |
-                  .symbol as $s |
-                  ($s | split(" ") | .[2]) as $pkg_id |
-                  select(($internal_pkg_ids | index($pkg_id)) != null) |
-                  $s
-                 ] | first) as $first_internal_symbol |
+            # Extract sources (role 1) and raw references (role 0)
+            [$valid_occurrences[] | select(.role == 1) | .symbol] as $source_type_symbols |
+            [$valid_occurrences[] | select(.role == 0) | .symbol] as $all_ref_symbols |
 
-                (if ($source_type_symbols | length) > 0 then
-                     ($source_type_symbols | map(short_symbol(.)))
-                 elif ($valid_ref_symbols | length) > 0 and $first_internal_symbol != null then
-                     [("__file__ " + $source_file)]
-                 else
-                     []
-                 end) as $source_symbols |
+            # Pre-aggregate valid refs by normalized type target, with occurrence count
+            (
+                $all_ref_symbols |
+                group_by(normalize_symbol(.)) |
+                map(
+                    normalize_symbol(.[0]) as $norm |
+                    $sym_to_file[$norm] as $target_file |
+                    (.[0] | split(" ") | .[2]) as $ref_pkg_id |
+                    select(
+                        ($target_file != null and $target_file != $source_file)
+                        or ($target_file == null
+                              and ($internal_pkg_ids | index($ref_pkg_id)) == null
+                              and $ref_pkg_id != ".")
+                    ) |
+                    { target: ($norm | split(" ") | .[2:5] | join(" ")), count: length }
+                )
+            ) as $valid_ref_groups |
 
-                select(($source_symbols | length) > 0) |
-                select(($valid_ref_symbols | length) > 0) |
+            # Find first internal symbol for __file__ fallback
+            ([$valid_occurrences[] |
+              .symbol as $s |
+              ($s | split(" ") | .[2]) as $pkg_id |
+              select(($internal_pkg_ids | index($pkg_id)) != null) |
+              $s
+             ] | first) as $first_internal_symbol |
 
-                $source_symbols[] as $source_symbol |
-                $valid_ref_symbols[] as $ref_symbol |
-                { source_symbol: $source_symbol, target_symbol: short_symbol($ref_symbol) }
-        ] |
+            (if ($source_type_symbols | length) > 0 then
+                 ($source_type_symbols | map(short_symbol(.)))
+             elif ($valid_ref_groups | length) > 0 and $first_internal_symbol != null then
+                 [("__file__ " + $source_file)]
+             else
+                 []
+             end) as $source_symbols |
 
-        group_by([.source_symbol, .target_symbol]) |
-        map(. as $group | {
-            source_symbol:   $group[0].source_symbol,
-            target_symbol:   $group[0].target_symbol,
-            reference_count: ($group | length)
-        }) |
-        sort_by(.source_symbol, .target_symbol) |
+            select(($source_symbols | length) > 0) |
+            select(($valid_ref_groups | length) > 0) |
 
-        .[] | [.source_symbol, .target_symbol, "DEPENDS_ON", .reference_count]
-        | @csv
+            $source_symbols[] as $source_symbol |
+            $valid_ref_groups[] as $ref_group |
+            select($source_symbol != $ref_group.target) |
+            [$source_symbol, $ref_group.target, "DEPENDS_ON", $ref_group.count]
+            | @csv
         ' "${input_file}"
 }
 

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -65,7 +65,7 @@ JQ_ADMIN_FUNCTIONS='
         symbol | split(" ") | if length >= 5 then .[4] else "" end;
 
     def is_type_descriptor(symbol):
-        descriptor(symbol) | (contains("#") and (endswith("]") | not));
+        descriptor(symbol) | (endswith("#") or (test("^.*#\\[") and endswith("]")));
 
     def is_base_type_descriptor(symbol):
         descriptor(symbol) | endswith("#");
@@ -154,7 +154,8 @@ JQ_ADMIN_FUNCTIONS='
 
 function build_symbol_information_index() {
     local input_file="${1}"
-    jq '{
+    local jq_program
+    jq_program="${JQ_ADMIN_FUNCTIONS}"'{
         symbol_to_file: [
             .documents[] |
             .relative_path as $file |
@@ -162,20 +163,20 @@ function build_symbol_information_index() {
             select((.symbol_roles // 0) % 2 == 1) |
             select(.symbol | startswith("local ") | not) |
             { key: .symbol, value: $file }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_kind: [
             .documents[].symbols[]? |
             select(.symbol != null) |
             { key: .symbol, value: (.kind // null) }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_signature_text: [
             .documents[].symbols[]? |
             select(.symbol != null) |
             select(.signature_documentation.text != null) |
             { key: .symbol, value: .signature_documentation.text }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_doc_first_line: [
             .documents[].symbols[]? |
@@ -185,7 +186,7 @@ function build_symbol_information_index() {
             select($doc | startswith("```")) |
             { key: .symbol,
               value: ($doc | split("\n") | .[1] // "") }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         internal_package_ids: [
             .documents[].occurrences[] |
@@ -193,8 +194,20 @@ function build_symbol_information_index() {
             select(.symbol | startswith("local ") | not) |
             select((.symbol | split(" ") | length) >= 5) |
             .symbol | split(" ") | .[2]
-        ] | unique
-    }' "${input_file}"
+        ] | unique,
+        
+        anonymous_classes: [
+            ([.documents[].symbols[]? | select(.symbol != null) | select(.kind == 26 or .kind == 66 or .kind == 67 or .kind == 80) | select(.enclosing_symbol != null and (.enclosing_symbol | startswith("local"))) | .enclosing_symbol] | unique) as $local_classes_with_methods |
+            .documents[] as $doc |
+            $doc.relative_path as $file |
+            ($doc.symbols // []) as $all_symbols |
+            ([$doc.occurrences[]? | select((.symbol_roles // 0) % 2 == 1) | select(.symbol | startswith("local ") | not) | select((.symbol | split(" ") | length) >= 5) | select(is_base_type_descriptor(.symbol)) | .symbol] | first) as $doc_first_type |
+            select($doc_first_type != null) |
+            ($doc_first_type | split(" ")) as $enc_tokens |
+            ([($all_symbols[] | select(.symbol != null and (.kind == 26 or .kind == 66 or .kind == 67 or .kind == 80)) | select(.enclosing_symbol != null and (.enclosing_symbol | startswith("local"))) | .enclosing_symbol as $enc | select(($local_classes_with_methods | index($enc)) != null))] | group_by(.enclosing_symbol)[] | (first(.[] | select(.relationships != null and (.relationships | length > 0))) // .[0]) as $first_method | [.[] | .relationships // []] as $all_relationships | $first_method.enclosing_symbol as $anon_class_sym | ([$all_symbols[] | select(.symbol == $anon_class_sym) | .enclosing_symbol] | first // $doc_first_type) as $anon_class_enclosing_symbol | ($anon_class_sym | sub("^local"; "") | (tonumber? // 0)) as $min_local_num | ((short_symbol($anon_class_enclosing_symbol) | gsub("[.#.]$"; "")) + "$anonymous" + ($min_local_num | tostring) + "#") as $anon_id | {file: $file, anon_id: $anon_id, enclosing_symbol: $doc_first_type, pkg_id: $enc_tokens[2], version: (if ($enc_tokens | length > 3) then $enc_tokens[3] else "." end), manager: (if ($enc_tokens | length > 1) then $enc_tokens[1] else "." end), min_local_num: $min_local_num, relationships: ($all_relationships | flatten // [])})
+        ]
+    }'
+    jq "$jq_program" "${input_file}"
 }
 
 # ---------------------------------------------------------------------------
@@ -351,9 +364,13 @@ function extract_external_type_nodes_admin() {
 
             ($symbol | split(" ")) as $tokens |
             $tokens[1] as $manager    |
-            $tokens[2] as $pkg_id     |
+            $tokens[2] as $pkg_id_from_symbol |
             $tokens[3] as $version    |
             $tokens[4] as $descriptor |
+            
+            # For external types (where pkg_id is "."), extract package from descriptor
+            ($descriptor | split("/")[0:2] | join("/")) as $pkg_from_descriptor |
+            (if $pkg_id_from_symbol == "." then $pkg_from_descriptor else $pkg_id_from_symbol end) as $pkg_id |
 
             select(($internal_pkg_ids | index($pkg_id)) == null) |
             select($pkg_id != ".") |
@@ -581,6 +598,69 @@ function extract_type_project_links_admin() {
     ' "${input_file}"
 }
 
+function extract_anonymous_class_nodes_admin() {
+    local symbol_index_file="${1}"
+    echo "null" | jq -r --slurpfile index "${symbol_index_file}" "${JQ_ADMIN_FUNCTIONS}"'
+        [
+            ($index[0].anonymous_classes // [])[] |
+            {
+                id:             .anon_id,
+                fqn:            .anon_id,
+                name:           (.anon_id | split("$") | .[0] | split("/") | last | gsub("#$"; "")),
+                language:       "Java",
+                scheme:         "semanticdb",
+                typeName:       "AnonymousClass",
+                file:           .file,
+                packageId:      .pkg_id,
+                packageManager: .manager,
+                version:        .version,
+                module:         ((.pkg_id // "") | if test("^[a-z]+/") then sub("^[a-z]+/"; "") else . end),
+                isAbstract:     "false",
+                isTest:         (if is_test(.file) then "true" else "false" end),
+                label:          "SCIP;SemanticCodeIndexAnonymousType;SemanticCodeIndexInternalType"
+            }
+        ] |
+        unique_by(.id) |
+        .[] | [.id, .fqn, .name, .language, .scheme, .typeName, .file, .packageId, .packageManager, .version, .module, .isAbstract, .isTest, .label]
+        | @csv
+    '
+}
+
+function extract_anonymous_class_edges_admin() {
+    local symbol_index_file="${1}"
+    echo "null" | jq -r --slurpfile index "${symbol_index_file}" "${JQ_ADMIN_FUNCTIONS}"'
+        ($index[0].anonymous_classes // [])[] |
+        .anon_id as $anon_id |
+        .relationships[] |
+        select((.is_reference == true) or (.is_implementation == true)) |
+        (.symbol | gsub("#.*"; "#")) as $target |
+        select($target | test("^semanticdb")) |
+        [$anon_id, short_symbol($target), "DEPENDS_ON", 1] | @csv
+    '
+}
+
+function extract_anonymous_class_project_links_admin() {
+    local symbol_index_file="${1}"
+    local input_file="${2}"
+    echo "null" | jq --slurpfile index "${symbol_index_file}" --slurpfile input_doc "${input_file}" "${JQ_ADMIN_FUNCTIONS}"'
+        select(($input_doc[0].metadata // null) != null and ($input_doc[0].metadata.project_root // null) != null) |
+        (
+            if ($input_doc[0].metadata.project_root | test("file://")) then
+                ($input_doc[0].metadata.project_root | gsub("^file://"; ""))
+            else
+                $input_doc[0].metadata.project_root
+            end
+            | gsub("/$"; "")
+            | gsub("[^A-Za-z0-9._-]"; "_")
+        ) as $project_fqn |
+        [
+            ($index[0].anonymous_classes // [])[] |
+            .anon_id |
+            [., $project_fqn, "BELONGS_TO"] | @csv
+        ][]
+    ' -r
+}
+
 function process_single_index_admin() {
     local input_file="${1}"
     local nodes_temp="${2}"
@@ -591,7 +671,14 @@ function process_single_index_admin() {
     echo "convertScipIndexToCsvForNeo4jAdminImport: Processing '${input_file}'..."
 
     local symbol_index_json
-    symbol_index_json="$(build_symbol_information_index "${input_file}")"
+    local build_exit_code=0
+    symbol_index_json="$(build_symbol_information_index "${input_file}")" || { build_exit_code=$?; }
+    
+    if [ "${build_exit_code}" -ne 0 ]; then
+        echo "ERROR: build_symbol_information_index failed with exit code ${build_exit_code}" >&2
+        echo "JSON output from jq: ${symbol_index_json}" >&2
+        return "${build_exit_code}"
+    fi
 
     # Write JSON to temporary file to avoid "Argument list too long" error with large indices
     local symbol_index_file
@@ -608,9 +695,14 @@ function process_single_index_admin() {
     fi
     # External nodes never emit a header
     extract_external_type_nodes_admin "${symbol_index_file}" "${input_file}" >> "${nodes_temp}"
+    
+    extract_anonymous_class_nodes_admin "${symbol_index_file}" >> "${nodes_temp}"
 
     extract_depends_on_edges_admin "${symbol_index_file}" "${input_file}" > "${edges_temp}"
+    extract_anonymous_class_edges_admin "${symbol_index_file}" >> "${edges_temp}"
+    
     extract_type_project_links_admin "${symbol_index_file}" "${input_file}" > "${links_temp}"
+    extract_anonymous_class_project_links_admin "${symbol_index_file}" "${input_file}" >> "${links_temp}"
 }
 
 # ---------------------------------------------------------------------------
@@ -724,6 +816,79 @@ function merge_project_csvs_admin() {
 }
 
 # ---------------------------------------------------------------------------
+# Validate that all edge node references exist in the nodes CSV
+# Input: nodes CSV file and edges CSV file
+# Returns: 0 if valid, 1 if missing nodes found; prints detailed error message
+# ---------------------------------------------------------------------------
+
+function validate_edge_node_references() {
+    local nodes_file="${1}"
+    local edges_file="${2}"
+
+    # Build set of all valid node IDs from nodes CSV (skip header)
+    local valid_nodes_file
+    valid_nodes_file=$(mktemp)
+    # Extract first column (quoted or unquoted) from nodes CSV and deduplicate
+    tail -n +2 "${nodes_file}" | awk -F',' '{
+        node_id = $1
+        gsub(/^"/, "", node_id)
+        gsub(/"$/, "", node_id)
+        print node_id
+    }' | sort -u > "${valid_nodes_file}"
+
+    # Check edges for missing node references
+    local missing_nodes_file
+    missing_nodes_file=$(mktemp)
+    trap "rm -f '${valid_nodes_file}' '${missing_nodes_file}'" RETURN
+
+    local missing_count=0
+    tail -n +2 "${edges_file}" | awk -F',' -v nodes_file="${valid_nodes_file}" '
+        BEGIN {
+            while ((getline node_line < nodes_file) > 0) {
+                valid_nodes[node_line] = 1
+            }
+            close(nodes_file)
+        }
+        {
+            start_id = $1
+            end_id = $2
+            gsub(/^"/, "", start_id)
+            gsub(/"$/, "", start_id)
+            gsub(/^"/, "", end_id)
+            gsub(/"$/, "", end_id)
+            
+            if (!(start_id in valid_nodes)) {
+                print "START_NODE: " start_id
+            }
+            if (!(end_id in valid_nodes)) {
+                print "END_NODE: " end_id
+            }
+        }
+    ' | sort -u > "${missing_nodes_file}"
+
+    if [ -s "${missing_nodes_file}" ]; then
+        echo "convertScipIndexToCsvForNeo4jAdminImport: ERROR: Found missing node references in edges CSV." >&2
+        echo "convertScipIndexToCsvForNeo4jAdminImport: These edge references point to nodes that don't exist:" >&2
+        head -20 "${missing_nodes_file}" | sed 's/^/  /' >&2
+        local total_missing
+        total_missing=$(wc -l < "${missing_nodes_file}")
+        if [ "${total_missing}" -gt 20 ]; then
+            echo "  ... and $(( total_missing - 20 )) more" >&2
+        fi
+        echo "" >&2
+        echo "convertScipIndexToCsvForNeo4jAdminImport: This usually means:" >&2
+        echo "  - Method/constructor symbols are being referenced as edges but not created as nodes" >&2
+        echo "  - Symbol normalization is inconsistent between node and edge extraction" >&2
+        echo "" >&2
+        echo "convertScipIndexToCsvForNeo4jAdminImport: Nodes CSV: ${nodes_file}" >&2
+        echo "convertScipIndexToCsvForNeo4jAdminImport: Edges CSV: ${edges_file}" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # Merge per-file BELONGS_TO link CSVs: deduplicate by (type_id, project_fqn)
 # Input: directory containing *_admin_links.csv files
 # ---------------------------------------------------------------------------
@@ -797,6 +962,13 @@ merge_project_csvs_admin "${tmp_dir}" "${projects_output}"
 
 echo "convertScipIndexToCsvForNeo4jAdminImport: Merging BELONGS_TO link CSVs → '${links_output}'..."
 merge_belongs_to_links_admin "${tmp_dir}" "${links_output}"
+
+# Validate that all edge references point to existing nodes
+echo "convertScipIndexToCsvForNeo4jAdminImport: Validating edge-node references..."
+if ! validate_edge_node_references "${nodes_output}" "${edges_output}"; then
+    echo "convertScipIndexToCsvForNeo4jAdminImport: Validation FAILED. Cannot proceed with Neo4j import." >&2
+    exit 1
+fi
 
 node_count=$(( $(wc -l < "${nodes_output}") - 1 ))
 project_count=$(( $(wc -l < "${projects_output}") - 1 ))

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -19,6 +19,13 @@ IMPORT_DIRECTORY=${IMPORT_DIRECTORY:-"./import"}
 CONVERT_SCIP_ADMIN_SCRIPT_DIR=${CONVERT_SCIP_ADMIN_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P )}
 echo "convertScipIndexToCsvForNeo4jAdminImport: CONVERT_SCIP_ADMIN_SCRIPT_DIR=${CONVERT_SCIP_ADMIN_SCRIPT_DIR}"
 
+_SCIP_ADMIN_DEBUG=false
+
+function debug_log() {
+    [ "${_SCIP_ADMIN_DEBUG}" = "true" ] || return 0
+    echo "convertScipIndexToCsvForNeo4jAdminImport: DEBUG: $*" >&2
+}
+
 function validate_prerequisites() {
     if ! command -v jq >/dev/null 2>&1; then
         echo "convertScipIndexToCsvForNeo4jAdminImport: Error: jq is required but not found in PATH." >&2
@@ -685,24 +692,90 @@ function process_single_index_admin() {
     symbol_index_file=$(mktemp)
     # shellcheck disable=SC2064
     trap "rm -f '${symbol_index_file}'" RETURN
+    
+    debug_log "Writing symbol index to temporary file: ${symbol_index_file}"
     echo "${symbol_index_json}" > "${symbol_index_file}"
+    
+    # Verify the index file was written and is not empty
+    local index_size
+    index_size=$(wc -c < "${symbol_index_file}")
+    debug_log "Symbol index file size: ${index_size} bytes"
+    if [ "${index_size}" -lt 10 ]; then
+        echo "ERROR: Symbol index file is too small (${index_size} bytes)" >&2
+        return 3
+    fi
+    
+    if [ "${_SCIP_ADMIN_DEBUG}" = "true" ]; then
+        echo "convertScipIndexToCsvForNeo4jAdminImport: DEBUG: First 500 chars of symbol_index_file:" >&2
+        head -c 500 "${symbol_index_file}" >&2
+        echo "" >&2
+    fi
+    debug_log "Validating JSON syntax..."
+    if ! jq empty "${symbol_index_file}" 2>&1; then
+        echo "ERROR: Symbol index file contains invalid JSON" >&2
+        echo "Full content of symbol index file:" >&2
+        cat "${symbol_index_file}" >&2
+        return 3
+    fi
+    debug_log "JSON syntax is valid"
 
+    debug_log "Extracting internal type nodes (emit_header=${emit_header})..."
     if [ "${emit_header}" = "true" ]; then
-        extract_type_nodes_admin "${symbol_index_file}" "${input_file}" > "${nodes_temp}"
+        extract_output=$(extract_type_nodes_admin "${symbol_index_file}" "${input_file}" 2>&1)
+        extract_exit=$?
+        if [ "${extract_exit}" -ne 0 ]; then
+            echo "ERROR: extract_type_nodes_admin failed with exit code ${extract_exit}" >&2
+            echo "Output from extract_type_nodes_admin:" >&2
+            echo "${extract_output}" >&2
+            return "${extract_exit}"
+        fi
+        echo "${extract_output}" > "${nodes_temp}"
     else
         # Skip the header line (first line) from internal nodes
-        extract_type_nodes_admin "${symbol_index_file}" "${input_file}" | tail -n +2 > "${nodes_temp}"
+        extract_output=$(extract_type_nodes_admin "${symbol_index_file}" "${input_file}" 2>&1)
+        extract_exit=$?
+        if [ "${extract_exit}" -ne 0 ]; then
+            echo "ERROR: extract_type_nodes_admin failed with exit code ${extract_exit}" >&2
+            echo "Output from extract_type_nodes_admin:" >&2
+            echo "${extract_output}" >&2
+            return "${extract_exit}"
+        fi
+        echo "${extract_output}" | tail -n +2 > "${nodes_temp}"
     fi
-    # External nodes never emit a header
-    extract_external_type_nodes_admin "${symbol_index_file}" "${input_file}" >> "${nodes_temp}"
+    local nodes_after_internal=$(wc -l < "${nodes_temp}" 2>/dev/null || echo "0")
+    debug_log "Internal nodes written: ${nodes_after_internal} lines"
     
-    extract_anonymous_class_nodes_admin "${symbol_index_file}" >> "${nodes_temp}"
+    debug_log "Extracting external type nodes..."
+    extract_external_type_nodes_admin "${symbol_index_file}" "${input_file}" >> "${nodes_temp}" 2>&1
+    local nodes_after_external=$(wc -l < "${nodes_temp}" 2>/dev/null || echo "0")
+    debug_log "Total nodes after external: ${nodes_after_external} lines"
+    
+    debug_log "Extracting anonymous class nodes..."
+    extract_anonymous_class_nodes_admin "${symbol_index_file}" >> "${nodes_temp}" 2>&1
+    local nodes_final=$(wc -l < "${nodes_temp}" 2>/dev/null || echo "0")
+    debug_log "Total nodes after anonymous classes: ${nodes_final} lines"
 
-    extract_depends_on_edges_admin "${symbol_index_file}" "${input_file}" > "${edges_temp}"
-    extract_anonymous_class_edges_admin "${symbol_index_file}" >> "${edges_temp}"
+    debug_log "Extracting DEPENDS_ON edges..."
+    extract_depends_on_edges_admin "${symbol_index_file}" "${input_file}" > "${edges_temp}" 2>&1
+    local edges_count=$(wc -l < "${edges_temp}" 2>/dev/null || echo "0")
+    debug_log "DEPENDS_ON edges written: ${edges_count} lines"
     
-    extract_type_project_links_admin "${symbol_index_file}" "${input_file}" > "${links_temp}"
-    extract_anonymous_class_project_links_admin "${symbol_index_file}" "${input_file}" >> "${links_temp}"
+    debug_log "Extracting anonymous class edges..."
+    extract_anonymous_class_edges_admin "${symbol_index_file}" >> "${edges_temp}" 2>&1
+    local edges_final=$(wc -l < "${edges_temp}" 2>/dev/null || echo "0")
+    debug_log "Total edges after anonymous classes: ${edges_final} lines"
+    
+    debug_log "Extracting type project links..."
+    extract_type_project_links_admin "${symbol_index_file}" "${input_file}" > "${links_temp}" 2>&1
+    local links_count=$(wc -l < "${links_temp}" 2>/dev/null || echo "0")
+    debug_log "Project links written: ${links_count} lines"
+    
+    debug_log "Extracting anonymous class project links..."
+    extract_anonymous_class_project_links_admin "${symbol_index_file}" "${input_file}" >> "${links_temp}" 2>&1
+    local links_final=$(wc -l < "${links_temp}" 2>/dev/null || echo "0")
+    debug_log "Total project links: ${links_final} lines"
+    
+    debug_log "Successfully completed processing of '${input_file}'"
 }
 
 # ---------------------------------------------------------------------------
@@ -933,18 +1006,31 @@ tmp_dir=$(mktemp -d)
 trap "rm -rf '${tmp_dir}'" EXIT
 
 first_file=true
+debug_log "Starting processing of SCIP index files"
 while IFS= read -r index_file; do
+    debug_log "Processing index file: ${index_file}"
     file_stem=$(basename "${index_file}" .scip.json | tr -cs 'A-Za-z0-9_-' '_')
     nodes_temp="${tmp_dir}/${file_stem}_admin_nodes.csv"
     edges_temp="${tmp_dir}/${file_stem}_admin_edges.csv"
     projects_temp="${tmp_dir}/${file_stem}_admin_projects.csv"
     links_temp="${tmp_dir}/${file_stem}_admin_links.csv"
 
-    process_single_index_admin "${index_file}" "${nodes_temp}" "${edges_temp}" "${links_temp}" "${first_file}"
+    debug_log "Calling process_single_index_admin with file_stem=${file_stem}"
+    _exit_code=0
+    process_single_index_admin "${index_file}" "${nodes_temp}" "${edges_temp}" "${links_temp}" "${first_file}" || { _exit_code=$?; }
+    if [ "${_exit_code}" -ne 0 ]; then
+        echo "ERROR: process_single_index_admin failed with exit code ${_exit_code}" >&2
+        exit "${_exit_code}"
+    fi
+    debug_log "process_single_index_admin completed successfully"
+    
+    debug_log "Calling extract_project_metadata_admin"
     extract_project_metadata_admin "${index_file}" "${first_file}" >> "${projects_temp}"
+    debug_log "extract_project_metadata_admin completed"
 
     first_file=false
 done < <(find "${INDICES_DIRECTORY}" -maxdepth 1 -name "*.scip.json" -type f | sort)
+debug_log "Finished processing all SCIP index files"
 
 nodes_output="${IMPORT_DIRECTORY}/scip_type_nodes_admin.csv"
 edges_output="${IMPORT_DIRECTORY}/scip_type_edges_admin.csv"

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -173,6 +173,7 @@ function extract_type_nodes() {
             else
                 $project_root_raw
             end
+            | gsub("/$"; "")
         ) as $project_root |
 
         (
@@ -300,6 +301,7 @@ function extract_external_type_nodes() {
             else
                 $project_root_raw
             end
+            | gsub("/$"; "")
         ) as $project_root |
         [
             .documents[] |
@@ -454,6 +456,7 @@ function extract_project_metadata() {
             else
                 $meta.project_root
             end
+            | gsub("/$"; "")
         ) as $project_root |
         [
             $project_root,

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -135,7 +135,7 @@ JQ_SHARED_FUNCTIONS='
 
 function build_symbol_information_index() {
     local input_file="${1}"
-    jq '{
+    jq "${JQ_SHARED_FUNCTIONS}"'{
         symbol_to_file: [
             .documents[] |
             .relative_path as $file |
@@ -143,20 +143,20 @@ function build_symbol_information_index() {
             select((.symbol_roles // 0) % 2 == 1) |
             select(.symbol | startswith("local ") | not) |
             { key: .symbol, value: $file }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_kind: [
             .documents[].symbols[]? |
             select(.symbol != null) |
             { key: .symbol, value: (.kind // null) }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_signature_text: [
             .documents[].symbols[]? |
             select(.symbol != null) |
             select(.signature_documentation.text != null) |
             { key: .symbol, value: .signature_documentation.text }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         symbol_to_doc_first_line: [
             .documents[].symbols[]? |
@@ -166,7 +166,7 @@ function build_symbol_information_index() {
             select($doc | startswith("```")) |
             { key: .symbol,
               value: ($doc | split("\n") | .[1] // "") }
-        ] | from_entries,
+        ] | (reduce .[] as $kv ({}; .[$kv.key] = $kv.value)),
 
         internal_package_ids: [
             .documents[].occurrences[] |
@@ -174,7 +174,28 @@ function build_symbol_information_index() {
             select(.symbol | startswith("local ") | not) |
             select((.symbol | split(" ") | length) >= 5) |
             .symbol | split(" ") | .[2]
-        ] | unique
+        ] | unique,
+
+        project_root: (
+            (.metadata.project_root // "unknown") as $project_root_raw |
+            if ($project_root_raw | test("file://")) then
+                ($project_root_raw | gsub("^file://"; ""))
+            else
+                $project_root_raw
+            end
+            | gsub("/$"; "")
+        ),
+
+        anonymous_classes: [
+            ([.documents[].symbols[]? | select(.symbol != null) | select(.kind == 26 or .kind == 66 or .kind == 67 or .kind == 80) | select(.enclosing_symbol != null and (.enclosing_symbol | startswith("local"))) | .enclosing_symbol] | unique) as $local_classes_with_methods |
+            .documents[] as $doc |
+            $doc.relative_path as $file |
+            ($doc.symbols // []) as $all_symbols |
+            ([$doc.occurrences[]? | select((.symbol_roles // 0) % 2 == 1) | select(.symbol | startswith("local ") | not) | select((.symbol | split(" ") | length) >= 5) | select(is_base_type_descriptor(.symbol)) | .symbol] | first) as $doc_first_type |
+            select($doc_first_type != null) |
+            ($doc_first_type | split(" ")) as $enc_tokens |
+            ([($all_symbols[] | select(.symbol != null and (.kind == 26 or .kind == 66 or .kind == 67 or .kind == 80)) | select(.enclosing_symbol != null and (.enclosing_symbol | startswith("local"))) | .enclosing_symbol as $enc | select(($local_classes_with_methods | index($enc)) != null))] | group_by(.enclosing_symbol)[] | (first(.[] | select(.relationships != null and (.relationships | length > 0))) // .[0]) as $first_method | [.[] | .relationships // []] as $all_relationships | $first_method.enclosing_symbol as $anon_class_sym | ([$all_symbols[] | select(.symbol == $anon_class_sym) | .enclosing_symbol] | first // $doc_first_type) as $anon_class_enclosing_symbol | ($anon_class_sym | sub("^local"; "") | (tonumber? // 0)) as $min_local_num | ((short_symbol($anon_class_enclosing_symbol) | gsub("[.#.]$"; "")) + "$anonymous" + ($min_local_num | tostring) + "#") as $anon_id | {file: $file, anon_id: $anon_id, enclosing_symbol: $doc_first_type, pkg_id: $enc_tokens[2], version: (if ($enc_tokens | length > 3) then $enc_tokens[3] else "." end), manager: (if ($enc_tokens | length > 1) then $enc_tokens[1] else "." end), min_local_num: $min_local_num, relationships: ($all_relationships | flatten // [])})
+        ]
     }' "${input_file}"
 }
 
@@ -483,6 +504,44 @@ function extract_project_metadata() {
     ' "${input_file}"
 }
 
+function extract_anonymous_class_nodes() {
+    local symbol_index_file="${1}"
+    echo "null" | jq -r --slurpfile index "${symbol_index_file}" '
+        [
+            ($index[0].anonymous_classes // [])[] |
+            {
+                symbol:          .anon_id,
+                display_name:    (.anon_id | split("$") | .[0] | split("/") | last | gsub("#$"; "")),
+                scheme:          "semanticdb",
+                type_name:       "AnonymousClass",
+                file:            .file,
+                package_id:      .pkg_id,
+                package_manager: .manager,
+                version:         .version,
+                module:          ((.pkg_id // "") | if test("^[a-z]+/") then sub("^[a-z]+/"; "") else . end),
+                is_abstract:     "false",
+                project_root:    ($index[0].project_root // "")
+            }
+        ] |
+        unique_by(.symbol) |
+        .[] | [.symbol, .display_name, .scheme, .type_name, .file, .package_id, .package_manager, .version, .module, .is_abstract, .project_root]
+        | @csv
+    '
+}
+
+function extract_anonymous_class_edges() {
+    local symbol_index_file="${1}"
+    echo "null" | jq -r --slurpfile index "${symbol_index_file}" "${JQ_SHARED_FUNCTIONS}"'
+        ($index[0].anonymous_classes // [])[] |
+        .anon_id as $anon_id |
+        .relationships[] |
+        select((.is_reference == true) or (.is_implementation == true)) |
+        (.symbol | gsub("#.*"; "#")) as $target |
+        select($target | test("^semanticdb")) |
+        [$anon_id, short_symbol($target), 1] | @csv
+    '
+}
+
 # ---------------------------------------------------------------------------
 # Process a single .scip.json file to temporary per-file CSVs
 # ---------------------------------------------------------------------------
@@ -512,8 +571,11 @@ function process_single_index() {
     fi
     # External nodes never emit a header
     extract_external_type_nodes "${symbol_index_file}" "${input_file}" >> "${nodes_temp}"
+    
+    extract_anonymous_class_nodes "${symbol_index_file}" >> "${nodes_temp}"
 
     extract_depends_on_edges "${symbol_index_file}" "${input_file}" > "${edges_temp}"
+    extract_anonymous_class_edges "${symbol_index_file}" >> "${edges_temp}"
 }
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -65,10 +65,33 @@ JQ_SHARED_FUNCTIONS='
         symbol | split(" ") | if length >= 5 then .[4] else "" end;
 
     def is_type_descriptor(symbol):
+        descriptor(symbol) | (contains("#") and (endswith("]") | not));
+
+    def is_base_type_descriptor(symbol):
         descriptor(symbol) | endswith("#");
 
     def is_type_parameter_descriptor(symbol):
         descriptor(symbol) | endswith("]");
+
+    def normalize_descriptor(symbol):
+        descriptor(symbol) | split("#")[0] + "#";
+
+    def normalize_symbol(symbol):
+        symbol | split(" ") | 
+        if length >= 5 then
+            .[0:4] as $prefix | 
+            (.[4] | split("#")[0] + "#") as $norm_desc |
+            ($prefix + [$norm_desc]) | join(" ")
+        else
+            symbol
+        end;
+
+    def short_symbol_normalized(s):
+        normalize_symbol(s) | split(" ") | if length >= 5 then
+            .[2:5] | join(" ")
+        else
+            .
+        end;
 
     def null_kind_fallback(signature_text; doc_first_line):
         if (signature_text // "" | test("^public final ")) then "Record"
@@ -188,7 +211,7 @@ function extract_type_nodes() {
 
                 .symbol as $symbol |
 
-                select(is_type_descriptor($symbol)) |
+                select(is_base_type_descriptor($symbol)) |
                 select(is_type_parameter_descriptor($symbol) | not) |
 
                 ($symbol | split(" ")) as $tokens |
@@ -227,7 +250,7 @@ function extract_type_nodes() {
                  select((.symbol_roles // 0) % 2 == 1) |
                  select(.symbol | startswith("local ") | not) |
                  select((.symbol | split(" ") | length) >= 5) |
-                 select(is_type_descriptor(.symbol)) |
+                 select(is_base_type_descriptor(.symbol)) |
                  select(is_type_parameter_descriptor(.symbol) | not) |
                  .symbol
                 ] as $defined_type_symbols |
@@ -364,71 +387,65 @@ function extract_depends_on_edges() {
 
         ($index[0].symbol_to_file)       as $sym_to_file       |
         ($index[0].internal_package_ids) as $internal_pkg_ids  |
-        [
-            .documents[] |
-            .relative_path as $source_file |
 
-                [.occurrences[] |
-                 select((.symbol_roles // 0) % 2 == 1) |
-                 select(.symbol | startswith("local ") | not) |
-                 select((.symbol | split(" ") | length) >= 5) |
-                 select(is_type_descriptor(.symbol)) |
-                 select(is_type_parameter_descriptor(.symbol) | not) |
-                 .symbol
-                ] as $source_type_symbols |
+        .documents[] |
+        .relative_path as $source_file |
 
-                [.occurrences[] |
-                 select((.symbol_roles // 0) % 2 == 0) |
-                 select(.symbol | startswith("local ") | not) |
-                 select((.symbol | split(" ") | length) >= 5) |
-                 .symbol as $ref_symbol |
-                 select(is_type_descriptor($ref_symbol)) |
-                 select(is_type_parameter_descriptor($ref_symbol) | not) |
-                 $sym_to_file[$ref_symbol] as $target_file |
-                 ($ref_symbol | split(" ") | .[2]) as $ref_pkg_id |
-                 (($target_file != null and $target_file != $source_file)
-                  or ($target_file == null
-                        and ($internal_pkg_ids | index($ref_pkg_id)) == null
-                        and $ref_pkg_id != ".")) as $is_valid_target |
-                 select($is_valid_target) |
-                 $ref_symbol
-                ] as $valid_ref_symbols |
+            # Filter and categorize all valid occurrences first (single pass)
+            [.occurrences[] |
+             select(.symbol | startswith("local ") | not) |
+             select((.symbol | split(" ") | length) >= 5) |
+             select(is_type_descriptor(.symbol)) |
+             select(is_type_parameter_descriptor(.symbol) | not) |
+             {symbol: .symbol, role: ((.symbol_roles // 0) % 2)}
+            ] as $valid_occurrences |
 
-                ([.occurrences[] |
-                  select(.symbol | startswith("local ") | not) |
-                  select((.symbol | split(" ") | length) >= 5) |
-                  .symbol as $s |
-                  ($s | split(" ") | .[2]) as $pkg_id |
-                  select(($internal_pkg_ids | index($pkg_id)) != null) |
-                  $s
-                 ] | first) as $first_internal_symbol |
+            # Extract sources (role 1) and raw references (role 0)
+            [$valid_occurrences[] | select(.role == 1) | .symbol] as $source_type_symbols |
+            [$valid_occurrences[] | select(.role == 0) | .symbol] as $all_ref_symbols |
 
-                (if ($source_type_symbols | length) > 0 then
-                     ($source_type_symbols | map(short_symbol(.)))
-                 elif ($valid_ref_symbols | length) > 0 and $first_internal_symbol != null then
-                     [("__file__ " + $source_file)]
-                 else
-                     []
-                 end) as $source_symbols |
+            # Pre-aggregate valid refs by normalized type target, with occurrence count
+            (
+                $all_ref_symbols |
+                group_by(normalize_symbol(.)) |
+                map(
+                    normalize_symbol(.[0]) as $norm |
+                    $sym_to_file[$norm] as $target_file |
+                    (.[0] | split(" ") | .[2]) as $ref_pkg_id |
+                    select(
+                        ($target_file != null and $target_file != $source_file)
+                        or ($target_file == null
+                              and ($internal_pkg_ids | index($ref_pkg_id)) == null
+                              and $ref_pkg_id != ".")
+                    ) |
+                    { target: ($norm | split(" ") | .[2:5] | join(" ")), count: length }
+                )
+            ) as $valid_ref_groups |
 
-                select(($source_symbols | length) > 0) |
-                select(($valid_ref_symbols | length) > 0) |
+            # Find first internal symbol for __file__ fallback
+            ([$valid_occurrences[] |
+              .symbol as $s |
+              ($s | split(" ") | .[2]) as $pkg_id |
+              select(($internal_pkg_ids | index($pkg_id)) != null) |
+              $s
+             ] | first) as $first_internal_symbol |
 
-                $source_symbols[] as $source_symbol |
-                $valid_ref_symbols[] as $ref_symbol |
-                { source_symbol: $source_symbol, target_symbol: short_symbol($ref_symbol) }
-        ] |
+            (if ($source_type_symbols | length) > 0 then
+                 ($source_type_symbols | map(short_symbol(.)))
+             elif ($valid_ref_groups | length) > 0 and $first_internal_symbol != null then
+                 [("__file__ " + $source_file)]
+             else
+                 []
+             end) as $source_symbols |
 
-        group_by([.source_symbol, .target_symbol]) |
-        map(. as $group | {
-            source_symbol:   $group[0].source_symbol,
-            target_symbol:   $group[0].target_symbol,
-            reference_count: ($group | length)
-        }) |
-        sort_by(.source_symbol, .target_symbol) |
+            select(($source_symbols | length) > 0) |
+            select(($valid_ref_groups | length) > 0) |
 
-        .[] | [.source_symbol, .target_symbol, (.reference_count | tostring)]
-        | @csv
+            $source_symbols[] as $source_symbol |
+            $valid_ref_groups[] as $ref_group |
+            select($source_symbol != $ref_group.target) |
+            [$source_symbol, $ref_group.target, ($ref_group.count | tostring)]
+            | @csv
         ' "${input_file}"
 }
 

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -229,7 +229,7 @@ function extract_type_nodes() {
 
                 {
                     symbol:          short_symbol($symbol),
-                    display_name:    ($descriptor | gsub("#"; "") | split("/") | last | gsub("`"; "")),
+                    display_name:    ($descriptor | gsub("#$"; "") | split("/") | last | gsub("`"; "")),
                     scheme:          scheme($symbol),
                     type_name:       $cu_type,
                     file:            $file,
@@ -357,7 +357,7 @@ function extract_external_type_nodes() {
 
             {
                 symbol:          short_symbol($symbol),
-                display_name:    ($descriptor | gsub("#"; "") | split("/") | last | gsub("`"; "")),
+                display_name:    ($descriptor | gsub("#$"; "") | split("/") | last | gsub("`"; "")),
                 scheme:          scheme($symbol),
                 type_name:       $cu_type,
                 file:            "",

--- a/domains/scip-index-import/importScipIndexData.sh
+++ b/domains/scip-index-import/importScipIndexData.sh
@@ -78,8 +78,8 @@ else
     echo "importScipIndexData: $(date +'%Y-%m-%dT%H:%M:%S%z') Converting SCIP index files to CSV..."
     ( INDICES_DIRECTORY="${INDICES_DIRECTORY}" IMPORT_DIRECTORY="${IMPORT_DIRECTORY}" bash "${SCIP_INDEX_IMPORT_SCRIPT_DIR}/convertScipIndexToCsvForNeo4jImport.sh" )
 
-    echo "importScipIndexData: $(date +'%Y-%m-%dT%H:%M:%S%z') Cleaning up existing SCIP type nodes..."
-    execute_cypher "${IMPORT_QUERIES_DIR}/Cleanup_SCIP_Type_Nodes.cypher"
+    echo "importScipIndexData: $(date +'%Y-%m-%dT%H:%M:%S%z') Cleaning up existing SCIP nodes..."
+    execute_cypher "${IMPORT_QUERIES_DIR}/Cleanup_All_SCIP_Nodes.cypher"
 
     echo "importScipIndexData: $(date +'%Y-%m-%dT%H:%M:%S%z') Creating SCIP type uniqueness constraints..."
     execute_cypher "${IMPORT_QUERIES_DIR}/Create_SCIP_Internal_Type_Constraint.cypher"

--- a/domains/scip-index-import/importScipIndexDataWithAdminImport.sh
+++ b/domains/scip-index-import/importScipIndexDataWithAdminImport.sh
@@ -94,7 +94,7 @@ function try_admin_import() {
 
     # Note: neo4j-admin database import full will fail if the database already exists,
     # but this is acceptable — the failure triggers fallback to LOAD CSV. The LOAD CSV path
-    # will clean existing data via Cypher (Cleanup_SCIP_Type_Nodes.cypher) before re-importing.
+    # will clean existing data via Cypher (Cleanup_All_SCIP_Nodes.cypher) before re-importing.
     # We do not pre-delete database files here as that would manipulate Neo4j's internal state.
 
     # Convert SCIP index files to neo4j-admin import CSVs

--- a/domains/scip-index-import/queries/enrichment/Set_SCIP_Artifact_Project_Name.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_SCIP_Artifact_Project_Name.cypher
@@ -3,6 +3,5 @@
 
 MATCH (p:SCIP:SemanticCodeIndexProject)-[:CONTAINS]->(a:SCIP:SemanticCodeIndexArtifact)
 WHERE p.name IS NOT NULL
-  AND a.projectName IS NULL
 SET a.projectName = p.name
 RETURN count(*) AS updatedNodes

--- a/domains/scip-index-import/queries/enrichment/Set_SCIP_Module_Project_Name.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_SCIP_Module_Project_Name.cypher
@@ -3,6 +3,5 @@
 
 MATCH (a:SCIP:SemanticCodeIndexArtifact)-[:CONTAINS]->(m:SCIP:SemanticCodeIndexModule)
 WHERE a.projectName IS NOT NULL
-  AND m.projectName IS NULL
 SET m.projectName = a.projectName
 RETURN count(*) AS updatedNodes

--- a/domains/scip-index-import/queries/enrichment/Set_SCIP_Project_Short_Name.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_SCIP_Project_Short_Name.cypher
@@ -3,7 +3,6 @@
 
 MATCH (p:SCIP:SemanticCodeIndexProject)
 WHERE p.projectRoot IS NOT NULL
-  AND p.name IS NULL
 SET p.name = CASE 
               WHEN p.projectRoot CONTAINS '/' 
               THEN REVERSE(SPLIT(REVERSE(p.projectRoot), '/')[0])

--- a/domains/scip-index-import/queries/enrichment/Set_SCIP_Type_Project_Name.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_SCIP_Type_Project_Name.cypher
@@ -1,7 +1,7 @@
 // Set "projectName" property on SemanticCodeIndexInternalType and SemanticCodeIndexExternalType nodes using the module property set during import.
+// Only set if projectName is not already defined to preserve any intentional custom values.
 
 MATCH (n:SCIP&SemanticCodeIndexInternalType|SCIP&SemanticCodeIndexExternalType)
-WHERE n.module IS NOT NULL
-  AND n.projectName IS NULL
-  SET n.projectName = n.module
+WHERE n.module IS NOT NULL AND n.projectName IS NULL
+SET n.projectName = n.module
 RETURN count(*) AS updatedNodes

--- a/domains/scip-index-import/queries/import/Cleanup_All_SCIP_Nodes.cypher
+++ b/domains/scip-index-import/queries/import/Cleanup_All_SCIP_Nodes.cypher
@@ -1,0 +1,5 @@
+// Remove all SCIP-labeled nodes and their relationships from Neo4j. Ensures a clean slate for re-import.
+// This replaces individual type node cleanup and removes orphaned modules, artifacts, and projects.
+
+MATCH (node:SCIP)
+DETACH DELETE node

--- a/domains/scip-index-import/queries/import/Import_SCIP_Type_External_Nodes.cypher
+++ b/domains/scip-index-import/queries/import/Import_SCIP_Type_External_Nodes.cypher
@@ -23,6 +23,6 @@ SET node.fqn            = row.symbol,
     node.packageManager = row.package_manager,
     node.version        = row.version,
     node.module         = row.module,
-    node.isAbstract     = (row.is_abstract = 'true'),
+    node.isAbstract     = (row.is_abstract = 'true') OR (row.display_name = 'package-info.java'),
     node.isTest         = false
 RETURN count(*) AS writtenRelationships

--- a/domains/scip-index-import/queries/import/Import_SCIP_Type_Internal_Nodes.cypher
+++ b/domains/scip-index-import/queries/import/Import_SCIP_Type_Internal_Nodes.cypher
@@ -23,7 +23,7 @@ SET node.fqn            = row.symbol,
     node.packageManager = row.package_manager,
     node.version        = row.version,
     node.module         = row.module,
-    node.isAbstract     = (row.is_abstract = 'true'),
+    node.isAbstract     = (row.is_abstract = 'true') OR (row.display_name = 'package-info.java'),
     node.isTest         = (
                             row.file CONTAINS '/test/'    OR
                             row.file CONTAINS '/tests/'   OR

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
@@ -88,7 +88,23 @@ function assert_equals() {
         FAIL_COUNT=$((FAIL_COUNT + 1))
     fi
 }
-
+function assert_no_duplicate_nodes() {
+    local description="${1}"
+    local node_csv="${2}"
+    if [[ ! -f "${node_csv}" ]]; then
+        return  # Skip if file doesn't exist
+    fi
+    local total_nodes=$(tail -n +2 "${node_csv}" 2>/dev/null | wc -l || echo 0)
+    local unique_nodes=$(tail -n +2 "${node_csv}" 2>/dev/null | cut -d',' -f1 | sort -u | wc -l || echo 0)
+    if [[ ${total_nodes} -eq ${unique_nodes} ]]; then
+        echo "  PASS: ${description} (${unique_nodes} unique nodes)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL: ${description}"
+        echo "        Found ${total_nodes} total nodes but only ${unique_nodes} unique (${((total_nodes - unique_nodes))} duplicates)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
 # ---------------------------------------------------------------------------
 # Fixtures — minimal SCIP JSON documents for each test scenario
 # ---------------------------------------------------------------------------
@@ -229,6 +245,174 @@ function create_second_java_scip_json() {
       "symbols": [
         {
           "symbol": "semanticdb maven maven/com.other/lib 2.0 com/other/Bar#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with method-suffixed type references (var-inferred dependencies).
+# Tests that references like "TypeName#methodName()." are properly normalized and create edges.
+function create_method_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Handler.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Handler#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#handle().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#process().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Handler#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "kind": 7
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/com/example/Interceptor.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#handle().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#process().",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with field-suffixed type references.
+# Tests that field references like "TypeName#fieldName." are properly normalized.
+function create_field_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Config.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Config#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#provider.",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#cache.",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Config#",
+          "kind": 7
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/com/example/Factory.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#provider.",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#cache.",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with same-type method references to test self-loop filtering.
+# Tests that references from a type to its own methods do not create self-loop edges.
+function create_self_loop_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Service.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#execute().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#execute().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#validate().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#validate().",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#",
           "kind": 7
         }
       ]
@@ -479,6 +663,107 @@ multi_edges=$(cat "${multi_import_dir}/scip_type_edges_admin.csv")
 # Bar (project B) references Foo (external from B) 3 times → referenceCount:int=3
 assert_contains "Bar→Foo edge exists in merged edges" "com/other/Bar#" "${multi_edges}"
 assert_contains "Bar→Foo referenceCount:int summed to 3" ',3' "${multi_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: method-suffixed references (var-inferred dependencies)
+# ---------------------------------------------------------------------------
+
+echo "Test: method-suffixed type references (admin import)"
+method_ref_indices_dir="${tmp_test_dir}/method_ref_indices"
+method_ref_import_dir="${tmp_test_dir}/method_ref_import"
+mkdir -p "${method_ref_indices_dir}"
+
+create_method_reference_scip_json > "${method_ref_indices_dir}/method_refs.scip.json"
+
+run_script_with_env "${method_ref_indices_dir}" "${method_ref_import_dir}"
+assert_exit_code "exits 0 for method-suffixed references" "0" "${exit_code}"
+
+method_ref_edges_admin_csv="${method_ref_import_dir}/scip_type_edges_admin.csv"
+assert_file_exists "creates admin edge CSV with method references" "${method_ref_edges_admin_csv}"
+
+method_ref_edges=$(cat "${method_ref_edges_admin_csv}")
+# Handler references Interceptor methods (handle(), process()) and type
+# All should normalize to base type Interceptor# and create edges
+assert_contains "edge from Handler to Interceptor" "com/example/Handler#" "${method_ref_edges}"
+assert_contains "target is Interceptor base type" "com/example/Interceptor#" "${method_ref_edges}"
+
+# Verify admin-specific fields (relationship type, isInternal, language)
+assert_contains "edge has DEPENDS_ON relationship type" "DEPENDS_ON" "${method_ref_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: field-suffixed references (var-inferred field dependencies)
+# ---------------------------------------------------------------------------
+
+echo "Test: field-suffixed type references (admin import)"
+field_ref_indices_dir="${tmp_test_dir}/field_ref_indices"
+field_ref_import_dir="${tmp_test_dir}/field_ref_import"
+mkdir -p "${field_ref_indices_dir}"
+
+create_field_reference_scip_json > "${field_ref_indices_dir}/field_refs.scip.json"
+
+run_script_with_env "${field_ref_indices_dir}" "${field_ref_import_dir}"
+assert_exit_code "exits 0 for field-suffixed references" "0" "${exit_code}"
+
+field_ref_edges_admin_csv="${field_ref_import_dir}/scip_type_edges_admin.csv"
+assert_file_exists "creates admin edge CSV with field references" "${field_ref_edges_admin_csv}"
+
+field_ref_edges=$(cat "${field_ref_edges_admin_csv}")
+# Config references Factory fields (provider., cache.) and type
+# All should normalize to base type Factory# and create edges
+assert_contains "edge from Config to Factory (from field ref .provider)" "com/example/Config#" "${field_ref_edges}"
+assert_contains "target is Factory base type" "com/example/Factory#" "${field_ref_edges}"
+
+# Verify admin-specific fields
+assert_contains "edge has relationship type" "DEPENDS_ON" "${field_ref_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: self-loop filtering (method refs within same type should not create edges)
+# ---------------------------------------------------------------------------
+
+echo "Test: self-loop filtering for same-type method references (admin import)"
+self_loop_indices_dir="${tmp_test_dir}/self_loop_indices"
+self_loop_import_dir="${tmp_test_dir}/self_loop_import"
+mkdir -p "${self_loop_indices_dir}"
+
+create_self_loop_scip_json > "${self_loop_indices_dir}/self_loop.scip.json"
+
+run_script_with_env "${self_loop_indices_dir}" "${self_loop_import_dir}"
+assert_exit_code "exits 0 for self-loop test" "0" "${exit_code}"
+
+self_loop_edges_admin_csv="${self_loop_import_dir}/scip_type_edges_admin.csv"
+assert_file_exists "creates admin edge CSV" "${self_loop_edges_admin_csv}"
+
+self_loop_edges=$(cat "${self_loop_edges_admin_csv}")
+# Service defines methods execute() and validate(), and has internal references to them
+# These should NOT create self-loop edges (Service → Service)
+self_loop_count=$(echo "${self_loop_edges}" | grep "com/example/Service#" | grep "com/example/Service#" || true)
+if [[ -z "${self_loop_count}" ]]; then
+    echo "  PASS: self-loops (Service→Service) are filtered out"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    echo "  FAIL: self-loops should be filtered, but found: ${self_loop_count}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+echo ""
+
+# Test: node deduplication
+echo "Test: node deduplication (no duplicate base types, admin import)"
+node_dedup_indices_dir="${tmp_test_dir}/node_dedup_indices"
+node_dedup_import_dir="${tmp_test_dir}/node_dedup_import"
+mkdir -p "${node_dedup_indices_dir}"
+
+# Use method_reference fixture which has potential for duplicate nodes if filtering is wrong
+create_method_reference_scip_json > "${node_dedup_indices_dir}/method_ref.scip.json"
+
+run_script_with_env "${node_dedup_indices_dir}" "${node_dedup_import_dir}"
+assert_exit_code "exits 0 for node dedup test" "0" "${exit_code}"
+
+node_dedup_nodes_csv="${node_dedup_import_dir}/scip_type_nodes_admin.csv"
+assert_file_exists "creates admin node CSV" "${node_dedup_nodes_csv}"
+assert_no_duplicate_nodes "no duplicate nodes (base types only, admin)" "${node_dedup_nodes_csv}"
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Tests convertScipIndexToCsvForNeo4jAdminImport.sh: validation, CSV columns, multi-file merge, admin-specific fields.
+# Tests convertScipIndexToCsvForNeo4jAdminImport.sh: validation, CSV columns, multi-file merge, admin-specific fields, anonymous inner classes.
 # Follows testConvertScipIndexToCsvForNeo4jImport.sh structure and assertion helpers.
 # Requires jq to be installed for the core test cases.
 
@@ -28,9 +28,11 @@ function assert_exit_code() {
         echo "  PASS: ${description}"
         PASS_COUNT=$((PASS_COUNT + 1))
     else
-        echo "  FAIL: ${description}"
-        echo "        Expected exit code: ${expected_exit}, got: ${actual_exit}"
-        FAIL_COUNT=$((FAIL_COUNT + 1))
+        echo "  FAIL: exits ${expected_exit} for ${description}" >&2
+        echo "        Expected exit code: ${expected_exit}, got: ${actual_exit}" >&2
+        echo "        Script output (first 50 lines):" >&2
+        echo "${output:-<empty>}" | head -50 | sed 's/^/        /' >&2
+        test_failed
     fi
 }
 
@@ -764,6 +766,181 @@ assert_exit_code "exits 0 for node dedup test" "0" "${exit_code}"
 node_dedup_nodes_csv="${node_dedup_import_dir}/scip_type_nodes_admin.csv"
 assert_file_exists "creates admin node CSV" "${node_dedup_nodes_csv}"
 assert_no_duplicate_nodes "no duplicate nodes (base types only, admin)" "${node_dedup_nodes_csv}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fixture: Java class with one anonymous inner class implementing Callback.
+# local 3 has enclosing_symbol + relationships.is_implementation to verify
+# anonymous class node creation and DEPENDS_ON edge generation.
+# ---------------------------------------------------------------------------
+
+function create_anonymous_class_scip_json() {
+    cat << 'EOF'
+{
+  "metadata": {
+    "project_root": "file:///tmp/test-anon-project",
+    "tool_info": {"name": "test-indexer", "version": "1.0"}
+  },
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Manager.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven jdk 11 com/example/Callback#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#execute().",
+          "kind": 26
+        },
+        {
+          "symbol": "local 0",
+          "kind": null,
+          "enclosing_symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#execute()."
+        },
+        {
+          "symbol": "local 3",
+          "display_name": "run",
+          "kind": 26,
+          "enclosing_symbol": "local 0",
+          "relationships": [
+            {
+              "symbol": "semanticdb maven jdk 11 com/example/Callback#run().",
+              "is_implementation": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test: anonymous inner class node creation (admin import)
+# ---------------------------------------------------------------------------
+
+echo "Test: anonymous inner class node (admin import)"
+anon_indices_dir="${tmp_test_dir}/anon_indices"
+anon_import_dir="${tmp_test_dir}/anon_import"
+mkdir -p "${anon_indices_dir}"
+create_anonymous_class_scip_json > "${anon_indices_dir}/manager.scip.json"
+
+run_script_with_env "${anon_indices_dir}" "${anon_import_dir}"
+if [ "${exit_code}" -ne 0 ]; then
+    echo "❌ Script failed with exit code ${exit_code}. Output:"
+    echo "${output}"
+fi
+assert_exit_code "exits 0 for anonymous class fixture" "0" "${exit_code}"
+
+anon_nodes_csv="${anon_import_dir}/scip_type_nodes_admin.csv"
+assert_file_exists "creates admin node CSV for anonymous class fixture" "${anon_nodes_csv}"
+
+anon_nodes=$(cat "${anon_nodes_csv}")
+assert_contains "anonymous class node has \$anonymous in ID"          '$anonymous'                                              "${anon_nodes}"
+assert_contains "anonymous class node has typeName=AnonymousClass"    '"AnonymousClass"'                                        "${anon_nodes}"
+assert_contains "anonymous class node has AnonymousType label"        "SemanticCodeIndexAnonymousType"                          "${anon_nodes}"
+assert_contains "anonymous class node has InternalType label"         "SemanticCodeIndexInternalType"                           "${anon_nodes}"
+assert_contains "anonymous class node has language=Java"              '"Java"'                                                  "${anon_nodes}"
+assert_contains "anonymous class node has isAbstract:boolean=false"   '"false"'                                                 "${anon_nodes}"
+assert_contains "enclosing class Manager also exists as node"         "com/example/Manager#"                                    "${anon_nodes}"
+assert_no_duplicate_nodes "no duplicate nodes with anonymous class"   "${anon_nodes_csv}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: anonymous inner class DEPENDS_ON edge to implemented interface (admin)
+# ---------------------------------------------------------------------------
+
+echo "Test: anonymous inner class DEPENDS_ON edge (admin import)"
+anon_edges_csv="${anon_import_dir}/scip_type_edges_admin.csv"
+assert_file_exists "creates admin edge CSV for anonymous class fixture" "${anon_edges_csv}"
+
+anon_edges=$(cat "${anon_edges_csv}")
+assert_contains "anonymous class depends on Callback interface" '$anonymous'              "${anon_edges}"
+assert_contains "anonymous DEPENDS_ON edge targets Callback#"  "com/example/Callback#"  "${anon_edges}"
+assert_contains "edge has DEPENDS_ON relationship type"        "DEPENDS_ON"              "${anon_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: anonymous inner class BELONGS_TO project link (admin import)
+# ---------------------------------------------------------------------------
+
+echo "Test: anonymous inner class BELONGS_TO link (admin import)"
+anon_links_csv="${anon_import_dir}/scip_type_project_links_admin.csv"
+assert_file_exists "creates admin link CSV for anonymous class fixture" "${anon_links_csv}"
+
+anon_links=$(cat "${anon_links_csv}")
+assert_contains "anonymous class node has BELONGS_TO link" '$anonymous' "${anon_links}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: local symbol without methods inside must NOT produce anonymous class node
+# Covers the false-positive case: local variables with enclosing_symbol but no
+# methods (kind=26/66/67/80) nested inside them. Only true anonymous inner classes
+# (with methods inside) should be detected.
+# ---------------------------------------------------------------------------
+
+echo "Test: no anonymous class node for local symbol without methods (admin)"
+no_anon_indices_dir="${tmp_test_dir}/no_anon_indices"
+no_anon_import_dir="${tmp_test_dir}/no_anon_import"
+mkdir -p "${no_anon_indices_dir}"
+cat << 'EOF' > "${no_anon_indices_dir}/constructor.scip.json"
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/MyException.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#`<init>`(+1).",
+          "kind": 26
+        },
+        {
+          "symbol": "local 1",
+          "display_name": "message",
+          "kind": 13,
+          "enclosing_symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#`<init>`(+1)."
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+run_script_with_env "${no_anon_indices_dir}" "${no_anon_import_dir}"
+assert_exit_code "exits 0 for no-is_implementation fixture" "0" "${exit_code}"
+
+no_anon_nodes_csv="${no_anon_import_dir}/scip_type_nodes_admin.csv"
+assert_file_exists "creates admin node CSV" "${no_anon_nodes_csv}"
+
+no_anon_nodes=$(cat "${no_anon_nodes_csv}")
+if echo "${no_anon_nodes}" | grep -qF '$anonymous'; then
+    echo "  FAIL: local symbol without methods inside should NOT create anonymous class node"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "  PASS: no anonymous class node for local symbol without methods"
+    PASS_COUNT=$((PASS_COUNT + 1))
+fi
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Tests convertScipIndexToCsvForNeo4jImport.sh: validation, CSV columns, multi-file merge.
+# Tests convertScipIndexToCsvForNeo4jImport.sh: validation, CSV columns, multi-file merge, anonymous inner classes.
 # Adapted from getting-started-with-scip/type-graph/create-type-graph-csv-test.sh.
 # Requires jq to be installed for the core test cases.
 
@@ -606,6 +606,156 @@ assert_exit_code "exits 0 for node dedup test" "0" "${exit_code}"
 node_dedup_nodes_csv="${node_dedup_import_dir}/scip_type_nodes.csv"
 assert_file_exists "creates node CSV" "${node_dedup_nodes_csv}"
 assert_no_duplicate_nodes "no duplicate nodes (base types only)" "${node_dedup_nodes_csv}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fixture: Java class with one anonymous inner class implementing Callback.
+# local 3 has enclosing_symbol + relationships.is_implementation to verify
+# anonymous class node creation and DEPENDS_ON edge generation.
+# ---------------------------------------------------------------------------
+
+function create_anonymous_class_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Manager.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven jdk 11 com/example/Callback#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#execute().",
+          "kind": 26
+        },
+        {
+          "symbol": "local 0",
+          "kind": null,
+          "enclosing_symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Manager#execute()."
+        },
+        {
+          "symbol": "local 3",
+          "display_name": "run",
+          "kind": 26,
+          "enclosing_symbol": "local 0",
+          "relationships": [
+            {
+              "symbol": "semanticdb maven jdk 11 com/example/Callback#run().",
+              "is_implementation": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test: anonymous inner class node creation (LOAD CSV)
+# ---------------------------------------------------------------------------
+
+echo "Test: anonymous inner class node (LOAD CSV)"
+anon_indices_dir="${tmp_test_dir}/anon_indices"
+anon_import_dir="${tmp_test_dir}/anon_import"
+mkdir -p "${anon_indices_dir}"
+create_anonymous_class_scip_json > "${anon_indices_dir}/manager.scip.json"
+
+run_script_with_env "${anon_indices_dir}" "${anon_import_dir}"
+assert_exit_code "exits 0 for anonymous class fixture" "0" "${exit_code}"
+
+anon_nodes_csv="${anon_import_dir}/scip_type_nodes.csv"
+assert_file_exists "creates node CSV for anonymous class fixture" "${anon_nodes_csv}"
+
+anon_nodes=$(cat "${anon_nodes_csv}")
+assert_contains "anonymous class node has \$anonymous in symbol"    '$anonymous'               "${anon_nodes}"
+assert_contains "anonymous class node has type_name=AnonymousClass" '"AnonymousClass"'         "${anon_nodes}"
+assert_contains "enclosing class Manager also exists as node"       "com/example/Manager#"     "${anon_nodes}"
+assert_no_duplicate_nodes "no duplicate nodes with anonymous class" "${anon_nodes_csv}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: anonymous inner class DEPENDS_ON edge to implemented interface (LOAD CSV)
+# ---------------------------------------------------------------------------
+
+echo "Test: anonymous inner class DEPENDS_ON edge (LOAD CSV)"
+anon_edges_csv="${anon_import_dir}/scip_type_edges.csv"
+assert_file_exists "creates edge CSV for anonymous class fixture" "${anon_edges_csv}"
+
+anon_edges=$(cat "${anon_edges_csv}")
+assert_contains "anonymous class depends on Callback interface" '$anonymous'             "${anon_edges}"
+assert_contains "anonymous DEPENDS_ON edge targets Callback#"   "com/example/Callback#" "${anon_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: local symbol without methods inside must NOT produce anonymous class node
+# Covers the false-positive case: local variables with enclosing_symbol but no
+# methods (kind=26/66/67/80) nested inside them. Only true anonymous inner classes
+# (with methods inside) should be detected.
+# ---------------------------------------------------------------------------
+
+echo "Test: no anonymous class node for local symbol without methods"
+no_anon_indices_dir="${tmp_test_dir}/no_anon_indices"
+no_anon_import_dir="${tmp_test_dir}/no_anon_import"
+mkdir -p "${no_anon_indices_dir}"
+cat << 'EOF' > "${no_anon_indices_dir}/constructor.scip.json"
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/MyException.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#`<init>`(+1).",
+          "kind": 26
+        },
+        {
+          "symbol": "local 1",
+          "display_name": "message",
+          "kind": 13,
+          "enclosing_symbol": "semanticdb maven maven/com.example/app 1.0 com/example/MyException#`<init>`(+1)."
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+run_script_with_env "${no_anon_indices_dir}" "${no_anon_import_dir}"
+assert_exit_code "exits 0 for no-methods fixture" "0" "${exit_code}"
+
+no_anon_nodes_csv="${no_anon_import_dir}/scip_type_nodes.csv"
+assert_file_exists "creates node CSV" "${no_anon_nodes_csv}"
+
+no_anon_nodes=$(cat "${no_anon_nodes_csv}")
+if echo "${no_anon_nodes}" | grep -qF '$anonymous'; then
+    echo "  FAIL: local symbol without methods inside should NOT create anonymous class node"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+    echo "  PASS: no anonymous class node for local symbol without methods"
+    PASS_COUNT=$((PASS_COUNT + 1))
+fi
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
@@ -75,6 +75,24 @@ function assert_equals() {
     fi
 }
 
+function assert_no_duplicate_nodes() {
+    local description="${1}"
+    local node_csv="${2}"
+    if [[ ! -f "${node_csv}" ]]; then
+        return  # Skip if file doesn't exist
+    fi
+    local total_nodes=$(tail -n +2 "${node_csv}" 2>/dev/null | wc -l || echo 0)
+    local unique_nodes=$(tail -n +2 "${node_csv}" 2>/dev/null | cut -d',' -f1 | sort -u | wc -l || echo 0)
+    if [[ ${total_nodes} -eq ${unique_nodes} ]]; then
+        echo "  PASS: ${description} (${unique_nodes} unique nodes)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL: ${description}"
+        echo "        Found ${total_nodes} total nodes but only ${unique_nodes} unique (${((total_nodes - unique_nodes))} duplicates)"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # Minimal valid SCIP JSON for Java-like project
 # ---------------------------------------------------------------------------
@@ -140,6 +158,174 @@ function create_second_java_scip_json() {
       "symbols": [
         {
           "symbol": "semanticdb maven maven/com.other/lib 2.0 com/other/Bar#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with method-suffixed type references (var-inferred dependencies).
+# Tests that references like "TypeName#methodName()." are properly normalized and create edges.
+function create_method_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Handler.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Handler#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#handle().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#process().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Handler#",
+          "kind": 7
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "kind": 7
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/com/example/Interceptor.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#handle().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#process().",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Interceptor#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with field-suffixed type references.
+# Tests that field references like "TypeName#fieldName." are properly normalized.
+function create_field_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Config.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Config#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#provider.",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#cache.",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Config#",
+          "kind": 7
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/com/example/Factory.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#provider.",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#cache.",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Factory#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Creates SCIP JSON with same-type method references to test self-loop filtering.
+# Tests that references from a type to its own methods do not create self-loop edges.
+function create_self_loop_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/com/example/Service.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#execute().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#execute().",
+          "symbol_roles": 0
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#validate().",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#validate().",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven maven/com.example/app 1.0 com/example/Service#",
           "kind": 7
         }
       ]
@@ -305,6 +491,121 @@ assert_exit_code "exits 0 with .sha file present" "0" "${exit_code}"
 
 sha_nodes_csv="${sha_import_dir}/scip_type_nodes.csv"
 assert_file_exists "creates scip_type_nodes.csv despite .sha file" "${sha_nodes_csv}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: method-suffixed references (var-inferred dependencies)
+# ---------------------------------------------------------------------------
+
+echo "Test: method-suffixed type references"
+method_ref_indices_dir="${tmp_test_dir}/method_ref_indices"
+method_ref_import_dir="${tmp_test_dir}/method_ref_import"
+mkdir -p "${method_ref_indices_dir}"
+
+create_method_reference_scip_json > "${method_ref_indices_dir}/method_refs.scip.json"
+
+run_script_with_env "${method_ref_indices_dir}" "${method_ref_import_dir}"
+assert_exit_code "exits 0 for method-suffixed references" "0" "${exit_code}"
+
+method_ref_edges_csv="${method_ref_import_dir}/scip_type_edges.csv"
+assert_file_exists "creates edge CSV with method references" "${method_ref_edges_csv}"
+
+method_ref_edges=$(cat "${method_ref_edges_csv}")
+# Handler references Interceptor methods (handle(), process()) and type
+# All three should normalize to base type Interceptor# and create edges
+assert_contains "edge from Handler to Interceptor (from method ref #handle())" "com/example/Handler#" "${method_ref_edges}"
+assert_contains "target is Interceptor base type" "com/example/Interceptor#" "${method_ref_edges}"
+
+# Count edges from Handler to Interceptor: should include edges from method references
+handler_to_interceptor=$(echo "${method_ref_edges}" | grep "com/example/Handler#" | grep "com/example/Interceptor#" || true)
+if [[ -n "${handler_to_interceptor}" ]]; then
+    echo "  PASS: method-suffixed references create edges to base type"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    echo "  FAIL: method-suffixed references should create edges to base type"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: field-suffixed references (var-inferred field dependencies)
+# ---------------------------------------------------------------------------
+
+echo "Test: field-suffixed type references"
+field_ref_indices_dir="${tmp_test_dir}/field_ref_indices"
+field_ref_import_dir="${tmp_test_dir}/field_ref_import"
+mkdir -p "${field_ref_indices_dir}"
+
+create_field_reference_scip_json > "${field_ref_indices_dir}/field_refs.scip.json"
+
+run_script_with_env "${field_ref_indices_dir}" "${field_ref_import_dir}"
+assert_exit_code "exits 0 for field-suffixed references" "0" "${exit_code}"
+
+field_ref_edges_csv="${field_ref_import_dir}/scip_type_edges.csv"
+assert_file_exists "creates edge CSV with field references" "${field_ref_edges_csv}"
+
+field_ref_edges=$(cat "${field_ref_edges_csv}")
+# Config references Factory fields (provider., cache.) and type
+# All should normalize to base type Factory# and create edges
+assert_contains "edge from Config to Factory (from field ref .provider)" "com/example/Config#" "${field_ref_edges}"
+assert_contains "target is Factory base type" "com/example/Factory#" "${field_ref_edges}"
+
+# Field references should create edges to base type
+config_to_factory=$(echo "${field_ref_edges}" | grep "com/example/Config#" | grep "com/example/Factory#" || true)
+if [[ -n "${config_to_factory}" ]]; then
+    echo "  PASS: field-suffixed references create edges to base type"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    echo "  FAIL: field-suffixed references should create edges to base type"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test: self-loop filtering (method refs within same type should not create edges)
+# ---------------------------------------------------------------------------
+
+echo "Test: self-loop filtering for same-type method references"
+self_loop_indices_dir="${tmp_test_dir}/self_loop_indices"
+self_loop_import_dir="${tmp_test_dir}/self_loop_import"
+mkdir -p "${self_loop_indices_dir}"
+
+create_self_loop_scip_json > "${self_loop_indices_dir}/self_loop.scip.json"
+
+run_script_with_env "${self_loop_indices_dir}" "${self_loop_import_dir}"
+assert_exit_code "exits 0 for self-loop test" "0" "${exit_code}"
+
+self_loop_edges_csv="${self_loop_import_dir}/scip_type_edges.csv"
+assert_file_exists "creates edge CSV" "${self_loop_edges_csv}"
+
+self_loop_edges=$(cat "${self_loop_edges_csv}")
+# Service defines methods execute() and validate(), and has internal references to them
+# These should NOT create self-loop edges (Service → Service)
+self_loop_count=$(echo "${self_loop_edges}" | grep "com/example/Service#" | grep "com/example/Service#" || true)
+if [[ -z "${self_loop_count}" ]]; then
+    echo "  PASS: self-loops (Service→Service) are filtered out"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    echo "  FAIL: self-loops should be filtered, but found: ${self_loop_count}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+echo ""
+
+# Test: node deduplication
+echo "Test: node deduplication (no duplicate base types)"
+node_dedup_indices_dir="${tmp_test_dir}/node_dedup_indices"
+node_dedup_import_dir="${tmp_test_dir}/node_dedup_import"
+mkdir -p "${node_dedup_indices_dir}"
+
+# Use method_reference fixture which has potential for duplicate nodes if filtering is wrong
+create_method_reference_scip_json > "${node_dedup_indices_dir}/method_ref.scip.json"
+
+run_script_with_env "${node_dedup_indices_dir}" "${node_dedup_import_dir}"
+assert_exit_code "exits 0 for node dedup test" "0" "${exit_code}"
+
+node_dedup_nodes_csv="${node_dedup_import_dir}/scip_type_nodes.csv"
+assert_file_exists "creates node CSV" "${node_dedup_nodes_csv}"
+assert_no_duplicate_nodes "no duplicate nodes (base types only)" "${node_dedup_nodes_csv}"
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/test_node_dedup.sh
+++ b/domains/scip-index-import/test_node_dedup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Test SCIP index node deduplication for anonymous classes with method-suffixed symbol references.
+
+set -o errexit -o pipefail -o nounset
+IFS=$'\n\t'
+
+# Get this "domains/scip-index-import" directory
+SCIP_TEST_SCRIPT_DIR=${SCIP_TEST_SCRIPT_DIR:-$( CDPATH=. cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null && pwd -P )}
+SCIP_CONVERSION_SCRIPT="${SCIP_TEST_SCRIPT_DIR}/convertScipIndexToCsvForNeo4jImport.sh"
+
+# Create a test SCIP index with method-suffixed references to check node deduplication
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+cat > "$TEST_DIR/test.scip.json" << 'SCIP'
+{
+  "documents": [
+    {
+      "relative_path": "ExampleClass.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/ExampleClass#", "symbol_roles": 1, "range": [0, 0, 0, 10]},
+        {"symbol": "semanticdb maven . . org/example/TargetClass#doSomething().", "symbol_roles": 0, "range": [1, 0, 1, 10]}
+      ]
+    }
+  ],
+  "external_symbols": [
+    {"symbol": "semanticdb maven . . org/example/TargetClass#", "kind": "Class", "documentation": "Target class"}
+  ]
+}
+SCIP
+
+# Convert using main script
+INDICES_DIRECTORY="$TEST_DIR" IMPORT_DIRECTORY="$TEST_DIR/neo4j-import" bash "$SCIP_CONVERSION_SCRIPT" > /dev/null 2>&1
+
+# Check node CSV for duplicates
+NODE_CSV="$TEST_DIR/neo4j-import/scip_type_nodes.csv"
+if [ -f "$NODE_CSV" ]; then
+  UNIQUE_NODES=$(tail -n +2 "$NODE_CSV" | cut -d',' -f1 | sort -u | wc -l)
+  TOTAL_NODES=$(tail -n +2 "$NODE_CSV" | wc -l)
+  echo ""
+  echo "Node deduplication check:"
+  echo "  Total node entries: $TOTAL_NODES"
+  echo "  Unique node entries: $UNIQUE_NODES"
+  if [ "$UNIQUE_NODES" -eq "$TOTAL_NODES" ]; then
+    echo "  Result: ✓ No duplicate nodes"
+  else
+    echo "  Result: ✗ Found duplicate nodes"
+  fi
+fi


### PR DESCRIPTION
### 🚀 Feature

- [Extend support for SCIP indices in internal dependencies domain](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/cb2ec56e08b9d1e77345e889787014abd10aeb18)
- [Detect anonymous inner classes in SCIP indices](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/fd1f0db7893931021e5f15308409fce39aef57de)

### ⚙️ Optimization

- [Ignore line length warnings when using markdownlint](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/2a6a89d8b37030c6352cb4b4c6b033e399e60d0e)
- [Improve re-importing SCIP indices](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/3dc529f11d794909a10a99d6a1e1ba1065c7dc7b)
- [add optional internal debug for scip admin import](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/cd249f677b8bb5e74a24ee9bb035ad00a07a2c1f)

### 🛠 Fix

- [Fix typo in SCIP project label from admin import](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/3474f5a30e66358992060d0df1ce055c72c717fa)
- [Support trailing slash in SCIP index project root](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/9dfc83c88b71b9e00010e855a4476912f58a2d19)
- [Fix missing SCIP "Occurrence" dependencies](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/c93e6ccda8c5c3e3a2bff25b31ca225d036574c2)
- [Treat package-info.java as an abstract type](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/f86178cd129deae8ecbc9fab4bc265efcfec7f81)
- [Retain separation character of SCIP data for sub type names](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/a6056fbd0ee2f1752e57ed64d7077b77bcc2f7d1)


### 📖 Documentation

- [Ignore line length warnings when using markdownlint](https://github.com/JohT/code-graph-analysis-pipeline/pull/631/commits/9f2bcd43731d06848b55779dc7f42685acee4958)