### PR TITLE
Fix SCIP & Java dependency property enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This document describes the changes to the Code Graph Analysis Pipeline. The changes are grouped by version and date. The latest version is at the top.
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+* **SCIP inner type dependencies fixed** — Inner type references (e.g., `Cache#EntryListener#`) are now correctly preserved instead of being collapsed to their enclosing type. Applies across all SCIP-supported languages. Regression tests added.
+
+### 📋 Known Limitations - Documented
+
+* **Generic type parameters and type annotations** — SCIP indexers do not capture type references in generic type parameters or complex type annotations (e.g., `<T extends ProcessingContext>`). See [SCIP.md Known Limitations](SCIP.md#generic-type-parameters-and-type-annotations) for details.
+
 ## v4.0.1 Improve charts to look more similar to previous Jupyter notebook charts and add pipeline to validate Jupyter notebooks
 
 ### 🎨 Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ This document describes the changes to the Code Graph Analysis Pipeline. The cha
 ### 🐛 Bug Fixes
 
 * **SCIP inner type dependencies fixed** — Inner type references (e.g., `Cache#EntryListener#`) are now correctly preserved instead of being collapsed to their enclosing type. Applies across all SCIP-supported languages. Regression tests added.
+* **SCIP sibling inner class dependencies fixed** - Dependencies between inner types defined in the same file (e.g., `WorkPackage$BatchProcessingEntry` depending on `WorkPackage$ProcessingEntry`) are now captured. Previously, the same-file filter in edge extraction dropped all same-file references. Regression tests added.
+* **SCIP inheritance and implementation dependencies captured** - The conversion script now processes `symbols[].relationships` with `is_implementation: true` to capture type dependencies from interface inheritance and class implementations that are not recorded as explicit symbol occurrences (e.g., transitive interface supertypes). Regression tests added.
 
 ### 📋 Known Limitations - Documented
 
 * **Generic type parameters and type annotations** — SCIP indexers do not capture type references in generic type parameters or complex type annotations (e.g., `<T extends ProcessingContext>`). See [SCIP.md Known Limitations](SCIP.md#generic-type-parameters-and-type-annotations) for details.
+* **Additional SCIP limitations identified** — Static factory method return types, lambda inferred parameter types, type inference (ternary/`var`), and field types used only as method arguments are not captured as dependencies by SCIP indexers. See [SCIP.md Known Limitations](SCIP.md#static-factory-method-return-types) for details.
 
 ## v4.0.1 Improve charts to look more similar to previous Jupyter notebook charts and add pipeline to validate Jupyter notebooks
 

--- a/SCIP.md
+++ b/SCIP.md
@@ -119,6 +119,165 @@ On repeat runs (unchanged index) or when the fast path fails, the regular LOAD C
 
 See [domains/scip-index-import/README.md](domains/scip-index-import/README.md#fast-import-via-neo4j-admin) for full details.
 
+## Known Limitations
+
+### SCIP-Java Only Captures Explicit Type References
+
+**Limitation**: SCIP-Java (and other SCIP indexers) only captures **explicit type references** in source code. This means:
+
+- ✅ **Captured**: Direct method calls, field access, type annotations, inheritance declarations
+
+  ```java
+  MyClass obj = new MyClass();           // ✅ captured
+  obj.method();                          // ✅ captured
+  List<String> list;                     // ✅ captured
+  class Child extends Parent { }         // ✅ captured
+  ```
+
+- ❌ **Not captured**: Implicit or compiler-generated references
+  - Inner class access to outer class members (implicit `this` binding)
+  - Javadoc `@link` or `@see` tags (documentation references)
+  - Reflection-based references
+  - Metaprogramming constructs
+
+### Inner Class Dependencies Are Incomplete
+
+**Impact**: Non-static inner classes do not record dependencies on their enclosing class, even though they have implicit access to all private members at runtime.
+
+**Example**:
+
+```java
+class Coordinator {
+    private EventSource eventSource;
+    private TokenStore tokenStore;
+    
+    // Inner class can access all Coordinator private members implicitly
+    private class CoordinationTask implements Runnable {
+        public void run() {
+            eventSource.getEvents();      // Implicit access via compiler-generated Coordinator.this
+            tokenStore.store(token);      // Not visible as explicit reference in SCIP
+        }
+    }
+}
+```
+
+In the SCIP index:
+
+- ✅ `Coordinator → CoordinationTask` edge exists (explicit instantiation)
+- ❌ `CoordinationTask → Coordinator` edge **missing** (implicit dependency not recorded)
+
+**Implications**:
+
+- Dependency graphs are incomplete for nested class structures
+- Cycle detection may miss cycles that involve inner classes
+- Architecture analysis may undercount dependencies in codebases with heavy use of inner classes
+
+**Workaround**: Consider refactoring inner classes to package-private or public top-level classes if dependency tracking is critical for your analysis.
+
+### Anonymous Inner Class Names won't necessarily match between Java and SCIP
+
+**Limitation**: Anonymous inner classes in Java are assigned names like `OuterClass$1`, `OuterClass$2`, etc. However, SCIP is imported as `OuterClass$anonymous0`, `OuterClass$anonymous1`, etc., with no guaranteed matching numbers.
+
+**Impact**: Dependencies involving anonymous inner classes may appear missing in SCIP data when trying to match by name between Java and SCIP.
+
+**Workaround**: There is no reliable workaround other than being aware of this limitation when analyzing dependencies involving anonymous inner classes.
+
+### JavaDoc References
+
+**Limitation**: References in Javadoc comments using `@link` or `@see` tags are not captured as dependencies in SCIP.
+
+**Impact**: Dependencies that are only mentioned in documentation may appear missing in SCIP data.
+
+**Workaround**: There is no direct workaround; consider adding explicit code references if tracking these dependencies is important.
+
+### Generic Type Parameters and Type Annotations
+
+**Limitation**: Type references in generic type parameters and certain type annotations may not be captured as symbol occurrences in SCIP.
+
+**Example**:
+
+```java
+// Method with generic type parameter
+public <T extends ProcessingContext> void process(T context) {  // ❌ ProcessingContext may not be captured
+    context.handle();
+}
+
+// Field with generic type that should depend on inner type
+private final Set<Cache.EntryListener> adapters;  // ✅ Sometimes captured, ❌ sometimes not
+
+// Field using inner type in complex generics
+private Map<String, ? extends ProcessingContext> handlers;  // ❌ Likely not captured
+```
+
+**Impact**: Type dependencies involving generic type parameters or complex type annotations may be missing from SCIP data even though jQAssistant (bytecode/AST-based analysis) captures them.
+
+**Evidence**: In AxonFramework analysis, `DefaultDispatchInterceptorRegistry` references `ProcessingContext` (confirmed by jQAssistant), but this reference does not appear in SCIP index (520 occurrences checked, none contain ProcessingContext).
+
+**Root Cause**: SCIP indexers (particularly scip-java) may treat type parameters and certain annotation contexts as implicit/contextual and not record them as explicit symbol occurrences.
+
+**Workaround**: There is no reliable workaround in the conversion pipeline. This is an upstream SCIP indexer limitation that would require:
+
+- Enhancement to the SCIP indexer (scip-java) to capture these references
+- Post-processing in the conversion script to infer these dependencies (complex and error-prone)
+
+### Static Factory Method Return Types
+
+**Limitation**: When a static factory method is called, SCIP records the class that owns the method but not the return type.
+
+**Example**:
+
+```java
+return MessageStream.empty();  // ✅ MessageStream# captured, ❌ MessageStream.Empty# not captured
+return MessageStream.single(message);  // ✅ MessageStream# captured, ❌ MessageStream.Single# not captured
+```
+
+**Impact**: Type dependencies on inner types that are only reachable through static factory method return types are missing. jQAssistant captures these from bytecode (the compiled return type descriptor is explicit).
+
+### Lambda Inferred Parameter Types
+
+**Limitation**: Lambda parameter types inferred from the functional interface signature are not recorded as symbol occurrences by SCIP.
+
+**Example**:
+
+```java
+// Lambda parameter types (p: ProcessingContext, phase: ProcessingLifecycle.Phase) are inferred
+processingLifecycle.runOnPreInvocation(pc -> {
+    pc.onError((p, phase, e) -> rollback());  // ❌ ProcessingLifecycle.Phase not captured
+});
+```
+
+**Impact**: Type dependencies that only appear as inferred lambda parameter types are missing. jQAssistant captures these from bytecode where the compiled lambda class contains the explicit parameter types.
+
+### Type Inference (Ternary Expressions and `var`)
+
+**Limitation**: When the Java compiler infers a common supertype for a ternary expression or `var` variable, SCIP does not record that inferred type as an occurrence.
+
+**Example**:
+
+```java
+// Java compiler infers Converter as the least-upper-bound type for `converter`
+var converter = isEvent ? context.component(EventConverter.class)
+                        : context.component(MessageConverter.class);
+// ✅ EventConverter# and MessageConverter# captured, ❌ Converter# (inferred LCA) not captured
+```
+
+**Impact**: Type dependencies on shared supertypes that appear only through type inference are missing. jQAssistant captures these from bytecode where the compiled local variable has the inferred type.
+
+### Field Types Used Only as Method Arguments
+
+**Limitation**: When a field of type `T` is passed as a method argument, SCIP records the field reference but not the field's declared type.
+
+**Example**:
+
+```java
+context.getResource(LegacyResources.AGGREGATE_IDENTIFIER_KEY);
+// ✅ context#getResource(). method captured
+// ✅ LegacyResources#AGGREGATE_IDENTIFIER_KEY. field captured
+// ❌ Context.ResourceKey (the field's declared type) not captured
+```
+
+**Impact**: Type dependencies that are transitively implied by field types used as method arguments are missing from SCIP data.
+
 ## Troubleshooting
 
 **`jq` not found**

--- a/cypher/Dependency_Enrichment/Set_Incoming_Java_Package_Dependencies.cypher
+++ b/cypher/Dependency_Enrichment/Set_Incoming_Java_Package_Dependencies.cypher
@@ -3,7 +3,6 @@
    MATCH (p:Java:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
 OPTIONAL MATCH (p)-[:CONTAINS]->(it:Java:Type)<-[r:DEPENDS_ON]-(et:Java:Type)<-[:CONTAINS]-(ep:Package)<-[:CONTAINS]-(ea:Artifact)
-OPTIONAL MATCH (it)<-[:DEPENDS_ON]-(eti:Java:Type:Interface)
    WHERE p <> ep
      AND p.fqn <> ep.fqn
      // AND p.incomingDependencies IS NULL // comment out to recalculate
@@ -12,8 +11,8 @@ OPTIONAL MATCH (it)<-[:DEPENDS_ON]-(eti:Java:Type:Interface)
         ,COUNT(et)               AS incomingDependencies
         ,SUM(r.weight)           AS incomingDependenciesWeight
         ,COUNT(DISTINCT et)      AS incomingDependentTypes 
-        ,COUNT(DISTINCT eti)     AS incomingDependentInterfaces // also included in dependent types
-        ,COUNT(DISTINCT ep)      AS incomingDependentPackages
+         // Count interface types. They are also included in dependent types.
+        ,COUNT{ MATCH (it)<-[:DEPENDS_ON]-(eti:Java:Type:Interface) RETURN DISTINCT eti } AS incomingDependentInterfaces        ,COUNT(DISTINCT ep)      AS incomingDependentPackages
         ,COUNT(DISTINCT ea)  - 1 AS incomingDependentArtifacts
 ORDER BY incomingDependencies DESC, p.fqn ASC // package with most incoming dependencies first
      SET p.incomingDependencies        = incomingDependencies

--- a/cypher/Dependency_Enrichment/Set_Outgoing_Java_Package_Dependencies.cypher
+++ b/cypher/Dependency_Enrichment/Set_Outgoing_Java_Package_Dependencies.cypher
@@ -3,7 +3,6 @@
    MATCH (p:Java:Package)
    MATCH (artifact:Artifact)-[:CONTAINS]->(p)
 OPTIONAL MATCH (p)-[:CONTAINS]->(it:Java:Type)-[r:DEPENDS_ON]->(et:Java:Type)<-[:CONTAINS]-(ep:Package)<-[:CONTAINS]-(ea:Artifact)
-OPTIONAL MATCH (it)-[:DEPENDS_ON]->(eti:Java:Type:Interface)
    WHERE p <> ep
      AND p.fqn <> ep.fqn
      // AND p.incomingDependencies IS NULL // comment out to recalculate
@@ -12,7 +11,8 @@ OPTIONAL MATCH (it)-[:DEPENDS_ON]->(eti:Java:Type:Interface)
         ,COUNT(et)              AS outgoingDependencies
         ,SUM(r.weight)          AS outgoingDependenciesWeight
         ,COUNT(DISTINCT et)     AS outgoingDependentTypes 
-        ,COUNT(DISTINCT eti)    AS outgoingDependentInterfaces // also included in dependent types
+        // Count interface types. They are also included in dependent types.
+        ,COUNT{ MATCH (it)-[:DEPENDS_ON]->(eti:Java:Type:Interface) RETURN DISTINCT eti } AS outgoingDependentInterfaces
         ,COUNT(DISTINCT ep)     AS outgoingDependentPackages
         ,COUNT(DISTINCT ea)  -1 AS outgoingDependentArtifacts
 ORDER BY outgoingDependencies DESC, p.fqn ASC // package with most incoming dependencies first

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
@@ -1,16 +1,25 @@
 // Calculate and set Instability for SCIP Semantic Index modules. Requires "Set_Incoming_SCIP_Module_Dependencies.cypher" and "Set_Outgoing_SCIP_Module_Dependencies.cypher" from the scip-index-import enrichment phase.
-// Reuses existing incomingDependencies and outgoingDependencies already set during enrichment.
 
 MATCH (m:SemanticCodeIndexModule)
 WHERE m.incomingDependencies IS NOT NULL
   AND m.outgoingDependencies IS NOT NULL
  WITH m
-     ,toFloat(m.outgoingDependencies) / (m.outgoingDependencies + m.incomingDependencies + 1E-38) AS instability
-  SET m.instability = instability
-RETURN m.projectName          AS projectName
-      ,m.fqn                  AS fullQualifiedModuleName
-      ,m.name                 AS moduleName
+     ,toFloat(m.outgoingDependencies)        / (m.outgoingDependencies        + m.incomingDependencies        + 1E-38) AS instability
+     ,toFloat(m.outgoingDependentModules)    / (m.outgoingDependentModules    + m.incomingDependentModules    + 1E-38) AS instabilityModules
+     ,toFloat(m.outgoingDependentArtifacts)  / (m.outgoingDependentArtifacts  + m.incomingDependentArtifacts  + 1E-38) AS instabilityArtifacts
+  SET m.instability          = instability
+     ,m.instabilityModules   = instabilityModules
+     ,m.instabilityArtifacts = instabilityArtifacts
+RETURN m.projectName               AS projectName
+      ,m.fqn                       AS fullQualifiedModuleName
+      ,m.name                      AS moduleName
       ,instability
-      ,m.outgoingDependencies AS outgoingDependencies
-      ,m.incomingDependencies AS incomingDependencies
+      ,instabilityModules
+      ,instabilityArtifacts
+      ,m.outgoingDependencies      AS outgoingDependencies
+      ,m.incomingDependencies      AS incomingDependencies
+      ,m.outgoingDependentModules  AS outgoingDependentModules
+      ,m.incomingDependentModules  AS incomingDependentModules
+      ,m.outgoingDependentArtifacts AS outgoingDependentArtifacts
+      ,m.incomingDependentArtifacts AS incomingDependentArtifacts
 ORDER BY instability ASC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Calculate_and_set_Instability_for_SCIP.cypher
@@ -17,7 +17,9 @@ RETURN m.projectName               AS projectName
       ,instabilityModules
       ,instabilityArtifacts
       ,m.outgoingDependencies      AS outgoingDependencies
+      ,m.outgoingDependenciesWeight AS outgoingDependenciesWeight
       ,m.incomingDependencies      AS incomingDependencies
+      ,m.incomingDependenciesWeight AS incomingDependenciesWeight
       ,m.outgoingDependentModules  AS outgoingDependentModules
       ,m.incomingDependentModules  AS incomingDependentModules
       ,m.outgoingDependentArtifacts AS outgoingDependentArtifacts

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
@@ -6,9 +6,11 @@ RETURN m.projectName                  AS projectName
       ,m.fqn                            AS fullQualifiedModuleName
       ,m.name                           AS moduleName
       ,m.incomingDependencies           AS incomingDependencies
+      ,m.incomingDependenciesWeight     AS incomingDependenciesWeight
       ,m.incomingDependentModules       AS incomingDependentModules
       ,m.incomingDependentArtifacts     AS incomingDependentArtifacts
       ,m.outgoingDependencies           AS outgoingDependencies
+      ,m.outgoingDependenciesWeight     AS outgoingDependenciesWeight
       ,m.outgoingDependentModules       AS outgoingDependentModules
       ,m.outgoingDependentArtifacts     AS outgoingDependentArtifacts
 ORDER BY incomingDependencies DESC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Incoming_SCIP_Module_Dependencies.cypher
@@ -2,9 +2,13 @@
 
 MATCH (m:SemanticCodeIndexModule)
 WHERE m.incomingDependencies IS NOT NULL
-RETURN m.projectName          AS projectName
-      ,m.fqn                  AS fullQualifiedModuleName
-      ,m.name                 AS moduleName
-      ,m.incomingDependencies AS incomingDependencies
-      ,m.outgoingDependencies AS outgoingDependencies
+RETURN m.projectName                  AS projectName
+      ,m.fqn                            AS fullQualifiedModuleName
+      ,m.name                           AS moduleName
+      ,m.incomingDependencies           AS incomingDependencies
+      ,m.incomingDependentModules       AS incomingDependentModules
+      ,m.incomingDependentArtifacts     AS incomingDependentArtifacts
+      ,m.outgoingDependencies           AS outgoingDependencies
+      ,m.outgoingDependentModules       AS outgoingDependentModules
+      ,m.outgoingDependentArtifacts     AS outgoingDependentArtifacts
 ORDER BY incomingDependencies DESC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
@@ -2,10 +2,14 @@
 
 MATCH (m:SemanticCodeIndexModule)
 WHERE m.instability IS NOT NULL
-RETURN m.projectName          AS projectName
-      ,m.fqn                  AS fullQualifiedModuleName
-      ,m.name                 AS moduleName
-      ,m.instability          AS instability
-      ,m.outgoingDependencies AS outgoingDependencies
-      ,m.incomingDependencies AS incomingDependencies
+RETURN m.projectName                  AS projectName
+      ,m.fqn                            AS fullQualifiedModuleName
+      ,m.name                           AS moduleName
+      ,m.instability                    AS instability
+      ,m.instabilityModules             AS instabilityModules
+      ,m.instabilityArtifacts           AS instabilityArtifacts
+      ,m.outgoingDependencies           AS outgoingDependencies
+      ,m.incomingDependencies           AS incomingDependencies
+      ,m.outgoingDependentArtifacts     AS outgoingDependentArtifacts
+      ,m.incomingDependentArtifacts     AS incomingDependentArtifacts
 ORDER BY instability ASC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Instability_for_SCIP.cypher
@@ -9,7 +9,9 @@ RETURN m.projectName                  AS projectName
       ,m.instabilityModules             AS instabilityModules
       ,m.instabilityArtifacts           AS instabilityArtifacts
       ,m.outgoingDependencies           AS outgoingDependencies
+      ,m.outgoingDependenciesWeight     AS outgoingDependenciesWeight
       ,m.incomingDependencies           AS incomingDependencies
+      ,m.incomingDependenciesWeight     AS incomingDependenciesWeight
       ,m.outgoingDependentArtifacts     AS outgoingDependentArtifacts
       ,m.incomingDependentArtifacts     AS incomingDependentArtifacts
 ORDER BY instability ASC, fullQualifiedModuleName ASC

--- a/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Outgoing_SCIP_Module_Dependencies.cypher
+++ b/domains/internal-dependencies/queries/object-oriented-design-metrics/Get_Outgoing_SCIP_Module_Dependencies.cypher
@@ -6,5 +6,7 @@ RETURN m.projectName          AS projectName
       ,m.fqn                  AS fullQualifiedModuleName
       ,m.name                 AS moduleName
       ,m.outgoingDependencies AS outgoingDependencies
+      ,m.outgoingDependenciesWeight AS outgoingDependenciesWeight
       ,m.incomingDependencies AS incomingDependencies
+      ,m.incomingDependenciesWeight AS incomingDependenciesWeight
 ORDER BY outgoingDependencies DESC, fullQualifiedModuleName ASC

--- a/domains/scip-index-import/README.md
+++ b/domains/scip-index-import/README.md
@@ -279,8 +279,8 @@ Set dependency counts and derived properties on nodes.
 | Query | Purpose |
 |-------|---------|
 | [Set_SCIP_Module_Is_Test_And_Marker_Integer.cypher](./queries/enrichment/Set_SCIP_Module_Is_Test_And_Marker_Integer.cypher) | Set `isTest` and `testMarkerInteger` on modules — true if any contained type is a test |
-| [Set_Incoming_SCIP_Module_Dependencies.cypher](./queries/enrichment/Set_Incoming_SCIP_Module_Dependencies.cypher) | Set `incomingDependencies` and `incomingDependenciesWeight` on modules |
-| [Set_Outgoing_SCIP_Module_Dependencies.cypher](./queries/enrichment/Set_Outgoing_SCIP_Module_Dependencies.cypher) | Set `outgoingDependencies` and `outgoingDependenciesWeight` on modules |
+| [Set_Incoming_SCIP_Module_Dependencies.cypher](./queries/enrichment/Set_Incoming_SCIP_Module_Dependencies.cypher) | Set `incomingDependencies` (COUNT), `incomingDependenciesWeight` (SUM), `incomingDependentModules`, and `incomingDependentArtifacts` on modules (includes all sources: test and non-test) |
+| [Set_Outgoing_SCIP_Module_Dependencies.cypher](./queries/enrichment/Set_Outgoing_SCIP_Module_Dependencies.cypher) | Set `outgoingDependencies` (COUNT), `outgoingDependenciesWeight` (SUM), `outgoingDependentModules`, and `outgoingDependentArtifacts` on modules (includes all targets: test and non-test) |
 
 **Artifact Enrichment:**
 
@@ -334,6 +334,26 @@ Shared queries from [`cypher/Dependency_Enrichment/`](../../cypher/Dependency_En
 | `language` | `SemanticCodeIndexInternalType`, `SemanticCodeIndexExternalType` | Detected language (e.g. `Java`, `TypeScript`, `Go`) |
 | `incomingDependencies` | `SCIPType` | Number of types that depend on this type |
 | `outgoingDependencies` | `SCIPType` | Number of types this type depends on |
+| `incomingDependencies` | `SCIPModule` | **COUNT** of type-level DEPENDS_ON edges into types in this module (aggregated from type level) |
+| `incomingDependenciesWeight` | `SCIPModule` | **SUM** of `referenceCount` from those edges (edge magnitude) |
+| `outgoingDependencies` | `SCIPModule` | **COUNT** of type-level DEPENDS_ON edges from types in this module |
+| `outgoingDependenciesWeight` | `SCIPModule` | **SUM** of `referenceCount` from those edges |
+
+### Module Dependency Semantics
+
+**Important Note:** SCIP module dependency metrics use a **different edge model** than Java Packages:
+
+- **SCIP:** One edge per unique type pair (no edge multiplicity) — each distinct (source type → target type) pair creates exactly one DEPENDS_ON edge
+- **Java:** Can have multiple DEPENDS_ON edges between the same type pair (richer detail but more edges)
+
+This structural difference means SCIP typically reports ~42–60% fewer edges than equivalent Java Package nodes, even when analyzing the same code.
+
+**Example:** AxonFramework `messaging/core` module:
+- **SCIP:** 4,908 type-level edges (unique type pairs)
+- **Java Package:** 11,673 type-level edges (including multiple edges per pair)
+- **Gap:** ~59% difference due to edge model, not missing data
+
+Both representations are valid; they just capture dependencies at different granularities.
 
 ### Test Detection
 

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -87,7 +87,12 @@ JQ_ADMIN_FUNCTIONS='
         symbol | split(" ") | 
         if length >= 5 then
             .[0:4] as $prefix | 
-            (.[4] | split("#")[0] + "#") as $norm_desc |
+            .[4] as $descriptor_value |
+            (if ($descriptor_value | endswith("#")) then
+                $descriptor_value
+             else
+                 ($descriptor_value | split("#") | .[:-1] | join("#") + "#")
+             end) as $norm_desc |
             ($prefix + [$norm_desc]) | join(" ")
         else
             symbol

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jAdminImport.sh
@@ -456,7 +456,7 @@ function extract_depends_on_edges_admin() {
                     $sym_to_file[$norm] as $target_file |
                     (.[0] | split(" ") | .[2]) as $ref_pkg_id |
                     select(
-                        ($target_file != null and $target_file != $source_file)
+                        ($target_file != null)
                         or ($target_file == null
                               and ($internal_pkg_ids | index($ref_pkg_id)) == null
                               and $ref_pkg_id != ".")
@@ -489,6 +489,49 @@ function extract_depends_on_edges_admin() {
             select($source_symbol != $ref_group.target) |
             [$source_symbol, $ref_group.target, "DEPENDS_ON", $ref_group.count]
             | @csv
+        ' "${input_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Pass 3b — Extract DEPENDS_ON edges from SCIP symbol relationships (no header)
+# Processes documents[].symbols[].relationships[] where is_implementation=true
+# to capture inheritance and interface-implementation type dependencies that
+# do not appear as explicit occurrences (e.g. transitive interface inheritance).
+# ---------------------------------------------------------------------------
+
+function extract_relationship_edges_admin() {
+    local symbol_index_file="${1}"
+    local input_file="${2}"
+    jq -r --slurpfile index "${symbol_index_file}" "${JQ_ADMIN_FUNCTIONS}"'
+
+        ($index[0].symbol_to_file) as $sym_to_file |
+
+        .documents[] |
+        .relative_path as $source_file |
+
+        (.symbols // [])[] |
+        select(.symbol != null) |
+        .symbol as $source_symbol |
+        select(is_base_type_descriptor($source_symbol)) |
+        select(is_type_parameter_descriptor($source_symbol) | not) |
+
+        $sym_to_file[$source_symbol] as $source_file_lookup |
+        select($source_file_lookup == $source_file) |
+
+        (.relationships // [])[] |
+        select(.is_implementation == true) |
+        .symbol as $target_symbol |
+        select(is_base_type_descriptor($target_symbol)) |
+        select(is_type_parameter_descriptor($target_symbol) | not) |
+
+        $sym_to_file[$target_symbol] as $target_file |
+        select($target_file != null) |
+        select($target_file != $source_file) |
+
+        (short_symbol($source_symbol)) as $src |
+        (short_symbol($target_symbol)) as $tgt |
+        select($src != $tgt) |
+        [$src, $tgt, "DEPENDS_ON", "1"] | @csv
         ' "${input_file}"
 }
 
@@ -764,6 +807,11 @@ function process_single_index_admin() {
     extract_depends_on_edges_admin "${symbol_index_file}" "${input_file}" > "${edges_temp}" 2>&1
     local edges_count=$(wc -l < "${edges_temp}" 2>/dev/null || echo "0")
     debug_log "DEPENDS_ON edges written: ${edges_count} lines"
+
+    debug_log "Extracting relationship edges..."
+    extract_relationship_edges_admin "${symbol_index_file}" "${input_file}" >> "${edges_temp}" 2>&1
+    local edges_after_rels=$(wc -l < "${edges_temp}" 2>/dev/null || echo "0")
+    debug_log "Total edges after relationships: ${edges_after_rels} lines"
     
     debug_log "Extracting anonymous class edges..."
     extract_anonymous_class_edges_admin "${symbol_index_file}" >> "${edges_temp}" 2>&1

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -426,8 +426,8 @@ function extract_depends_on_edges() {
              {symbol: .symbol, role: ((.symbol_roles // 0) % 2)}
             ] as $valid_occurrences |
 
-            # Extract sources (role 1) and raw references (role 0)
-            [$valid_occurrences[] | select(.role == 1) | .symbol] as $source_type_symbols |
+            # Extract sources (role 1, base type descriptors only) and raw references (role 0)
+            [$valid_occurrences[] | select(.role == 1) | select(is_base_type_descriptor(.symbol)) | .symbol] as $source_type_symbols |
             [$valid_occurrences[] | select(.role == 0) | .symbol] as $all_ref_symbols |
 
             # Pre-aggregate valid refs by normalized type target, with occurrence count
@@ -439,7 +439,7 @@ function extract_depends_on_edges() {
                     $sym_to_file[$norm] as $target_file |
                     (.[0] | split(" ") | .[2]) as $ref_pkg_id |
                     select(
-                        ($target_file != null and $target_file != $source_file)
+                        ($target_file != null)
                         or ($target_file == null
                               and ($internal_pkg_ids | index($ref_pkg_id)) == null
                               and $ref_pkg_id != ".")
@@ -472,6 +472,49 @@ function extract_depends_on_edges() {
             select($source_symbol != $ref_group.target) |
             [$source_symbol, $ref_group.target, ($ref_group.count | tostring)]
             | @csv
+        ' "${input_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Pass 3b — Extract DEPENDS_ON edges from SCIP symbol relationships (no header)
+# Processes documents[].symbols[].relationships[] where is_implementation=true
+# to capture inheritance and interface-implementation type dependencies that
+# do not appear as explicit occurrences (e.g. transitive interface inheritance).
+# ---------------------------------------------------------------------------
+
+function extract_relationship_edges() {
+    local symbol_index_file="${1}"
+    local input_file="${2}"
+    jq -r --slurpfile index "${symbol_index_file}" "${JQ_SHARED_FUNCTIONS}"'
+
+        ($index[0].symbol_to_file) as $sym_to_file |
+
+        .documents[] |
+        .relative_path as $source_file |
+
+        (.symbols // [])[] |
+        select(.symbol != null) |
+        .symbol as $source_symbol |
+        select(is_base_type_descriptor($source_symbol)) |
+        select(is_type_parameter_descriptor($source_symbol) | not) |
+
+        $sym_to_file[$source_symbol] as $source_file_lookup |
+        select($source_file_lookup == $source_file) |
+
+        (.relationships // [])[] |
+        select(.is_implementation == true) |
+        .symbol as $target_symbol |
+        select(is_base_type_descriptor($target_symbol)) |
+        select(is_type_parameter_descriptor($target_symbol) | not) |
+
+        $sym_to_file[$target_symbol] as $target_file |
+        select($target_file != null) |
+        select($target_file != $source_file) |
+
+        (short_symbol($source_symbol)) as $src |
+        (short_symbol($target_symbol)) as $tgt |
+        select($src != $tgt) |
+        [$src, $tgt, "1"] | @csv
         ' "${input_file}"
 }
 
@@ -580,6 +623,7 @@ function process_single_index() {
     extract_anonymous_class_nodes "${symbol_index_file}" >> "${nodes_temp}"
 
     extract_depends_on_edges "${symbol_index_file}" "${input_file}" > "${edges_temp}"
+    extract_relationship_edges "${symbol_index_file}" "${input_file}" >> "${edges_temp}"
     extract_anonymous_class_edges "${symbol_index_file}" >> "${edges_temp}"
 }
 

--- a/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/convertScipIndexToCsvForNeo4jImport.sh
@@ -80,7 +80,12 @@ JQ_SHARED_FUNCTIONS='
         symbol | split(" ") | 
         if length >= 5 then
             .[0:4] as $prefix | 
-            (.[4] | split("#")[0] + "#") as $norm_desc |
+            .[4] as $descriptor_value |
+            (if ($descriptor_value | endswith("#")) then
+                $descriptor_value
+             else
+                 ($descriptor_value | split("#") | .[:-1] | join("#") + "#")
+             end) as $norm_desc |
             ($prefix + [$norm_desc]) | join(" ")
         else
             symbol

--- a/domains/scip-index-import/queries/enrichment/Set_Incoming_SCIP_Module_Dependencies.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_Incoming_SCIP_Module_Dependencies.cypher
@@ -1,12 +1,25 @@
-// Set incoming SCIP module dependencies. Mirrors type-level enrichment pattern. Requires "Link_SCIP_Module_DEPENDS_ON_SCIP_Module.cypher".
+// Set incoming SCIP module dependencies aggregated from type-level DEPENDS_ON relationships.
+// incomingDependencies = COUNT of type-level edges into types in this module.
+// incomingDependenciesWeight = SUM of referenceCount (magnitude of those edges).
+// incomingDependentModules = COUNT DISTINCT of modules that have types depending on this module's types.
+// incomingDependentArtifacts = COUNT DISTINCT of artifacts that contain those dependent modules.
 
    MATCH (m:SemanticCodeIndexModule)
-OPTIONAL MATCH (m)<-[r:DEPENDS_ON]-(source:SemanticCodeIndexModule)
-   WHERE m <> source
+OPTIONAL MATCH (m)-[:CONTAINS]->(it:SemanticCodeIndexInternalType)<-[typeDependency:DEPENDS_ON]-(et:SemanticCodeIndexInternalType)<-[:CONTAINS]-(targetModule:SemanticCodeIndexModule)<-[:CONTAINS]-(sourceArtifact:SemanticCodeIndexArtifact)
+   WHERE m <> targetModule
     WITH m
-        ,count(DISTINCT source.fqn) AS incomingDependencies
-        ,sum(r.referenceCount)      AS incomingDependenciesWeight
-     SET m.incomingDependencies       = incomingDependencies
-        ,m.incomingDependenciesWeight = incomingDependenciesWeight
+        ,count(DISTINCT typeDependency)     AS incomingDependencies
+        ,sum(typeDependency.referenceCount) AS incomingDependenciesWeight
+        ,count(DISTINCT et)                 AS distinctSourceTypes
+        ,count(DISTINCT targetModule)       AS distinctTargetModules
+        ,count(DISTINCT sourceArtifact)     AS distinctSourceArtifacts
+     SET m.incomingDependencies        = incomingDependencies
+        ,m.incomingDependenciesWeight  = incomingDependenciesWeight
+        ,m.incomingDependentModules    = distinctTargetModules
+        ,m.incomingDependentArtifacts  = distinctSourceArtifacts
   RETURN m.fqn AS module
         ,incomingDependencies
+        ,incomingDependenciesWeight
+        ,distinctSourceTypes
+        ,distinctTargetModules
+        ,distinctSourceArtifacts

--- a/domains/scip-index-import/queries/enrichment/Set_Outgoing_SCIP_Module_Dependencies.cypher
+++ b/domains/scip-index-import/queries/enrichment/Set_Outgoing_SCIP_Module_Dependencies.cypher
@@ -1,12 +1,25 @@
-// Set outgoing SCIP module dependencies. Mirrors type-level enrichment pattern. Requires "Link_SCIP_Module_DEPENDS_ON_SCIP_Module.cypher".
+// Set outgoing SCIP module dependencies aggregated from type-level DEPENDS_ON relationships.
+// outgoingDependencies = COUNT of type-level edges from types in this module.
+// outgoingDependenciesWeight = SUM of referenceCount (magnitude of those edges).
+// outgoingDependentModules = COUNT DISTINCT of modules that contain types depended on by this module's types.
+// outgoingDependentArtifacts = COUNT DISTINCT of artifacts that contain those dependent modules.
 
    MATCH (m:SemanticCodeIndexModule)
-OPTIONAL MATCH (m)-[r:DEPENDS_ON]->(target:SemanticCodeIndexModule)
-   WHERE m <> target
+OPTIONAL MATCH (m)-[:CONTAINS]->(it:SemanticCodeIndexInternalType)-[typeDependency:DEPENDS_ON]->(et)<-[:CONTAINS]-(targetModule:SemanticCodeIndexModule)<-[:CONTAINS]-(targetArtifact:SemanticCodeIndexArtifact)
+   WHERE m <> targetModule
     WITH m
-        ,count(DISTINCT target.fqn) AS outgoingDependencies
-        ,sum(r.referenceCount)      AS outgoingDependenciesWeight
-     SET m.outgoingDependencies       = outgoingDependencies
-        ,m.outgoingDependenciesWeight = outgoingDependenciesWeight
+        ,count(typeDependency)              AS outgoingDependencies
+        ,sum(typeDependency.referenceCount) AS outgoingDependenciesWeight
+        ,count(DISTINCT et)                 AS distinctTargetTypes
+        ,count(DISTINCT targetModule)       AS distinctTargetModules
+        ,count(DISTINCT targetArtifact)     AS distinctTargetArtifacts
+     SET m.outgoingDependencies        = outgoingDependencies
+        ,m.outgoingDependenciesWeight  = outgoingDependenciesWeight
+        ,m.outgoingDependentModules    = distinctTargetModules
+        ,m.outgoingDependentArtifacts  = distinctTargetArtifacts
   RETURN m.fqn AS module
         ,outgoingDependencies
+        ,outgoingDependenciesWeight
+        ,distinctTargetTypes
+        ,distinctTargetModules
+        ,distinctTargetArtifacts

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
@@ -1046,6 +1046,107 @@ assert_contains "WeakReferenceCache→Cache#EntryListener# reference count is 1 
 echo ""
 
 # ---------------------------------------------------------------------------
+# Fixture: sibling inner types in the same file (BUG 1 regression test for admin).
+# ---------------------------------------------------------------------------
+
+function create_sibling_inner_type_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/Outer.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/Outer#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerA#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#"}
+      ],
+      "symbols": [
+        {"symbol": "semanticdb maven . . org/example/Outer#", "kind": 7},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerA#", "kind": 7},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#", "kind": 7}
+      ]
+    }
+  ]
+}
+EOF
+}
+
+echo "Test: sibling inner types in same file create edges between each other (admin)"
+sibling_inner_indices_dir="${tmp_test_dir}/sibling_inner_indices"
+sibling_inner_import_dir="${tmp_test_dir}/sibling_inner_import"
+mkdir -p "${sibling_inner_indices_dir}"
+
+create_sibling_inner_type_scip_json > "${sibling_inner_indices_dir}/sibling_inner.scip.json"
+run_script_with_env "${sibling_inner_indices_dir}" "${sibling_inner_import_dir}"
+assert_exit_code "exits 0 for sibling inner type fixture (admin)" "0" "${exit_code}"
+
+sibling_inner_edges=$(cat "${sibling_inner_import_dir}/scip_type_edges_admin.csv")
+assert_contains "InnerA depends on sibling InnerB (same-file edge, admin)" \
+    '. . org/example/Outer#InnerA#' "${sibling_inner_edges}"
+assert_contains "InnerB is the target of the sibling edge (admin)" \
+    '. . org/example/Outer#InnerB#' "${sibling_inner_edges}"
+assert_not_contains "no InnerB self-loop (admin)" \
+    '". . org/example/Outer#InnerB#",". . org/example/Outer#InnerB#"' "${sibling_inner_edges}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fixture: class implementing an interface via symbols[].relationships (BUG 2 regression test for admin).
+# ---------------------------------------------------------------------------
+
+function create_relationship_dependency_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/MyInterface.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/MyInterface#", "symbol_roles": 1}
+      ],
+      "symbols": [
+        {"symbol": "semanticdb maven . . org/example/MyInterface#", "kind": 21}
+      ]
+    },
+    {
+      "relative_path": "src/main/java/org/example/MyImpl.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/MyImpl#", "symbol_roles": 1}
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/MyImpl#",
+          "kind": 7,
+          "relationships": [
+            {"symbol": "semanticdb maven . . org/example/MyInterface#", "is_implementation": true}
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+echo "Test: symbols.relationships with is_implementation creates edge to implemented interface (admin)"
+rel_dep_indices_dir="${tmp_test_dir}/rel_dep_indices"
+rel_dep_import_dir="${tmp_test_dir}/rel_dep_import"
+mkdir -p "${rel_dep_indices_dir}"
+
+create_relationship_dependency_scip_json > "${rel_dep_indices_dir}/rel_dep.scip.json"
+run_script_with_env "${rel_dep_indices_dir}" "${rel_dep_import_dir}"
+assert_exit_code "exits 0 for relationship dependency fixture (admin)" "0" "${exit_code}"
+
+rel_dep_edges=$(cat "${rel_dep_import_dir}/scip_type_edges_admin.csv")
+assert_contains "MyImpl depends on MyInterface via relationship (admin)" \
+    '. . org/example/MyInterface#' "${rel_dep_edges}"
+assert_contains "MyImpl is the source of the relationship edge (admin)" \
+    '. . org/example/MyImpl#' "${rel_dep_edges}"
+assert_contains "relationship edge has DEPENDS_ON type (admin)" "DEPENDS_ON" "${rel_dep_edges}"
+rel_dep_edge=$(echo "${rel_dep_edges}" | grep "MyImpl#" | grep "MyInterface#" || true)
+assert_contains "relationship edge has count 1 (admin)" ",1" "${rel_dep_edge}"
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jAdminImport.sh
@@ -944,6 +944,108 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
+# Fixture: outer interface with inner interface, and a class referencing the inner.
+# Models the AxonFramework Cache#EntryListener# pattern:
+#   - Cache.java defines Cache# (outer) and Cache#EntryListener# (inner interface)
+#   - WeakReferenceCache.java references Cache#EntryListener# (null role = reference)
+#     and calls a method Cache#EntryListener#onEntryExpired(). (role 0 = usage)
+# The admin is_type_descriptor only matches endswith("#"), so the method call is
+# filtered out. After the normalize_symbol fix, count is 1 (bare type reference only).
+# ---------------------------------------------------------------------------
+
+function create_inner_type_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/Cache.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#",
+          "kind": 21
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#",
+          "kind": 21
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/org/example/WeakReferenceCache.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven . . org/example/WeakReferenceCache#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#"
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#onEntryExpired().",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/WeakReferenceCache#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test: inner type references (e.g. Cache#EntryListener#) create edges to the
+# inner type itself, not the outer type.
+# Regression test for normalize_symbol incorrectly stripping inner type paths.
+# Admin import: method call is filtered by is_type_descriptor, count is 1.
+# ---------------------------------------------------------------------------
+
+echo "Test: inner type reference creates edge to inner type, not outer type (admin)"
+inner_type_ref_indices_dir="${tmp_test_dir}/inner_type_ref_indices"
+inner_type_ref_import_dir="${tmp_test_dir}/inner_type_ref_import"
+mkdir -p "${inner_type_ref_indices_dir}"
+
+create_inner_type_reference_scip_json > "${inner_type_ref_indices_dir}/inner_type_ref.scip.json"
+
+run_script_with_env "${inner_type_ref_indices_dir}" "${inner_type_ref_import_dir}"
+assert_exit_code "exits 0 for inner type reference fixture (admin)" "0" "${exit_code}"
+
+inner_type_nodes_csv="${inner_type_ref_import_dir}/scip_type_nodes_admin.csv"
+inner_type_edges_csv="${inner_type_ref_import_dir}/scip_type_edges_admin.csv"
+assert_file_exists "creates admin node CSV for inner type fixture" "${inner_type_nodes_csv}"
+assert_file_exists "creates admin edge CSV for inner type fixture" "${inner_type_edges_csv}"
+
+inner_type_nodes=$(cat "${inner_type_nodes_csv}")
+assert_contains "inner interface Cache#EntryListener# is a node (admin)" "Cache#EntryListener#" "${inner_type_nodes}"
+
+inner_type_edges=$(cat "${inner_type_edges_csv}")
+# WeakReferenceCache references Cache#EntryListener# (null role only; method call filtered by is_type_descriptor).
+# count is 1 — only the bare type reference with null role passes the admin filter.
+assert_contains "WeakReferenceCache depends on inner type Cache#EntryListener# (admin)" "Cache#EntryListener#" "${inner_type_edges}"
+# The full target symbol '. . org/example/Cache#' (closed by quote + comma) must not appear:
+# 'WeakReferenceCache#"' contains 'Cache#"' as a substring, but not '"Cache#",' (full quoted value).
+assert_not_contains "inner type Cache#EntryListener# not collapsed to outer Cache# (admin)" '". . org/example/Cache#",' "${inner_type_edges}"
+assert_contains "edge has DEPENDS_ON relationship type (inner type)" "DEPENDS_ON" "${inner_type_edges}"
+
+inner_edge=$(echo "${inner_type_edges}" | grep "WeakReferenceCache#" | grep "Cache#EntryListener#" || true)
+assert_contains "WeakReferenceCache→Cache#EntryListener# reference count is 1 (admin)" ",1" "${inner_edge}"
+echo ""
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
@@ -61,6 +61,20 @@ function assert_contains() {
     fi
 }
 
+function assert_not_contains() {
+    local description="${1}"
+    local needle="${2}"
+    local haystack="${3}"
+    if ! echo "${haystack}" | grep -qF "${needle}"; then
+        echo "  PASS: ${description}"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  FAIL: ${description}"
+        echo "        Expected NOT to find: ${needle}"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
 function assert_equals() {
     local description="${1}"
     local expected="${2}"
@@ -756,6 +770,106 @@ else
     echo "  PASS: no anonymous class node for local symbol without methods"
     PASS_COUNT=$((PASS_COUNT + 1))
 fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fixture: outer interface with inner interface, and a class referencing the inner.
+# Models the AxonFramework Cache#EntryListener# pattern:
+#   - Cache.java defines Cache# (outer) and Cache#EntryListener# (inner interface)
+#   - WeakReferenceCache.java references Cache#EntryListener# (null role = reference)
+#     and calls a method Cache#EntryListener#onEntryExpired(). (role 0 = usage)
+# Before the normalize_symbol fix, both would collapse to Cache# (wrong).
+# After the fix, both correctly point to Cache#EntryListener#.
+# ---------------------------------------------------------------------------
+
+function create_inner_type_reference_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/Cache.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#",
+          "symbol_roles": 1
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#",
+          "kind": 21
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#",
+          "kind": 21
+        }
+      ]
+    },
+    {
+      "relative_path": "src/main/java/org/example/WeakReferenceCache.java",
+      "occurrences": [
+        {
+          "symbol": "semanticdb maven . . org/example/WeakReferenceCache#",
+          "symbol_roles": 1
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#"
+        },
+        {
+          "symbol": "semanticdb maven . . org/example/Cache#EntryListener#onEntryExpired().",
+          "symbol_roles": 0
+        }
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/WeakReferenceCache#",
+          "kind": 7
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Test: inner type references (e.g. Cache#EntryListener#) create edges to the
+# inner type itself, not the outer type.
+# Regression test for normalize_symbol incorrectly stripping inner type paths.
+# ---------------------------------------------------------------------------
+
+echo "Test: inner type reference creates edge to inner type, not outer type"
+inner_type_ref_indices_dir="${tmp_test_dir}/inner_type_ref_indices"
+inner_type_ref_import_dir="${tmp_test_dir}/inner_type_ref_import"
+mkdir -p "${inner_type_ref_indices_dir}"
+
+create_inner_type_reference_scip_json > "${inner_type_ref_indices_dir}/inner_type_ref.scip.json"
+
+run_script_with_env "${inner_type_ref_indices_dir}" "${inner_type_ref_import_dir}"
+assert_exit_code "exits 0 for inner type reference fixture" "0" "${exit_code}"
+
+inner_type_nodes_csv="${inner_type_ref_import_dir}/scip_type_nodes.csv"
+inner_type_edges_csv="${inner_type_ref_import_dir}/scip_type_edges.csv"
+assert_file_exists "creates node CSV for inner type fixture" "${inner_type_nodes_csv}"
+assert_file_exists "creates edge CSV for inner type fixture" "${inner_type_edges_csv}"
+
+inner_type_nodes=$(cat "${inner_type_nodes_csv}")
+assert_contains "inner interface Cache#EntryListener# is a node" "Cache#EntryListener#" "${inner_type_nodes}"
+
+inner_type_edges=$(cat "${inner_type_edges_csv}")
+# WeakReferenceCache references Cache#EntryListener# (null role) and calls a method on it (role 0).
+# Both should normalize to Cache#EntryListener# — reference count is 2.
+assert_contains "WeakReferenceCache depends on inner type Cache#EntryListener#" "Cache#EntryListener#" "${inner_type_edges}"
+# The full target symbol '. . org/example/Cache#' (closed by quote + comma) must not appear:
+# 'WeakReferenceCache#"' contains 'Cache#"' as a substring, but not '"Cache#",' (full quoted value).
+assert_not_contains "inner type Cache#EntryListener# not collapsed to outer Cache#" '". . org/example/Cache#",' "${inner_type_edges}"
+
+inner_edge=$(echo "${inner_type_edges}" | grep "WeakReferenceCache#" | grep "Cache#EntryListener#" || true)
+assert_contains "WeakReferenceCache→Cache#EntryListener# reference count is 2" ",2" "${inner_edge}"
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
+++ b/domains/scip-index-import/testConvertScipIndexToCsvForNeo4jImport.sh
@@ -782,6 +782,57 @@ echo ""
 # After the fix, both correctly point to Cache#EntryListener#.
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Fixture: two sibling inner types defined in the same file, one referencing the other.
+# Models e.g. PessimisticLockFactory$DisposableLock depending on $PubliclyOwnedReentrantLock.
+# Both are inner types of the same outer class and live in the same Java source file.
+# Before BUG 1 fix: same-file filter dropped this edge.
+# After fix: edge is correctly emitted.
+# ---------------------------------------------------------------------------
+
+function create_sibling_inner_type_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/Outer.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/Outer#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerA#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#", "symbol_roles": 1},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#doSomething().", "symbol_roles": 0}
+      ],
+      "symbols": [
+        {"symbol": "semanticdb maven . . org/example/Outer#", "kind": 7},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerA#", "kind": 7},
+        {"symbol": "semanticdb maven . . org/example/Outer#InnerB#", "kind": 7}
+      ]
+    }
+  ]
+}
+EOF
+}
+
+echo "Test: sibling inner types in same file create edges between each other"
+sibling_inner_indices_dir="${tmp_test_dir}/sibling_inner_indices"
+sibling_inner_import_dir="${tmp_test_dir}/sibling_inner_import"
+mkdir -p "${sibling_inner_indices_dir}"
+
+create_sibling_inner_type_scip_json > "${sibling_inner_indices_dir}/sibling_inner.scip.json"
+run_script_with_env "${sibling_inner_indices_dir}" "${sibling_inner_import_dir}"
+assert_exit_code "exits 0 for sibling inner type fixture" "0" "${exit_code}"
+
+sibling_inner_edges=$(cat "${sibling_inner_import_dir}/scip_type_edges.csv")
+# InnerA has a method reference to InnerB (doSomething), so InnerA should depend on InnerB.
+assert_contains "InnerA depends on sibling InnerB (same-file edge)" \
+    '. . org/example/Outer#InnerA#' "${sibling_inner_edges}"
+assert_contains "InnerB is the target of the sibling edge" \
+    '. . org/example/Outer#InnerB#' "${sibling_inner_edges}"
+# No self-loop: InnerB must not appear as depending on itself
+assert_not_contains "no InnerB self-loop" \
+    '". . org/example/Outer#InnerB#",". . org/example/Outer#InnerB#"' "${sibling_inner_edges}"
+echo ""
+
 function create_inner_type_reference_scip_json() {
     cat << 'EOF'
 {
@@ -870,6 +921,68 @@ assert_not_contains "inner type Cache#EntryListener# not collapsed to outer Cach
 
 inner_edge=$(echo "${inner_type_edges}" | grep "WeakReferenceCache#" | grep "Cache#EntryListener#" || true)
 assert_contains "WeakReferenceCache→Cache#EntryListener# reference count is 2" ",2" "${inner_edge}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fixture: class implementing an interface defined in a different file,
+# captured only via symbols[].relationships (is_implementation=true), not occurrences.
+# Models e.g. SimpleQueryBus implements QueryHandlerRegistry:
+#   - Interface.java defines Interface#
+#   - Impl.java defines Impl# with a relationship to Interface# (is_implementation)
+#   - Impl.java has no occurrence of Interface# (only via inheritance)
+# Before BUG 2 fix: no edge created (relationships not processed).
+# After fix: edge Impl# → Interface# is created with count=1.
+# ---------------------------------------------------------------------------
+
+function create_relationship_dependency_scip_json() {
+    cat << 'EOF'
+{
+  "documents": [
+    {
+      "relative_path": "src/main/java/org/example/MyInterface.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/MyInterface#", "symbol_roles": 1}
+      ],
+      "symbols": [
+        {"symbol": "semanticdb maven . . org/example/MyInterface#", "kind": 21}
+      ]
+    },
+    {
+      "relative_path": "src/main/java/org/example/MyImpl.java",
+      "occurrences": [
+        {"symbol": "semanticdb maven . . org/example/MyImpl#", "symbol_roles": 1}
+      ],
+      "symbols": [
+        {
+          "symbol": "semanticdb maven . . org/example/MyImpl#",
+          "kind": 7,
+          "relationships": [
+            {"symbol": "semanticdb maven . . org/example/MyInterface#", "is_implementation": true}
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+echo "Test: symbols.relationships with is_implementation creates edge to implemented interface"
+rel_dep_indices_dir="${tmp_test_dir}/rel_dep_indices"
+rel_dep_import_dir="${tmp_test_dir}/rel_dep_import"
+mkdir -p "${rel_dep_indices_dir}"
+
+create_relationship_dependency_scip_json > "${rel_dep_indices_dir}/rel_dep.scip.json"
+run_script_with_env "${rel_dep_indices_dir}" "${rel_dep_import_dir}"
+assert_exit_code "exits 0 for relationship dependency fixture" "0" "${exit_code}"
+
+rel_dep_edges=$(cat "${rel_dep_import_dir}/scip_type_edges.csv")
+assert_contains "MyImpl depends on MyInterface via relationship" \
+    '. . org/example/MyInterface#' "${rel_dep_edges}"
+assert_contains "MyImpl is the source of the relationship edge" \
+    '. . org/example/MyImpl#' "${rel_dep_edges}"
+rel_dep_edge=$(echo "${rel_dep_edges}" | grep "MyImpl#" | grep "MyInterface#" || true)
+assert_contains "relationship edge has count 1" ",1" "${rel_dep_edge}"
 echo ""
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🚀 Feature

- [Add weighted dependency count to query result](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/dc35d524f4697980b0fce194f5e355a7f658a667)

### 🛠 Fix

- [Fix incoming and outgoing dependencies for SCIP index data](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/c4247b0a957aee5034c739ded5d9c5d94cf2bf5c)
- [Fix wrong incoming/outgoing dependencies count](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/ea1b31700a9966c163558cdad3555241cfcf3805)
- [Fix missing SCIP inner type dependencies](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/4ba6196528bcd6a1955a9348ce802bfb55c8e7ac)
- [Fix missing SCIP inheritance & sibling inner dependencies](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/d7de8fd08222450ce795b505cc9339c5c9fe5099)

### 📖 Documentation

- [Document known limitations using SCIP index data](https://github.com/JohT/code-graph-analysis-pipeline/pull/643/commits/0569fe512227d8bc2732425fd5a9697f8990cb46)